### PR TITLE
security: improve JWT validation (nbf claim, clock skew, JTI logging)

### DIFF
--- a/include/bastion_jwt.h
+++ b/include/bastion_jwt.h
@@ -114,4 +114,24 @@ void bastion_jwt_claims_free(bastion_jwt_claims_t *claims);
  */
 bool bastion_jwt_is_bastion_allowed(const char *bastion_id, const char *allowed_bastions);
 
+#ifdef BASTION_JWT_TEST
+/*
+ * Validate JWT time claims (exposed for unit testing)
+ *
+ * Parameters:
+ *   exp            - Expiration time (0 = not set)
+ *   nbf            - Not before time (0 = not set)
+ *   iat            - Issued at time (0 = not set)
+ *   now            - Current time to validate against
+ *   max_clock_skew - Allowed clock skew in seconds
+ *
+ * Returns:
+ *   BASTION_JWT_OK if valid
+ *   BASTION_JWT_EXPIRED if token expired
+ *   BASTION_JWT_NOT_YET_VALID if token not yet valid
+ */
+bastion_jwt_result_t bastion_jwt_validate_time(
+    time_t exp, time_t nbf, time_t iat, time_t now, int max_clock_skew);
+#endif
+
 #endif /* BASTION_JWT_H */

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -102,6 +102,7 @@ add_test(NAME test_token_manager COMMAND test_token_manager)
 
 # Test bastion JWT verification
 add_executable(test_bastion_jwt test_bastion_jwt.c ../src/bastion_jwt.c ../src/jwks_cache.c ../src/jti_cache.c)
+target_compile_definitions(test_bastion_jwt PRIVATE BASTION_JWT_TEST)
 target_include_directories(test_bastion_jwt PRIVATE
     ${CMAKE_SOURCE_DIR}/include
     ${CURL_INCLUDE_DIRS}


### PR DESCRIPTION
## Summary
- Add `nbf` (not-before) claim support per RFC 7519
- Validate `nbf` if present, fall back to `iat` for backwards compatibility  
- Reduce default clock skew from 60s to 30s for tighter security
- Truncate JTI values in log messages to avoid information disclosure

## Breaking change
⚠️ Default clock skew reduced from 60s to 30s. If systems have significant clock drift, they may need to explicitly configure `max_clock_skew` in bastion JWT config.

## Test plan
- [x] Build passes
- [x] All 15 tests pass
- [ ] Manual: verify JWT with `nbf` claim is properly validated

🤖 Generated with [Claude Code](https://claude.com/claude-code)