### PR TITLE
Security hardening: compiler flags and operational docs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,6 +79,22 @@ target_compile_options(pam_llng PRIVATE
     -Wall -Wextra -Werror
     -fPIC
     -D_GNU_SOURCE
+    # Security hardening flags
+    -fstack-protector-strong      # Stack buffer overflow protection
+    -Wformat -Wformat-security    # Format string vulnerability detection
+)
+
+# _FORTIFY_SOURCE requires optimization (-O1 or higher) to be effective
+# Only enable for Release/RelWithDebInfo builds to avoid warnings in Debug
+target_compile_definitions(pam_llng PRIVATE
+    $<$<OR:$<CONFIG:Release>,$<CONFIG:RelWithDebInfo>>:_FORTIFY_SOURCE=2>
+)
+
+# Linker security flags (Full RELRO = relro + now)
+target_link_options(pam_llng PRIVATE
+    -Wl,-z,relro                  # RELRO (with -z,now = Full RELRO)
+    -Wl,-z,now                    # Resolve symbols at load time (completes Full RELRO)
+    -Wl,-z,noexecstack            # Non-executable stack
 )
 
 # Installation

--- a/nss/CMakeLists.txt
+++ b/nss/CMakeLists.txt
@@ -27,6 +27,22 @@ set_target_properties(nss_llng PROPERTIES
 target_compile_options(nss_llng PRIVATE
     -Wall -Wextra -fPIC
     -D_GNU_SOURCE
+    # Security hardening flags
+    -fstack-protector-strong      # Stack buffer overflow protection
+    -Wformat -Wformat-security    # Format string vulnerability detection
+)
+
+# _FORTIFY_SOURCE requires optimization (-O1 or higher) to be effective
+# Only enable for Release/RelWithDebInfo builds to avoid warnings in Debug
+target_compile_definitions(nss_llng PRIVATE
+    $<$<OR:$<CONFIG:Release>,$<CONFIG:RelWithDebInfo>>:_FORTIFY_SOURCE=2>
+)
+
+# Linker security flags (Full RELRO = relro + now)
+target_link_options(nss_llng PRIVATE
+    -Wl,-z,relro                  # RELRO (with -z,now = Full RELRO)
+    -Wl,-z,now                    # Resolve symbols at load time (completes Full RELRO)
+    -Wl,-z,noexecstack            # Non-executable stack
 )
 
 # Install NSS module to the same libdir as PAM module


### PR DESCRIPTION
Build hardening:
- Add -fstack-protector-strong for stack overflow protection
- Add -D_FORTIFY_SOURCE=2 for runtime buffer overflow detection
- Add -Wformat -Wformat-security for format string checks
- Add linker flags: RELRO, BIND_NOW, noexecstack
- Apply to both PAM and NSS modules

Documentation (SECURITY.md):
- Add warning about debug logging risks in production
- Document machine-id stability requirement for encryption
- Add re-enrollment procedure after machine-id change