### PR TITLE
cleanup: consolidate code patterns and remove magic numbers

### DIFF
--- a/include/str_utils.h
+++ b/include/str_utils.h
@@ -24,4 +24,19 @@ char *str_trim(char *str);
  */
 bool str_parse_bool(const char *value);
 
+/*
+ * Safely extract a string from a json-c object and duplicate it.
+ * Returns NULL if the object is NULL or the string is NULL.
+ * Caller must free the returned string.
+ *
+ * Note: Requires json-c to be included before using this function.
+ */
+#ifdef JSON_C_VERSION
+static inline char *str_json_strdup(struct json_object *obj)
+{
+    const char *str = json_object_get_string(obj);
+    return str ? strdup(str) : NULL;
+}
+#endif
+
 #endif /* STR_UTILS_H */

--- a/include/token_cache.h
+++ b/include/token_cache.h
@@ -71,6 +71,9 @@ int cache_store(token_cache_t *cache,
 
 /*
  * Invalidate a specific token
+ * NOTE: This function is a no-op due to hashing scheme limitations.
+ * Use cache_invalidate_user() instead for user-based invalidation.
+ * Kept for API compatibility.
  */
 void cache_invalidate(token_cache_t *cache, const char *token);
 

--- a/src/auth_cache.c
+++ b/src/auth_cache.c
@@ -24,17 +24,14 @@
 #include <json-c/json.h>
 
 #include "auth_cache.h"
+#include "str_utils.h"
 
 /* Cache format version */
 #define AUTH_CACHE_VERSION 3
 #define AUTH_CACHE_MAGIC "LLNGCACHE03"
 
-/* Safe strdup from JSON - returns NULL if json string is NULL */
-static inline char *safe_json_strdup(struct json_object *obj)
-{
-    const char *str = json_object_get_string(obj);
-    return str ? strdup(str) : NULL;
-}
+/* Use shared JSON strdup utility */
+#define safe_json_strdup str_json_strdup
 
 /* Encryption constants (same as token_cache) */
 #define MACHINE_ID_FILE "/etc/machine-id"

--- a/src/ob_client.c
+++ b/src/ob_client.c
@@ -18,6 +18,7 @@
 
 #include "ob_client.h"
 #include "jwt_utils.h"
+#include "str_utils.h"
 
 /* TLS version constants for min_tls_version configuration */
 #define TLS_VERSION_1_2 12
@@ -29,12 +30,8 @@
 /* Security: Maximum user groups to prevent DoS via memory exhaustion */
 #define MAX_USER_GROUPS 256
 
-/* Safe strdup from JSON - returns NULL if json string is NULL */
-static inline char *safe_json_strdup(struct json_object *obj)
-{
-    const char *str = json_object_get_string(obj);
-    return str ? strdup(str) : NULL;
-}
+/* Use shared JSON strdup utility */
+#define safe_json_strdup str_json_strdup
 
 /* Forward declaration for internal authorize function */
 static int ob_authorize_user_internal(ob_client_t *client,

--- a/src/pam_openbastion.c
+++ b/src/pam_openbastion.c
@@ -57,6 +57,9 @@
 #define SECONDS_PER_DAY 86400
 #define DEFAULT_OFFLINE_CACHE_TTL 86400  /* Default 24 hours for offline cache */
 
+/* Security: Maximum length for SSH_USER_AUTH environment variable */
+#define MAX_SSH_AUTH_LEN 8192
+
 /* Internal data structure */
 typedef struct {
     pam_openbastion_config_t config;
@@ -746,7 +749,7 @@ static char *extract_ssh_key_fingerprint(pam_handle_t *pamh)
     }
 
     /* Security: Check length before processing */
-    if (strlen(ssh_auth) >= 8192) {
+    if (strlen(ssh_auth) >= MAX_SSH_AUTH_LEN) {
         OB_LOG_WARN(pamh, "SSH_USER_AUTH too long, ignoring");
         return NULL;
     }
@@ -826,12 +829,10 @@ static int extract_ssh_cert_info(pam_handle_t *pamh, ob_ssh_cert_info_t *cert_in
     }
 
     /* Security: Check length before processing (fixes #45) */
-    #define MAX_SSH_AUTH_LEN 8192
     if (strlen(ssh_auth) >= MAX_SSH_AUTH_LEN) {
         OB_LOG_WARN(pamh, "SSH_USER_AUTH too long, ignoring");
         return 0;
     }
-    #undef MAX_SSH_AUTH_LEN
 
     OB_LOG_DEBUG(pamh, "SSH_USER_AUTH: %s", ssh_auth);
 


### PR DESCRIPTION
## Summary
- Define `MAX_SSH_AUTH_LEN` constant (8192) at file level instead of inline #define/#undef
- Document `cache_invalidate()` as no-op (kept for API compatibility)
- Move `safe_json_strdup()` to `str_utils.h` as `str_json_strdup()`
- Update `ob_client.c` and `auth_cache.c` to use shared utility

## Impact
Code cleanup only - no behavior changes.

## Test plan
- [x] Build passes
- [x] All 15 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)