### PR TITLE
security: add syslog warnings when SSL verification is disabled

### DIFF
--- a/nss/libnss_openbastion.c
+++ b/nss/libnss_openbastion.c
@@ -793,6 +793,13 @@ static int query_llng_userinfo(const char *username, struct passwd *pw,
     if (!g_config.verify_ssl) {
         curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 0L);
         curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, 0L);
+        /* Log warning only once per process to avoid log spam */
+        static int ssl_warning_logged = 0;
+        if (!ssl_warning_logged) {
+            ssl_warning_logged = 1;
+            syslog(LOG_WARNING, "nss_openbastion: SSL verification disabled - "
+                   "vulnerable to MITM attacks");
+        }
     }
 
     CURLcode res = curl_easy_perform(curl);

--- a/src/crowdsec.c
+++ b/src/crowdsec.c
@@ -156,6 +156,13 @@ static void setup_curl(crowdsec_context_t *ctx)
     } else {
         curl_easy_setopt(ctx->curl, CURLOPT_SSL_VERIFYPEER, 0L);
         curl_easy_setopt(ctx->curl, CURLOPT_SSL_VERIFYHOST, 0L);
+        /* Log warning only once per process to avoid log spam */
+        static int ssl_warning_logged = 0;
+        if (!ssl_warning_logged) {
+            ssl_warning_logged = 1;
+            syslog(LOG_WARNING, "open-bastion: CrowdSec connection with SSL "
+                   "verification disabled - vulnerable to MITM attacks");
+        }
     }
 }
 

--- a/src/jwks_cache.c
+++ b/src/jwks_cache.c
@@ -9,6 +9,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
+#include <syslog.h>
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <unistd.h>
@@ -372,6 +373,13 @@ static int fetch_jwks(jwks_cache_t *cache)
     if (!cache->verify_ssl) {
         curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 0L);
         curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, 0L);
+        /* Log warning only once per process to avoid log spam */
+        static int ssl_warning_logged = 0;
+        if (!ssl_warning_logged) {
+            ssl_warning_logged = 1;
+            syslog(LOG_WARNING, "open-bastion: JWKS fetch with SSL verification "
+                   "disabled - vulnerable to MITM attacks");
+        }
     }
 
     if (cache->ca_cert) {

--- a/src/ob_client.c
+++ b/src/ob_client.c
@@ -9,6 +9,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
+#include <syslog.h>
 #include <pthread.h>
 #include <curl/curl.h>
 #include <json-c/json.h>
@@ -486,6 +487,13 @@ static void setup_curl(ob_client_t *client)
     if (!client->verify_ssl) {
         curl_easy_setopt(client->curl, CURLOPT_SSL_VERIFYPEER, 0L);
         curl_easy_setopt(client->curl, CURLOPT_SSL_VERIFYHOST, 0L);
+        /* Log warning only once per process to avoid log spam */
+        static int ssl_warning_logged = 0;
+        if (!ssl_warning_logged) {
+            ssl_warning_logged = 1;
+            syslog(LOG_WARNING, "open-bastion: SSL verification disabled - "
+                   "vulnerable to MITM attacks");
+        }
     }
 
     if (client->ca_cert) {


### PR DESCRIPTION
## Summary
- Log a WARNING message via syslog whenever `verify_ssl=false` is configured
- Alerts administrators that the connection is vulnerable to MITM attacks
- Covers all HTTP client code paths: ob_client, jwks_cache, crowdsec, libnss_openbastion

## Test plan
- [x] Build passes
- [x] All 15 tests pass
- [ ] Manual: set `verify_ssl=false` in config and verify syslog warning appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)