### PR TITLE
Add CrowdSec alerts processing limit (DoS prevention)

### DIFF
--- a/src/crowdsec.c
+++ b/src/crowdsec.c
@@ -14,6 +14,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
+#include <syslog.h>
 #include <curl/curl.h>
 #include <json-c/json.h>
 #include <openssl/sha.h>
@@ -37,6 +38,9 @@
 
 /* Minimum interval between failed login attempts (avoid hammering LAPI) */
 #define TOKEN_RETRY_INTERVAL 30
+
+/* Maximum number of alerts to process (DoS prevention) */
+#define MAX_ALERTS_TO_PROCESS 1000
 
 /* Cached decision entry */
 typedef struct {
@@ -435,6 +439,16 @@ static int get_alerts_count(crowdsec_context_t *ctx, const char *ip)
     time_t time_limit = time(NULL) - ctx->config.block_delay;
     int count = 0;
     int len = json_object_array_length(alerts);
+
+    /*
+     * Security: Limit the number of alerts we process to prevent DoS.
+     * A malicious or misconfigured CrowdSec could return millions of alerts.
+     */
+    if (len > MAX_ALERTS_TO_PROCESS) {
+        syslog(LOG_WARNING, "open-bastion: crowdsec: too many alerts (%d), "
+               "processing only first %d", len, MAX_ALERTS_TO_PROCESS);
+        len = MAX_ALERTS_TO_PROCESS;
+    }
 
     for (int i = 0; i < len; i++) {
         struct json_object *alert = json_object_array_get_idx(alerts, i);


### PR DESCRIPTION
## Summary
Add a limit to the number of alerts processed from CrowdSec LAPI to prevent potential DoS attacks.

## Security Issue
A malicious or misconfigured CrowdSec LAPI could return millions of alerts, causing the PAM module to block indefinitely while processing them during SSH authentication.

## Changes
- Add `MAX_ALERTS_TO_PROCESS` constant (1000 alerts)
- Log warning via syslog when limit is exceeded
- Add `syslog.h` include

## Impact
- If CrowdSec returns >1000 alerts, only the first 1000 are processed
- Authentication continues normally, with a warning logged
- No user-visible change under normal operation

## Test plan
- [x] test_crowdsec passes (12/12 tests)
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)