### PR TITLE
Deduplicate trim() and parse_bool() functions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,7 @@ set(PAM_MODULE_SOURCES
     src/jti_cache.c
     src/crowdsec.c
     src/service_account.c
+    src/str_utils.c
 )
 
 if(ENABLE_CACHE)

--- a/include/str_utils.h
+++ b/include/str_utils.h
@@ -1,0 +1,27 @@
+/*
+ * str_utils.h - String utility functions for Open Bastion
+ *
+ * Copyright (C) 2025 Linagora
+ * License: AGPL-3.0
+ */
+
+#ifndef STR_UTILS_H
+#define STR_UTILS_H
+
+#include <stdbool.h>
+
+/*
+ * Trim leading and trailing whitespace from string in-place.
+ * Returns pointer to trimmed string (may be offset from input).
+ * Returns NULL if input is NULL.
+ */
+char *str_trim(char *str);
+
+/*
+ * Parse boolean value from string.
+ * Returns true for: "true", "yes", "1", "on"
+ * Returns false for: "false", "no", "0", "off", NULL, and any other value
+ */
+bool str_parse_bool(const char *value);
+
+#endif /* STR_UTILS_H */

--- a/src/config.c
+++ b/src/config.c
@@ -19,6 +19,7 @@
 #include <syslog.h>
 
 #include "config.h"
+#include "str_utils.h"
 
 /*
  * Security: check file permissions for sensitive files.
@@ -236,44 +237,9 @@ void config_free(pam_openbastion_config_t *config)
     explicit_bzero(config, sizeof(*config));
 }
 
-/* Trim whitespace from string */
-static char *trim(char *str)
-{
-    if (!str) return NULL;
-
-    /* Trim leading */
-    while (isspace((unsigned char)*str)) str++;
-
-    if (*str == '\0') return str;
-
-    /* Trim trailing */
-    char *end = str + strlen(str) - 1;
-    while (end > str && isspace((unsigned char)*end)) end--;
-    end[1] = '\0';
-
-    return str;
-}
-
-/*
- * Helper to parse boolean values.
- * Returns true for: "true", "yes", "1", "on"
- * Returns false for: "false", "no", "0", "off", and any other value
- */
-static bool parse_bool(const char *value)
-{
-    if (!value) return false;
-
-    /* Explicit true values */
-    if (strcmp(value, "true") == 0 ||
-        strcmp(value, "yes") == 0 ||
-        strcmp(value, "1") == 0 ||
-        strcmp(value, "on") == 0) {
-        return true;
-    }
-
-    /* All other values including "false", "no", "0", "off" return false */
-    return false;
-}
+/* Use shared string utilities from str_utils.h */
+#define trim str_trim
+#define parse_bool str_parse_bool
 
 /* Maximum lengths for security-sensitive configuration values */
 #define MAX_URL_LENGTH 512

--- a/src/service_account.c
+++ b/src/service_account.c
@@ -18,6 +18,7 @@
 
 #include "service_account.h"
 #include "config.h"
+#include "str_utils.h"
 
 /* Initial capacity for accounts array */
 #define INITIAL_CAPACITY 8
@@ -53,42 +54,9 @@ static int check_file_permissions_fd(int fd)
     return 0;  /* OK */
 }
 
