### PR TITLE
Security hardening and performance optimizations

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -238,9 +238,12 @@ Recommended permissions:
 | Brute force | Rate limiting with exponential backoff |
 | Cache tampering | AES-256-GCM authenticated encryption |
 | Path injection | Strict path validation, approved lists |
-| Buffer overflow | Bounds-checked string operations |
+| Buffer overflow | Bounds-checked string operations, snprintf with null-termination |
 | UID collision | Fail-safe collision detection |
 | Request tampering | Optional HMAC request signing with nonces |
+| Memory exhaustion DoS | Response size limits (256KB), group limits (256 max) |
+| Integer overflow | Input validation in base64 encoding, backoff calculations |
+| Malformed JSON | Type validation for critical response fields |
 
 ## Security Reporting
 

--- a/src/auth_cache.c
+++ b/src/auth_cache.c
@@ -47,6 +47,9 @@ static inline char *safe_json_strdup(struct json_object *obj)
 /* Maximum cache entries */
 #define MAX_AUTH_CACHE_ENTRIES 10000
 
+/* Security: Maximum user groups to prevent DoS via memory exhaustion */
+#define MAX_USER_GROUPS 256
+
 /* Cache structure */
 struct auth_cache {
     char *cache_dir;
@@ -451,6 +454,10 @@ bool auth_cache_lookup(auth_cache_t *cache,
     if (json_object_object_get_ex(json, "groups", &val)) {
         if (json_object_is_type(val, json_type_array)) {
             size_t count = json_object_array_length(val);
+            /* Security: Limit groups to prevent DoS via memory exhaustion */
+            if (count > MAX_USER_GROUPS) {
+                count = MAX_USER_GROUPS;
+            }
             entry->groups = calloc(count + 1, sizeof(char *));
             if (entry->groups) {
                 entry->groups_count = count;

--- a/src/pam_llng.c
+++ b/src/pam_llng.c
@@ -1044,10 +1044,10 @@ PAM_EXTERN int pam_sm_acct_mgmt(pam_handle_t *pamh,
     client_ip = get_client_ip(pamh);
     tty = get_tty(pamh);
 
-    /* Get hostname */
-    char hostname[256];
-    if (gethostname(hostname, sizeof(hostname)) != 0) {
-        strncpy(hostname, "unknown", sizeof(hostname));
+    /* Get hostname - use snprintf for guaranteed null-termination */
+    char hostname[256] = {0};
+    if (gethostname(hostname, sizeof(hostname) - 1) != 0) {
+        snprintf(hostname, sizeof(hostname), "unknown");
     }
 
     /* Get service name */


### PR DESCRIPTION
## Security Fixes

| Severity | Issue | Fix |
|----------|-------|-----|
| High | `strncpy` without guaranteed null-terminator in `gethostname` fallback | Use `snprintf` with explicit null-termination |
| Medium | Missing JSON type validation for boolean fields | Add `json_object_is_type()` checks |
| Medium | No input validation in `base64_encode` | Add null check and max size limit |
| Medium | Unlimited group allocation from server response | Cap at 256 groups |
| Low | 1MB max response size too generous | Reduce to 256KB |

## Performance Optimizations
- **TCP Keep-Alive**: Reduces connection setup overhead for multiple requests
- **HTTP Compression**: Server responses are typically JSON text, highly compressible