### PR TITLE
Add path length limit to prevent DoS via long paths

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -946,12 +946,21 @@ int config_validate(const pam_openbastion_config_t *config)
 }
 
 /*
+ * Maximum path length to prevent DoS via very long paths.
+ * Linux PATH_MAX is 4096, but we use a smaller limit for security.
+ */
+#define MAX_SAFE_PATH_LENGTH 1024
+
+/*
  * Check if a path contains dangerous patterns
  * Returns 1 if dangerous, 0 if safe
  */
 static int path_contains_dangerous_patterns(const char *path)
 {
     if (!path) return 1;
+
+    /* Limit path length to prevent DoS - use strnlen to avoid scanning entire string */
+    if (strnlen(path, MAX_SAFE_PATH_LENGTH + 1) > MAX_SAFE_PATH_LENGTH) return 1;
 
     /* Must be absolute path */
     if (path[0] != '/') return 1;

--- a/tests/test_path_validator.c
+++ b/tests/test_path_validator.c
@@ -183,6 +183,22 @@ static int test_double_slashes(void)
     return 1;
 }
 
+/* Test that excessively long paths are rejected (DoS prevention) */
+static int test_path_length_limit(void)
+{
+    /* Create a path longer than MAX_SAFE_PATH_LENGTH (1024) */
+    char long_path[2048];
+    memset(long_path, 'a', sizeof(long_path) - 1);
+    long_path[0] = '/';
+    long_path[sizeof(long_path) - 1] = '\0';
+
+    /* Very long paths should be rejected */
+    if (config_validate_shell(long_path, long_path) == 0) return 0;
+    if (config_validate_home(long_path, long_path) == 0) return 0;
+
+    return 1;
+}
+
 int main(void)
 {
     printf("Path Validator Tests\n");
@@ -208,6 +224,7 @@ int main(void)
     printf("\nEdge cases:\n");
     TEST(null_empty_inputs);
     TEST(double_slashes);
+    TEST(path_length_limit);
 
     printf("\n%d/%d tests passed\n", tests_passed, tests_run);
 


### PR DESCRIPTION
## Summary
Add `MAX_SAFE_PATH_LENGTH` (1024 bytes) check in path validation to prevent potential DoS attacks.

## Security Issue
Without a length limit, maliciously long paths could cause CPU waste iterating through strings in `path_contains_dangerous_patterns()`.

## Solution
- Add `MAX_SAFE_PATH_LENGTH` constant (1024 bytes)
- Check length at start of `path_contains_dangerous_patterns()`
- Reject paths exceeding the limit before any string operations

## Rationale
- Linux PATH_MAX is 4096, but we use a smaller limit for security
- No legitimate shell or home path needs 1024+ characters
- Early rejection prevents unnecessary processing

## Test plan
- [x] test_path_validator passes (16/16 tests, including new path_length_limit test)
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)