-/* Trim whitespace from string */
-static char *trim(char *str)
-{
-    if (!str) return NULL;
-
-    /* Trim leading */
-    while (isspace((unsigned char)*str)) str++;
-
-    if (*str == '\0') return str;
-
-    /* Trim trailing */
-    char *end = str + strlen(str) - 1;
-    while (end > str && isspace((unsigned char)*end)) end--;
-    end[1] = '\0';
-
-    return str;
-}
-
-/*
- * Helper to parse boolean values.
- * Returns true for: "true", "yes", "1", "on"
- * Returns false for: "false", "no", "0", "off", and any other value
- */
-static bool parse_bool(const char *value)
-{
-    if (!value) return false;
-
-    if (strcmp(value, "true") == 0 ||
-        strcmp(value, "yes") == 0 ||
-        strcmp(value, "1") == 0 ||
-        strcmp(value, "on") == 0) {
-        return true;
-    }
-
-    return false;
-}
+/* Use shared string utilities from str_utils.h */
+#define trim str_trim
+#define parse_bool str_parse_bool
 
 /*
  * Safe integer parsing with validation.

--- a/src/str_utils.c
+++ b/src/str_utils.c
@@ -1,0 +1,42 @@
+/*
+ * str_utils.c - String utility functions for Open Bastion
+ *
+ * Copyright (C) 2025 Linagora
+ * License: AGPL-3.0
+ */
+
+#include <ctype.h>
+#include <string.h>
+
+#include "str_utils.h"
+
+char *str_trim(char *str)
+{
+    if (!str) return NULL;
+
+    /* Trim leading whitespace */
+    while (isspace((unsigned char)*str)) str++;
+
+    if (*str == '\0') return str;
+
+    /* Trim trailing whitespace */
+    char *end = str + strlen(str) - 1;
+    while (end > str && isspace((unsigned char)*end)) end--;
+    end[1] = '\0';
+
+    return str;
+}
+
+bool str_parse_bool(const char *value)
+{
+    if (!value) return false;
+
+    if (strcmp(value, "true") == 0 ||
+        strcmp(value, "yes") == 0 ||
+        strcmp(value, "1") == 0 ||
+        strcmp(value, "on") == 0) {
+        return true;
+    }
+
+    return false;
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Tests for pam_openbastion
 
 # Test configuration parsing
-add_executable(test_config test_config.c ../src/config.c)
+add_executable(test_config test_config.c ../src/config.c ../src/str_utils.c)
 target_include_directories(test_config PRIVATE ${CMAKE_SOURCE_DIR}/include)
 add_test(NAME test_config COMMAND test_config)
 
@@ -48,7 +48,7 @@ target_include_directories(test_nss_openbastion PRIVATE ${CMAKE_SOURCE_DIR}/incl
 add_test(NAME test_nss_openbastion COMMAND test_nss_openbastion)
 
 # Test path validation
-add_executable(test_path_validator test_path_validator.c ../src/config.c)
+add_executable(test_path_validator test_path_validator.c ../src/config.c ../src/str_utils.c)
 target_include_directories(test_path_validator PRIVATE ${CMAKE_SOURCE_DIR}/include)
 add_test(NAME test_path_validator COMMAND test_path_validator)
 
@@ -141,7 +141,7 @@ target_link_libraries(test_crowdsec
 add_test(NAME test_crowdsec COMMAND test_crowdsec)
 
 # Test service account management
-add_executable(test_service_account test_service_account.c ../src/service_account.c ../src/config.c)
+add_executable(test_service_account test_service_account.c ../src/service_account.c ../src/config.c ../src/str_utils.c)
 target_include_directories(test_service_account PRIVATE ${CMAKE_SOURCE_DIR}/include)
 add_test(NAME test_service_account COMMAND test_service_account)
 


### PR DESCRIPTION
## Summary
- Extract common string utility functions into a shared `str_utils.c` module
- `str_trim()`: Trim leading/trailing whitespace
- `str_parse_bool()`: Parse boolean from string ("true", "yes", "1", "on")

## Changes
- New files: `include/str_utils.h`, `src/str_utils.c`
- `config.c` and `service_account.c` now use the shared implementation
- Updated `tests/CMakeLists.txt` to link `str_utils.c` where needed

## Benefits
- Removes ~60 lines of duplicate code
- Ensures consistent behavior across all configuration parsing
- Single point of maintenance for string utilities

## Test plan
- [x] All existing tests pass (test_config, test_path_validator, test_service_account)
- [x] Build succeeds with ENABLE_CACHE=ON

🤖 Generated with [Claude Code](https://claude.com/claude-code)