### PR TITLE
Security: fix privilege escalation in session recorder wrapper

### DIFF
--- a/doc/security/02-ssh-connection.md
+++ b/doc/security/02-ssh-connection.md
@@ -1055,12 +1055,13 @@ L'enregistrement de session utilise un wrapper setgid (`ob-session-recorder-wrap
 Le session recorder utilise un wrapper C setgid (`ob-session-recorder-wrapper`) appartenant au groupe `ob-sessions` :
 
 1. Le binaire wrapper est installé en mode `2755 root:ob-sessions` (bit setgid)
-2. Le wrapper appelle `setregid()` pour persister le gid effectif `ob-sessions` à travers l'`execve()` du script bash (le kernel supprime le setgid sur les scripts interprétés `#!`)
-3. Le répertoire `/var/lib/open-bastion/sessions` a les permissions `1770 root:ob-sessions` :
+2. Le wrapper utilise son gid effectif `ob-sessions` **uniquement** pour créer le sous-répertoire utilisateur en mode `2770 user:ob-sessions` (bit setgid sur le répertoire)
+3. Le wrapper exec le script recorder **sans** appeler `setregid()` : le kernel supprime naturellement le setgid sur les scripts interprétés `#!`, donc le script et le shell de l'utilisateur tournent avec le gid original
+4. Le répertoire `/var/lib/open-bastion/sessions` a les permissions `1770 root:ob-sessions` :
    - `1` (sticky bit) : seul le propriétaire du répertoire (root) peut supprimer les fichiers
    - `770` : seuls root et le groupe `ob-sessions` peuvent accéder au répertoire
-4. Les fichiers de session sont créés avec le groupe `ob-sessions` (hérité du processus setgid)
-5. L'utilisateur n'a pas le gid `ob-sessions` dans son shell interactif (le setgid ne s'applique qu'au wrapper)
+5. Les fichiers de session héritent du groupe `ob-sessions` grâce au bit setgid du sous-répertoire utilisateur (mode `2770`), sans que le processus ait besoin du gid élevé
+6. L'environnement est sanitisé (LD_PRELOAD, BASH_ENV, PATH durci) avant l'exec
 
 **Résultat :** L'utilisateur ne peut ni lire, ni modifier, ni supprimer les fichiers d'enregistrement de session depuis son shell.
 

--- a/doc/security/02-ssh-connection.md
+++ b/doc/security/02-ssh-connection.md
@@ -1056,7 +1056,7 @@ Le session recorder utilise un wrapper C setgid (`ob-session-recorder-wrapper`) 
 
 1. Le binaire wrapper est installé en mode `2755 root:ob-sessions` (bit setgid)
 2. Le wrapper utilise son gid effectif `ob-sessions` **uniquement** pour créer le sous-répertoire utilisateur en mode `2770 user:ob-sessions` (bit setgid sur le répertoire)
-3. Le wrapper exec le script recorder **sans** appeler `setregid()` : le kernel supprime naturellement le setgid sur les scripts interprétés `#!`, donc le script et le shell de l'utilisateur tournent avec le gid original
+3. Le wrapper drop explicitement le gid élevé via `setregid(orig_gid, orig_gid)` avant l'exec. `exec` ne supprime **pas** un gid effectif/sauvé déjà acquis (seuls les bits setgid du *fichier* exécuté sont ignorés). Le drop explicite garantit que le script et le shell tournent avec le gid original de l'utilisateur
 4. Le répertoire `/var/lib/open-bastion/sessions` a les permissions `1770 root:ob-sessions` :
    - `1` (sticky bit) : seul le propriétaire du répertoire (root) peut supprimer les fichiers
    - `770` : seuls root et le groupe `ob-sessions` peuvent accéder au répertoire

--- a/doc/security/99-risk-reduce.md
+++ b/doc/security/99-risk-reduce.md
@@ -145,7 +145,9 @@ Le Mode E bloque l'escalade par conception (réauthentification SSO obligatoire)
 
 - Wrapper setgid `ob-session-recorder-wrapper` (groupe `ob-sessions`, mode `2755`)
 - Répertoire sessions `/var/lib/open-bastion/sessions` en mode `1770 root:ob-sessions` (sticky bit)
-- `setregid()` dans le wrapper pour persister le gid à travers l'exec du script bash
+- Sous-répertoires utilisateur en mode `2770 user:ob-sessions` (bit setgid pour héritage du groupe)
+- Le wrapper n'appelle plus `setregid()` : le gid élevé sert uniquement à créer le sous-répertoire, puis le kernel le supprime naturellement sur exec du script
+- Sanitisation de l'environnement (LD_PRELOAD, BASH_ENV, PATH durci) avant exec
 - Syslog (`auth.info`) comme journal d'audit indépendant et inaltérable
 
 **Score résiduel :** P=1, I=1 (zone verte). L'utilisateur ne peut ni accéder ni supprimer les fichiers de session. Syslog préserve les traces minimales même en cas de compromission root.

--- a/doc/security/99-risk-reduce.md
+++ b/doc/security/99-risk-reduce.md
@@ -146,7 +146,7 @@ Le Mode E bloque l'escalade par conception (réauthentification SSO obligatoire)
 - Wrapper setgid `ob-session-recorder-wrapper` (groupe `ob-sessions`, mode `2755`)
 - Répertoire sessions `/var/lib/open-bastion/sessions` en mode `1770 root:ob-sessions` (sticky bit)
 - Sous-répertoires utilisateur en mode `2770 user:ob-sessions` (bit setgid pour héritage du groupe)
-- Le wrapper n'appelle plus `setregid()` : le gid élevé sert uniquement à créer le sous-répertoire, puis le kernel le supprime naturellement sur exec du script
+- Le wrapper drop explicitement le gid élevé via `setregid()` après création du sous-répertoire et avant exec du script (`exec` ne supprime pas un gid effectif/sauvé déjà acquis)
 - Sanitisation de l'environnement (LD_PRELOAD, BASH_ENV, PATH durci) avant exec
 - Syslog (`auth.info`) comme journal d'audit indépendant et inaltérable
 

--- a/doc/session-recording.md
+++ b/doc/session-recording.md
@@ -190,9 +190,9 @@ Each recording has an accompanying JSON metadata file (`.json`):
 ```
 
 - Sessions root: mode `1770`, owned `root:ob-sessions`
-- Per-user subdirectories: created by the wrapper
-- Recording files: mode `0640`, owned by `root:ob-sessions`
-- Organization: One subdirectory per user; users cannot delete recordings
+- Per-user subdirectories: mode `2770` (setgid), owned `user:ob-sessions`, created by the wrapper
+- Recording files: inherit `ob-sessions` group from directory's setgid bit
+- Organization: One subdirectory per user; users cannot access other users' recordings
 
 ## Replaying Sessions
 
@@ -225,17 +225,21 @@ scriptreplay timing.txt recording.typescript
 
 ### Privilege Separation via Setgid Wrapper
 
-Session recordings are written by `ob-session-recorder-wrapper`, a setgid helper
+Session recordings are written via `ob-session-recorder-wrapper`, a setgid helper
 owned by `root:ob-sessions`. This design provides tamper-evident recordings:
 
 - The sessions directory `/var/lib/open-bastion/sessions` has mode `1770` and is
   owned by `root:ob-sessions` (sticky bit set).
-- The wrapper runs with the `ob-sessions` group privilege, which allows it to
-  write into the shared directory.
-- Recorded users are **not** members of `ob-sessions`, so they cannot delete or
-  modify their own session recordings.
-- The actual recorder binary `/usr/sbin/ob-session-recorder` is invoked by the
-  wrapper after privilege setup.
+- The wrapper uses its elevated effective gid (`ob-sessions`) **only** to create
+  the per-user session subdirectory with mode `2770` (setgid bit on directory)
+  and ownership `user:ob-sessions`.
+- The wrapper then exec's the recorder script **without** calling `setregid()`:
+  the kernel naturally strips the setgid on exec of interpreted scripts (`#!`),
+  so the script and the user's shell run with the user's original gid only.
+- Files created inside the per-user directory inherit the `ob-sessions` group
+  thanks to the directory's setgid bit — no process-level privilege needed.
+- Recorded users are **not** members of `ob-sessions`, so they cannot access
+  other users' session recordings.
 
 This means `ForceCommand` should point to `ob-session-recorder-wrapper`, not
 directly to `ob-session-recorder`.
@@ -243,7 +247,8 @@ directly to `ob-session-recorder`.
 ### File Permissions
 
 - Sessions directory: mode `1770`, owned `root:ob-sessions`
-- Recording files: `0640` (owned by root, group `ob-sessions`)
+- Per-user subdirectories: mode `2770` (setgid), owned `user:ob-sessions`
+- Recording files: inherit `ob-sessions` group from directory setgid bit
 - Config file: `/etc/open-bastion/session-recorder.conf`, mode `0644` (root-owned)
 
 ### Storage Security

--- a/doc/session-recording.md
+++ b/doc/session-recording.md
@@ -233,9 +233,11 @@ owned by `root:ob-sessions`. This design provides tamper-evident recordings:
 - The wrapper uses its elevated effective gid (`ob-sessions`) **only** to create
   the per-user session subdirectory with mode `2770` (setgid bit on directory)
   and ownership `user:ob-sessions`.
-- The wrapper then exec's the recorder script **without** calling `setregid()`:
-  the kernel naturally strips the setgid on exec of interpreted scripts (`#!`),
-  so the script and the user's shell run with the user's original gid only.
+- After directory creation, the wrapper explicitly drops the elevated gid via
+  `setregid()`, restoring the user's original gid. `exec` does **not**
+  automatically strip an already-acquired effective/saved gid — only setgid
+  bits on the exec'd file are ignored. The explicit drop ensures the script
+  and the user's shell run with the user's original gid only.
 - Files created inside the per-user directory inherit the `ob-sessions` group
   thanks to the directory's setgid bit — no process-level privilege needed.
 - Recorded users are **not** members of `ob-sessions`, so they cannot access

--- a/scripts/ob-session-recorder
+++ b/scripts/ob-session-recorder
@@ -38,7 +38,8 @@ TTY_NAME="${SSH_TTY:-notty}"
 # Security: validate SESSION_USER to prevent path traversal attacks.
 # Must contain only safe characters before it is used to construct file paths.
 if [[ ! "$SESSION_USER" =~ ^[a-z_][a-z0-9_.-]*$ ]]; then
-    logger -t "$PROG_NAME" -p auth.err "Invalid session user: $SESSION_USER"
+    SAFE_USER=$(printf '%q' "$SESSION_USER")
+    logger -t "$PROG_NAME" -p auth.err "Invalid session user: $SAFE_USER"
     echo "Error: invalid session user" >&2
     exit 1
 fi
@@ -125,11 +126,14 @@ ensure_sessions_dir() {
         return 1
     fi
 
-    # Create user subdirectory (group ob-sessions via setgid wrapper)
+    # User subdirectory is created by ob-session-recorder-wrapper (setgid binary)
+    # with mode 2770 (setgid bit) and group ob-sessions. Files created inside
+    # inherit the ob-sessions group. If running without the wrapper (e.g. tests),
+    # create the directory as a fallback.
     local user_dir="$SESSIONS_DIR/$SESSION_USER"
     if [ ! -d "$user_dir" ]; then
-        mkdir "$user_dir"
-        chmod 0770 "$user_dir"
+        mkdir "$user_dir" 2>/dev/null || true
+        chmod 0770 "$user_dir" 2>/dev/null || true
     fi
 }
 
@@ -203,43 +207,20 @@ handle_timeout() {
     exit 124  # Standard timeout exit code
 }
 
-# Build a command prefix that drops the ob-sessions gid back to the user's
-# original primary group before spawning user shells.
-# The session file/directory is created before this is called, so the elevated
-# gid is no longer needed at that point.
-# Uses setpriv(1) (util-linux) when available; falls back to no-op if absent.
-# Trailing space in the non-empty return value is intentional: allows safe
-# concatenation with the command that follows (e.g. "${prefix}sh -c ...").
-build_drop_gid_prefix() {
-    if [ -n "${OB_ORIG_GID:-}" ] && command -v setpriv >/dev/null 2>&1; then
-        echo "setpriv --regid=${OB_ORIG_GID} --egid=${OB_ORIG_GID} --clear-groups -- "
-    else
-        echo ""
-    fi
-}
-
 # Record session using script command (always available)
 record_script() {
     local shell="${SHELL:-/bin/bash}"
-    local drop_prefix
-    drop_prefix=$(build_drop_gid_prefix)
 
     if [ -n "$ORIGINAL_COMMAND" ]; then
-        # Export the command so the inner sh -c can access it safely without
-        # additional quoting that would break complex commands.
-        OB_CMD="$ORIGINAL_COMMAND" \
-            script -q -c "${drop_prefix}sh -c \"\$OB_CMD\"" "$SESSION_FILE"
+        script -q -c "$ORIGINAL_COMMAND" "$SESSION_FILE"
     else
-        # shellcheck disable=SC2086
-        script -q -c "${drop_prefix}${shell}" "$SESSION_FILE"
+        script -q -c "$shell" "$SESSION_FILE"
     fi
 }
 
 # Record session using asciinema (if available)
 record_asciinema() {
     local shell="${SHELL:-/bin/bash}"
-    local drop_prefix
-    drop_prefix=$(build_drop_gid_prefix)
 
     if ! command -v asciinema >/dev/null 2>&1; then
         log_warn "asciinema not installed, falling back to script"
@@ -250,19 +231,15 @@ record_asciinema() {
     fi
 
     if [ -n "$ORIGINAL_COMMAND" ]; then
-        OB_CMD="$ORIGINAL_COMMAND" \
-            asciinema rec -c "${drop_prefix}sh -c \"\$OB_CMD\"" "$SESSION_FILE"
+        asciinema rec -c "$ORIGINAL_COMMAND" "$SESSION_FILE"
     else
-        # shellcheck disable=SC2086
-        asciinema rec -c "${drop_prefix}${shell}" "$SESSION_FILE"
+        asciinema rec -c "$shell" "$SESSION_FILE"
     fi
 }
 
 # Record session using ttyrec (if available)
 record_ttyrec() {
     local shell="${SHELL:-/bin/bash}"
-    local drop_prefix
-    drop_prefix=$(build_drop_gid_prefix)
 
     if ! command -v ttyrec >/dev/null 2>&1; then
         log_warn "ttyrec not installed, falling back to script"
@@ -273,11 +250,9 @@ record_ttyrec() {
     fi
 
     if [ -n "$ORIGINAL_COMMAND" ]; then
-        OB_CMD="$ORIGINAL_COMMAND" \
-            ttyrec -e "${drop_prefix}sh -c \"\$OB_CMD\"" "$SESSION_FILE"
+        ttyrec -e "$ORIGINAL_COMMAND" "$SESSION_FILE"
     else
-        # shellcheck disable=SC2086
-        ttyrec -e "${drop_prefix}${shell}" "$SESSION_FILE"
+        ttyrec -e "$shell" "$SESSION_FILE"
     fi
 }
 

--- a/scripts/ob-session-recorder
+++ b/scripts/ob-session-recorder
@@ -35,6 +35,14 @@ CLIENT_IP="${SSH_CLIENT:+${SSH_CLIENT%% *}}"
 CLIENT_IP="${CLIENT_IP:-unknown}"
 TTY_NAME="${SSH_TTY:-notty}"
 
+# Security: validate SESSION_USER to prevent path traversal attacks.
+# Must contain only safe characters before it is used to construct file paths.
+if [[ ! "$SESSION_USER" =~ ^[a-z_][a-z0-9_.-]*$ ]]; then
+    logger -t "$PROG_NAME" -p auth.err "Invalid session user: $SESSION_USER"
+    echo "Error: invalid session user" >&2
+    exit 1
+fi
+
 # Process management
 TIMEOUT_PID=""
 RECORDING_PID=""
@@ -195,20 +203,43 @@ handle_timeout() {
     exit 124  # Standard timeout exit code
 }
 
+# Build a command prefix that drops the ob-sessions gid back to the user's
+# original primary group before spawning user shells.
+# The session file/directory is created before this is called, so the elevated
+# gid is no longer needed at that point.
+# Uses setpriv(1) (util-linux) when available; falls back to no-op if absent.
+# Trailing space in the non-empty return value is intentional: allows safe
+# concatenation with the command that follows (e.g. "${prefix}sh -c ...").
+build_drop_gid_prefix() {
+    if [ -n "${OB_ORIG_GID:-}" ] && command -v setpriv >/dev/null 2>&1; then
+        echo "setpriv --regid=${OB_ORIG_GID} --egid=${OB_ORIG_GID} --clear-groups -- "
+    else
+        echo ""
+    fi
+}
+
 # Record session using script command (always available)
 record_script() {
     local shell="${SHELL:-/bin/bash}"
+    local drop_prefix
+    drop_prefix=$(build_drop_gid_prefix)
 
     if [ -n "$ORIGINAL_COMMAND" ]; then
-        script -q -c "$ORIGINAL_COMMAND" "$SESSION_FILE"
+        # Export the command so the inner sh -c can access it safely without
+        # additional quoting that would break complex commands.
+        OB_CMD="$ORIGINAL_COMMAND" \
+            script -q -c "${drop_prefix}sh -c \"\$OB_CMD\"" "$SESSION_FILE"
     else
-        script -q -c "$shell" "$SESSION_FILE"
+        # shellcheck disable=SC2086
+        script -q -c "${drop_prefix}${shell}" "$SESSION_FILE"
     fi
 }
 
 # Record session using asciinema (if available)
 record_asciinema() {
     local shell="${SHELL:-/bin/bash}"
+    local drop_prefix
+    drop_prefix=$(build_drop_gid_prefix)
 
     if ! command -v asciinema >/dev/null 2>&1; then
         log_warn "asciinema not installed, falling back to script"
@@ -219,15 +250,19 @@ record_asciinema() {
     fi
 
     if [ -n "$ORIGINAL_COMMAND" ]; then
-        asciinema rec -c "$ORIGINAL_COMMAND" "$SESSION_FILE"
+        OB_CMD="$ORIGINAL_COMMAND" \
+            asciinema rec -c "${drop_prefix}sh -c \"\$OB_CMD\"" "$SESSION_FILE"
     else
-        asciinema rec -c "$shell" "$SESSION_FILE"
+        # shellcheck disable=SC2086
+        asciinema rec -c "${drop_prefix}${shell}" "$SESSION_FILE"
     fi
 }
 
 # Record session using ttyrec (if available)
 record_ttyrec() {
     local shell="${SHELL:-/bin/bash}"
+    local drop_prefix
+    drop_prefix=$(build_drop_gid_prefix)
 
     if ! command -v ttyrec >/dev/null 2>&1; then
         log_warn "ttyrec not installed, falling back to script"
@@ -238,9 +273,11 @@ record_ttyrec() {
     fi
 
     if [ -n "$ORIGINAL_COMMAND" ]; then
-        ttyrec -e "$ORIGINAL_COMMAND" "$SESSION_FILE"
+        OB_CMD="$ORIGINAL_COMMAND" \
+            ttyrec -e "${drop_prefix}sh -c \"\$OB_CMD\"" "$SESSION_FILE"
     else
-        ttyrec -e "$shell" "$SESSION_FILE"
+        # shellcheck disable=SC2086
+        ttyrec -e "${drop_prefix}${shell}" "$SESSION_FILE"
     fi
 }
 

--- a/scripts/ob-session-recorder
+++ b/scripts/ob-session-recorder
@@ -26,7 +26,8 @@ MAX_SESSION_DURATION="${LLNG_MAX_SESSION:-86400}"  # 24 hours default
 
 # Metadata
 SESSION_ID=""
-SESSION_USER="${USER:-unknown}"
+# Derive username from real uid, not $USER (which is user-controllable).
+SESSION_USER="$(id -un 2>/dev/null || echo unknown)"
 SESSION_START=""
 SESSION_FILE=""
 METADATA_FILE=""

--- a/scripts/ob-session-recorder
+++ b/scripts/ob-session-recorder
@@ -135,6 +135,11 @@ ensure_sessions_dir() {
         mkdir "$user_dir" 2>/dev/null || true
         chmod 0770 "$user_dir" 2>/dev/null || true
     fi
+
+    if [ ! -d "$user_dir" ]; then
+        log_err "User sessions directory $user_dir does not exist and could not be created"
+        return 1
+    fi
 }
 
 # Write session metadata

--- a/src/ob-session-recorder-wrapper.c
+++ b/src/ob-session-recorder-wrapper.c
@@ -5,47 +5,71 @@
  *
  * Install as: root:ob-sessions, mode 2755 (setgid)
  *
- * Purpose: ensure the session recorder runs with effective gid ob-sessions
- * so that session files are created with group ob-sessions.  The sessions
- * directory is mode 1770 root:ob-sessions (sticky + rwxrwx---), which means
- * only root or a process with effective gid ob-sessions can create files
- * there.  The sticky bit prevents non-root/non-owner processes from deleting
- * files they do not own.
+ * Purpose: create the user's session recording directory with group
+ * ob-sessions and the setgid bit, then exec the session recorder script
+ * with the user's ORIGINAL privileges (no elevated gid).
+ *
+ * Architecture:
+ *  1. Kernel gives us effective gid = ob-sessions (via setgid bit on binary)
+ *  2. We create $SESSIONS_DIR/$USER/ owned by user:ob-sessions, mode 2770
+ *     - The directory's setgid bit ensures all files created inside inherit
+ *       the ob-sessions group, without the process needing elevated gid
+ *  3. We sanitize the environment (LD_PRELOAD, BASH_ENV, etc.)
+ *  4. We exec the recorder script WITHOUT calling setregid()
+ *     - The kernel naturally strips the setgid on exec of #! scripts
+ *     - The script and user's shell run with the user's original gid
+ *     - But files they create in the session dir get group ob-sessions
  *
  * Security properties:
  *  - The target path is hard-coded; no user-controlled input affects it.
- *  - Real uid/gid are unchanged; only effective gid comes from the setgid bit.
- *  - Dangerous environment variables (LD_PRELOAD etc.) are stripped before exec
- *    to prevent code injection via dynamic linker when running with elevated gid.
- *  - The user's original real gid is exported as OB_ORIG_GID so the session
- *    recorder can drop back to it before spawning user shells.
- *  - No temporary files, no dynamic allocation, no user-controlled paths.
+ *  - The elevated gid is used ONLY for directory creation, then dropped.
+ *  - Dangerous environment variables are stripped before exec.
+ *  - No setregid() call: the user's shell never has the ob-sessions gid.
+ *  - No temporary files, no user-controlled paths.
  */
 
 #include <unistd.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <sys/types.h>
+#include <sys/stat.h>
 #include <grp.h>
+#include <pwd.h>
 #include <errno.h>
 #include <string.h>
 
-/* Hard-coded path – never derived from user input */
+/* Hard-coded paths – never derived from user input */
 #define SESSION_RECORDER "/usr/sbin/ob-session-recorder"
+#define SESSIONS_DIR     "/var/lib/open-bastion/sessions"
 
 /*
- * Sanitize environment: remove variables that the dynamic linker or C library
- * honour and that could be abused to inject code or alter behaviour when
- * running with elevated group privileges.
+ * Validate a username: must match ^[a-z_][a-z0-9_.-]*$
+ * Returns 0 if valid, -1 if invalid.
+ */
+static int validate_username(const char *name)
+{
+    if (!name || !*name) return -1;
+
+    /* First char: lowercase letter or underscore */
+    if (!((*name >= 'a' && *name <= 'z') || *name == '_'))
+        return -1;
+
+    for (const char *p = name + 1; *p; p++) {
+        if (!((*p >= 'a' && *p <= 'z') || (*p >= '0' && *p <= '9') ||
+              *p == '_' || *p == '.' || *p == '-'))
+            return -1;
+    }
+    return 0;
+}
+
+/*
+ * Sanitize environment: remove variables that the dynamic linker, C library,
+ * or shell honour and that could be abused to inject code or alter behaviour.
  *
- * After setregid(), the kernel considers the exec'd process as non-privilege-
- * gaining (real gid == effective gid), so LD_PRELOAD etc. would NOT be
- * stripped automatically by the dynamic linker.  We must do it ourselves
- * before calling execv().
- *
- * We use execv() (not execve()) so that the current process environment—
- * after these unsetenv() calls—is inherited by the child.  Using execve()
- * with the original envp[] snapshot would bypass the sanitisation.
+ * Since we do NOT call setregid(), the kernel will strip LD_PRELOAD etc.
+ * on exec of the setgid binary itself. However, we sanitize them anyway as
+ * defense-in-depth, and we MUST strip BASH_ENV/ENV which the kernel does
+ * not handle (they are processed by the shell interpreter, not the loader).
  */
 static void sanitize_environment(void)
 {
@@ -54,7 +78,7 @@ static void sanitize_environment(void)
         "LD_PRELOAD",
         "LD_LIBRARY_PATH",
         "LD_AUDIT",
-        "LD_BIND_NOT",
+        "LD_BIND_NOW",
         "LD_DEBUG",
         "LD_DEBUG_OUTPUT",
         "LD_DYNAMIC_WEAK",
@@ -64,6 +88,12 @@ static void sanitize_environment(void)
         "LD_PROFILE_OUTPUT",
         "LD_SHOW_AUXV",
         "LD_USE_LOAD_BIAS",
+        /* Shell init vectors – executed before set -euo pipefail */
+        "BASH_ENV",
+        "ENV",
+        "SHELLOPTS",
+        "BASHOPTS",
+        "CDPATH",
         /* glibc / locale / resolver side-channels */
         "GCONV_PATH",
         "HOSTALIASES",
@@ -82,45 +112,94 @@ static void sanitize_environment(void)
     for (const char **var = dangerous_vars; *var; var++) {
         unsetenv(*var);
     }
+
+    /*
+     * Harden PATH: set a safe, minimal PATH to prevent execution of
+     * attacker-supplied binaries via $PATH in the recorder script.
+     */
+    setenv("PATH", "/usr/sbin:/usr/bin:/sbin:/bin", 1);
+}
+
+/*
+ * Create the user's session recording directory with the proper ownership
+ * and permissions. The directory gets the setgid bit so that all files
+ * created inside inherit the ob-sessions group.
+ *
+ * Returns 0 on success or if directory already exists, -1 on error.
+ */
+static int ensure_user_session_dir(const char *username, uid_t uid, gid_t sessions_gid)
+{
+    char dirpath[512];
+    int len = snprintf(dirpath, sizeof(dirpath), "%s/%s", SESSIONS_DIR, username);
+    if (len < 0 || (size_t)len >= sizeof(dirpath)) {
+        fprintf(stderr, "ob-session-recorder-wrapper: session dir path too long\n");
+        return -1;
+    }
+
+    struct stat st;
+    if (stat(dirpath, &st) == 0) {
+        /* Directory exists - verify it's a directory */
+        if (!S_ISDIR(st.st_mode)) {
+            fprintf(stderr, "ob-session-recorder-wrapper: %s exists but is not a directory\n",
+                    dirpath);
+            return -1;
+        }
+        /* Ensure setgid bit is set (repair if needed) */
+        if (!(st.st_mode & S_ISGID)) {
+            chmod(dirpath, 02770);
+        }
+        return 0;
+    }
+
+    /* Create directory - we have effective gid ob-sessions */
+    if (mkdir(dirpath, 02770) != 0) {
+        fprintf(stderr, "ob-session-recorder-wrapper: mkdir(%s) failed: %s\n",
+                dirpath, strerror(errno));
+        return -1;
+    }
+
+    /* Set ownership: user:ob-sessions */
+    if (chown(dirpath, uid, sessions_gid) != 0) {
+        fprintf(stderr, "ob-session-recorder-wrapper: chown(%s, %u, %u) failed: %s\n",
+                dirpath, (unsigned)uid, (unsigned)sessions_gid, strerror(errno));
+        /* Directory was created but ownership failed - remove it */
+        rmdir(dirpath);
+        return -1;
+    }
+
+    return 0;
 }
 
 int main(int argc __attribute__((unused)), char *argv[])
 {
-    /*
-     * Save the user's original real gid before we change it.
-     * Export it as OB_ORIG_GID so the session recorder script can drop back
-     * to the user's primary group before spawning user shells, limiting the
-     * window during which the ob-sessions gid is active.
-     */
-    gid_t orig_gid = getgid();
-    char orig_gid_str[32];
-    snprintf(orig_gid_str, sizeof(orig_gid_str), "%u", (unsigned int)orig_gid);
-    if (setenv("OB_ORIG_GID", orig_gid_str, 1) != 0) {
-        fprintf(stderr, "ob-session-recorder-wrapper: setenv(OB_ORIG_GID) failed: %s\n",
-                strerror(errno));
+    uid_t real_uid = getuid();
+    gid_t sessions_gid = getegid();  /* ob-sessions, from setgid bit */
+
+    /* Get username from real uid */
+    struct passwd *pw = getpwuid(real_uid);
+    if (!pw || !pw->pw_name) {
+        fprintf(stderr, "ob-session-recorder-wrapper: cannot resolve uid %u\n",
+                (unsigned)real_uid);
+        return 1;
+    }
+
+    /* Validate username to prevent path traversal */
+    if (validate_username(pw->pw_name) != 0) {
+        fprintf(stderr, "ob-session-recorder-wrapper: invalid username\n");
         return 1;
     }
 
     /*
-     * The kernel has already set our effective gid to ob-sessions via the
-     * setgid bit.  Persist it as the real gid so it survives exec of
-     * interpreted scripts (#!).
-     *
-     * Note: after this call, real gid == effective gid == ob-sessions.
-     * The kernel will therefore NOT strip LD_PRELOAD etc. on the next exec,
-     * which is why sanitize_environment() must be called below.
+     * Create the user's session directory with group ob-sessions and setgid bit.
+     * This is the ONLY operation that uses the elevated effective gid.
      */
-    gid_t target_gid = getegid();
-    if (setregid(target_gid, target_gid) != 0) {
-        fprintf(stderr, "ob-session-recorder-wrapper: setregid(%d) failed: %s\n",
-                target_gid, strerror(errno));
+    if (ensure_user_session_dir(pw->pw_name, real_uid, sessions_gid) != 0) {
         return 1;
     }
 
     /*
-     * Sanitize the environment: strip LD_PRELOAD and all other dynamic-linker
-     * variables that a malicious user could set to inject code running with
-     * the ob-sessions group.  Must be done AFTER setregid() and BEFORE execv().
+     * Sanitize the environment before exec.
+     * Strip LD_*, BASH_ENV, ENV, and harden PATH.
      */
     sanitize_environment();
 
@@ -132,10 +211,16 @@ int main(int argc __attribute__((unused)), char *argv[])
     }
 
     /*
-     * Exec the real session recorder, passing through all args.
-     * Use execv() (not execve()) so the sanitized current environment—
-     * after the unsetenv() calls above—is inherited by the child.
-     * execve() with the original envp snapshot would bypass sanitisation.
+     * Exec the real session recorder.
+     *
+     * We do NOT call setregid(). The kernel will naturally strip the setgid
+     * effective gid when exec'ing the #! script. The script and the user's
+     * shell will run with the user's original real gid only.
+     *
+     * Files created by the script in the session directory will inherit
+     * the ob-sessions group thanks to the directory's setgid bit (mode 2770).
+     *
+     * Use execv() so the sanitized in-process environment is inherited.
      */
     execv(SESSION_RECORDER, argv);
 

--- a/src/ob-session-recorder-wrapper.c
+++ b/src/ob-session-recorder-wrapper.c
@@ -15,8 +15,10 @@
  * Security properties:
  *  - The target path is hard-coded; no user-controlled input affects it.
  *  - Real uid/gid are unchanged; only effective gid comes from the setgid bit.
- *  - All environment variables are passed through (SSH_ORIGINAL_COMMAND etc.)
- *    because execve() inherits the caller's environment.
+ *  - Dangerous environment variables (LD_PRELOAD etc.) are stripped before exec
+ *    to prevent code injection via dynamic linker when running with elevated gid.
+ *  - The user's original real gid is exported as OB_ORIG_GID so the session
+ *    recorder can drop back to it before spawning user shells.
  *  - No temporary files, no dynamic allocation, no user-controlled paths.
  */
 
@@ -31,30 +33,82 @@
 /* Hard-coded path – never derived from user input */
 #define SESSION_RECORDER "/usr/sbin/ob-session-recorder"
 
-int main(int argc __attribute__((unused)), char *argv[], char *envp[])
+/*
+ * Sanitize environment: remove variables that the dynamic linker or C library
+ * honour and that could be abused to inject code or alter behaviour when
+ * running with elevated group privileges.
+ *
+ * After setregid(), the kernel considers the exec'd process as non-privilege-
+ * gaining (real gid == effective gid), so LD_PRELOAD etc. would NOT be
+ * stripped automatically by the dynamic linker.  We must do it ourselves
+ * before calling execv().
+ *
+ * We use execv() (not execve()) so that the current process environment—
+ * after these unsetenv() calls—is inherited by the child.  Using execve()
+ * with the original envp[] snapshot would bypass the sanitisation.
+ */
+static void sanitize_environment(void)
+{
+    static const char *dangerous_vars[] = {
+        /* Dynamic linker injection vectors */
+        "LD_PRELOAD",
+        "LD_LIBRARY_PATH",
+        "LD_AUDIT",
+        "LD_BIND_NOT",
+        "LD_DEBUG",
+        "LD_DEBUG_OUTPUT",
+        "LD_DYNAMIC_WEAK",
+        "LD_HWCAP_MASK",
+        "LD_ORIGIN_PATH",
+        "LD_PROFILE",
+        "LD_PROFILE_OUTPUT",
+        "LD_SHOW_AUXV",
+        "LD_USE_LOAD_BIAS",
+        /* glibc / locale / resolver side-channels */
+        "GCONV_PATH",
+        "HOSTALIASES",
+        "LOCALDOMAIN",
+        "LOCPATH",
+        "MALLOC_TRACE",
+        "NIS_PATH",
+        "NLSPATH",
+        "RESOLV_HOST_CONF",
+        "RES_OPTIONS",
+        /* Miscellaneous */
+        "TMPDIR",
+        NULL
+    };
+
+    for (const char **var = dangerous_vars; *var; var++) {
+        unsetenv(*var);
+    }
+}
+
+int main(int argc __attribute__((unused)), char *argv[])
 {
     /*
-     * The kernel has already set our effective gid to ob-sessions via the
-     * setgid bit.  We only need to make sure the supplementary groups list
-     * does not inadvertently grant extra privileges beyond what the real user
-     * already had.  We intentionally keep the real uid/gid so that the
-     * session recorder can tell which user is logging in.
-     *
-     * Drop any suid/sgid escalation beyond what we need: we want effective
-     * gid = ob-sessions (already set by kernel), and we do NOT want to run
-     * with elevated uid.  Since this binary is NOT setuid, effective uid
-     * already equals real uid – nothing to do for uid.
-     *
-     * We do NOT call setgroups() to strip supplementary groups: that would
-     * require CAP_SETGID and would break legitimate group memberships the
-     * user relies on for their shell session.
+     * Save the user's original real gid before we change it.
+     * Export it as OB_ORIG_GID so the session recorder script can drop back
+     * to the user's primary group before spawning user shells, limiting the
+     * window during which the ob-sessions gid is active.
      */
+    gid_t orig_gid = getgid();
+    char orig_gid_str[32];
+    snprintf(orig_gid_str, sizeof(orig_gid_str), "%u", (unsigned int)orig_gid);
+    if (setenv("OB_ORIG_GID", orig_gid_str, 1) != 0) {
+        fprintf(stderr, "ob-session-recorder-wrapper: setenv(OB_ORIG_GID) failed: %s\n",
+                strerror(errno));
+        return 1;
+    }
 
     /*
-     * Persist the effective gid (ob-sessions) as the real gid.
-     * The kernel drops setgid on exec of interpreted scripts (#!),
-     * so we must set the real gid explicitly before exec.
-     * This requires that the binary is setgid (chmod 2755).
+     * The kernel has already set our effective gid to ob-sessions via the
+     * setgid bit.  Persist it as the real gid so it survives exec of
+     * interpreted scripts (#!).
+     *
+     * Note: after this call, real gid == effective gid == ob-sessions.
+     * The kernel will therefore NOT strip LD_PRELOAD etc. on the next exec,
+     * which is why sanitize_environment() must be called below.
      */
     gid_t target_gid = getegid();
     if (setregid(target_gid, target_gid) != 0) {
@@ -63,6 +117,13 @@ int main(int argc __attribute__((unused)), char *argv[], char *envp[])
         return 1;
     }
 
+    /*
+     * Sanitize the environment: strip LD_PRELOAD and all other dynamic-linker
+     * variables that a malicious user could set to inject code running with
+     * the ob-sessions group.  Must be done AFTER setregid() and BEFORE execv().
+     */
+    sanitize_environment();
+
     /* Verify we can actually exec the recorder (basic sanity check) */
     if (access(SESSION_RECORDER, X_OK) != 0) {
         fprintf(stderr, "ob-session-recorder-wrapper: cannot execute %s: %s\n",
@@ -70,11 +131,16 @@ int main(int argc __attribute__((unused)), char *argv[], char *envp[])
         return 1;
     }
 
-    /* exec the real session recorder, passing through all args and env */
-    execve(SESSION_RECORDER, argv, envp);
+    /*
+     * Exec the real session recorder, passing through all args.
+     * Use execv() (not execve()) so the sanitized current environment—
+     * after the unsetenv() calls above—is inherited by the child.
+     * execve() with the original envp snapshot would bypass sanitisation.
+     */
+    execv(SESSION_RECORDER, argv);
 
-    /* execve only returns on error */
-    fprintf(stderr, "ob-session-recorder-wrapper: execve(%s) failed: %s\n",
+    /* execv only returns on error */
+    fprintf(stderr, "ob-session-recorder-wrapper: execv(%s) failed: %s\n",
             SESSION_RECORDER, strerror(errno));
     return 1;
 }

--- a/src/ob-session-recorder-wrapper.c
+++ b/src/ob-session-recorder-wrapper.c
@@ -33,6 +33,7 @@
 #include <stdlib.h>
 #include <sys/types.h>
 #include <sys/stat.h>
+#include <fcntl.h>
 #include <grp.h>
 #include <pwd.h>
 #include <errno.h>
@@ -136,37 +137,54 @@ static int ensure_user_session_dir(const char *username, uid_t uid, gid_t sessio
         return -1;
     }
 
-    struct stat st;
-    if (stat(dirpath, &st) == 0) {
-        /* Directory exists - verify it's a directory */
-        if (!S_ISDIR(st.st_mode)) {
-            fprintf(stderr, "ob-session-recorder-wrapper: %s exists but is not a directory\n",
-                    dirpath);
-            return -1;
+    /*
+     * Try to open an existing directory first.
+     * Use O_NOFOLLOW to prevent symlink attacks.
+     * All subsequent checks use the fd to avoid TOCTOU races.
+     */
+    int fd = open(dirpath, O_RDONLY | O_DIRECTORY | O_NOFOLLOW);
+    if (fd >= 0) {
+        /* Directory exists - ensure setgid bit is set (repair if needed) */
+        struct stat st;
+        if (fstat(fd, &st) == 0 && !(st.st_mode & S_ISGID)) {
+            fchmod(fd, 02770);
         }
-        /* Ensure setgid bit is set (repair if needed) */
-        if (!(st.st_mode & S_ISGID)) {
-            chmod(dirpath, 02770);
-        }
+        close(fd);
         return 0;
     }
 
-    /* Create directory - we have effective gid ob-sessions */
+    /* Directory does not exist - create it. We have effective gid ob-sessions. */
     if (mkdir(dirpath, 02770) != 0) {
+        if (errno == EEXIST) {
+            /* Race: another process created it between our open and mkdir */
+            return 0;
+        }
         fprintf(stderr, "ob-session-recorder-wrapper: mkdir(%s) failed: %s\n",
                 dirpath, strerror(errno));
         return -1;
     }
 
-    /* Set ownership: user:ob-sessions */
-    if (chown(dirpath, uid, sessions_gid) != 0) {
-        fprintf(stderr, "ob-session-recorder-wrapper: chown(%s, %u, %u) failed: %s\n",
-                dirpath, (unsigned)uid, (unsigned)sessions_gid, strerror(errno));
-        /* Directory was created but ownership failed - remove it */
+    /*
+     * Set ownership via fd to avoid TOCTOU between mkdir and chown.
+     * Open the directory we just created, then use fchown on the fd.
+     */
+    fd = open(dirpath, O_RDONLY | O_DIRECTORY | O_NOFOLLOW);
+    if (fd < 0) {
+        fprintf(stderr, "ob-session-recorder-wrapper: open(%s) after mkdir failed: %s\n",
+                dirpath, strerror(errno));
         rmdir(dirpath);
         return -1;
     }
 
+    if (fchown(fd, uid, sessions_gid) != 0) {
+        fprintf(stderr, "ob-session-recorder-wrapper: fchown(%s, %u, %u) failed: %s\n",
+                dirpath, (unsigned)uid, (unsigned)sessions_gid, strerror(errno));
+        close(fd);
+        rmdir(dirpath);
+        return -1;
+    }
+
+    close(fd);
     return 0;
 }
 

--- a/src/ob-session-recorder-wrapper.c
+++ b/src/ob-session-recorder-wrapper.c
@@ -14,17 +14,19 @@
  *  2. We create $SESSIONS_DIR/$USER/ owned by user:ob-sessions, mode 2770
  *     - The directory's setgid bit ensures all files created inside inherit
  *       the ob-sessions group, without the process needing elevated gid
- *  3. We sanitize the environment (LD_PRELOAD, BASH_ENV, etc.)
- *  4. We exec the recorder script WITHOUT calling setregid()
- *     - The kernel naturally strips the setgid on exec of #! scripts
- *     - The script and user's shell run with the user's original gid
- *     - But files they create in the session dir get group ob-sessions
+ *  3. We explicitly drop the elevated gid via setregid(orig, orig)
+ *     - exec does NOT strip an already-acquired effective/saved gid
+ *     - We must drop it ourselves before exec'ing the script
+ *  4. We sanitize the environment (LD_PRELOAD, BASH_ENV, etc.)
+ *  5. We exec the recorder script with the user's original gid only
+ *     - Files created in the session dir still get group ob-sessions
+ *       thanks to the directory's setgid bit (mode 2770)
  *
  * Security properties:
  *  - The target path is hard-coded; no user-controlled input affects it.
- *  - The elevated gid is used ONLY for directory creation, then dropped.
+ *  - The elevated gid is used ONLY for directory creation, then explicitly
+ *    dropped via setregid() before exec.
  *  - Dangerous environment variables are stripped before exec.
- *  - No setregid() call: the user's shell never has the ob-sessions gid.
  *  - No temporary files, no user-controlled paths.
  */
 
@@ -144,9 +146,24 @@ static int ensure_user_session_dir(const char *username, uid_t uid, gid_t sessio
      */
     int fd = open(dirpath, O_RDONLY | O_DIRECTORY | O_NOFOLLOW);
     if (fd >= 0) {
-        /* Directory exists - ensure setgid bit is set (repair if needed) */
+        /* Directory exists - validate and repair ownership/mode if needed */
         struct stat st;
-        if (fstat(fd, &st) == 0 && !(st.st_mode & S_ISGID)) {
+        if (fstat(fd, &st) != 0) {
+            close(fd);
+            return -1;
+        }
+        /* Ensure correct ownership: user:ob-sessions */
+        if (st.st_uid != uid || st.st_gid != sessions_gid) {
+            if (fchown(fd, uid, sessions_gid) != 0) {
+                fprintf(stderr, "ob-session-recorder-wrapper: "
+                        "cannot repair ownership on %s: %s\n",
+                        dirpath, strerror(errno));
+                close(fd);
+                return -1;
+            }
+        }
+        /* Ensure mode 2770 (setgid + rwxrwx---) */
+        if ((st.st_mode & 07777) != 02770) {
             fchmod(fd, 02770);
         }
         close(fd);
@@ -184,6 +201,12 @@ static int ensure_user_session_dir(const char *username, uid_t uid, gid_t sessio
         return -1;
     }
 
+    /*
+     * Re-apply mode after fchown: POSIX allows chown to clear the
+     * setgid bit as a security measure. Ensure 2770 is set.
+     */
+    fchmod(fd, 02770);
+
     close(fd);
     return 0;
 }
@@ -216,6 +239,25 @@ int main(int argc __attribute__((unused)), char *argv[])
     }
 
     /*
+     * Drop the elevated ob-sessions gid now that directory setup is done.
+     *
+     * The setgid bit on this binary gave us effective gid = ob-sessions.
+     * We used it solely to create/chown the session directory above.
+     * Now we must explicitly drop it: exec does NOT strip an already-acquired
+     * effective/saved gid — it only ignores setgid bits on the exec'd file.
+     *
+     * After this call: real = effective = saved = user's original gid.
+     * The session directory's setgid bit (mode 2770) ensures files created
+     * inside still inherit the ob-sessions group.
+     */
+    gid_t orig_gid = getgid();  /* user's real gid, unchanged by setgid bit */
+    if (setregid(orig_gid, orig_gid) != 0) {
+        fprintf(stderr, "ob-session-recorder-wrapper: setregid(%u) failed: %s\n",
+                (unsigned)orig_gid, strerror(errno));
+        return 1;
+    }
+
+    /*
      * Sanitize the environment before exec.
      * Strip LD_*, BASH_ENV, ENV, and harden PATH.
      */
@@ -231,12 +273,9 @@ int main(int argc __attribute__((unused)), char *argv[])
     /*
      * Exec the real session recorder.
      *
-     * We do NOT call setregid(). The kernel will naturally strip the setgid
-     * effective gid when exec'ing the #! script. The script and the user's
-     * shell will run with the user's original real gid only.
-     *
-     * Files created by the script in the session directory will inherit
-     * the ob-sessions group thanks to the directory's setgid bit (mode 2770).
+     * The elevated gid has been explicitly dropped above via setregid().
+     * The script and user's shell run with the user's original gid only.
+     * Files inherit the ob-sessions group from the directory's setgid bit.
      *
      * Use execv() so the sanitized in-process environment is inherited.
      */

--- a/tests/test_ob_session_recorder.sh
+++ b/tests/test_ob_session_recorder.sh
@@ -333,6 +333,69 @@ test_parse_args() {
     fi
 }
 
+# ── Test 13: Invalid SESSION_USER is rejected (path traversal prevention) ──
+test_invalid_session_user() {
+    # Run the script with a path-traversal username; it should exit non-zero.
+    local rc
+    USER="../../../etc/passwd" SSH_CLIENT="" SSH_TTY="" SSH_ORIGINAL_COMMAND="" \
+        bash "$SCRIPT_DIR/ob-session-recorder" --version >/dev/null 2>&1
+    rc=$?
+    if [ $rc -ne 0 ]; then
+        pass "Invalid SESSION_USER (path traversal) is rejected"
+    else
+        fail "Invalid SESSION_USER (path traversal) is rejected"
+    fi
+}
+
+# ── Test 14: Valid SESSION_USER passes validation ──
+test_valid_session_user() {
+    local out rc
+    out=$(USER="alice" SSH_CLIENT="" SSH_TTY="" SSH_ORIGINAL_COMMAND="" \
+        bash "$SCRIPT_DIR/ob-session-recorder" --version 2>&1)
+    rc=$?
+    if [ $rc -eq 0 ] && echo "$out" | grep -q "version"; then
+        pass "Valid SESSION_USER passes validation"
+    else
+        fail "Valid SESSION_USER passes validation" "exit=$rc out=$out"
+    fi
+}
+
+# ── Test 15: build_drop_gid_prefix returns empty when OB_ORIG_GID unset ──
+test_build_drop_gid_prefix_empty() {
+    (
+        source_script "ob-session-recorder"
+        unset OB_ORIG_GID 2>/dev/null || true
+        local prefix
+        prefix=$(build_drop_gid_prefix)
+        [ -z "$prefix" ] && exit 0 || exit 1
+    )
+    if [ $? -eq 0 ]; then
+        pass "build_drop_gid_prefix: empty when OB_ORIG_GID unset"
+    else
+        fail "build_drop_gid_prefix: empty when OB_ORIG_GID unset"
+    fi
+}
+
+# ── Test 16: build_drop_gid_prefix includes setpriv when OB_ORIG_GID set ──
+test_build_drop_gid_prefix_setpriv() {
+    (
+        source_script "ob-session-recorder"
+        if ! command -v setpriv >/dev/null 2>&1; then
+            # setpriv not installed; skip by passing
+            exit 0
+        fi
+        OB_ORIG_GID=1000
+        local prefix
+        prefix=$(build_drop_gid_prefix)
+        echo "$prefix" | grep -q "setpriv" && exit 0 || exit 1
+    )
+    if [ $? -eq 0 ]; then
+        pass "build_drop_gid_prefix: setpriv prefix when OB_ORIG_GID set"
+    else
+        fail "build_drop_gid_prefix: setpriv prefix when OB_ORIG_GID set"
+    fi
+}
+
 # ── Run all tests ──
 echo "=== Testing ob-session-recorder ==="
 run_test test_syntax
@@ -351,6 +414,10 @@ run_test test_ensure_sessions_dir_missing
 run_test test_write_metadata
 run_test test_env_defaults
 run_test test_parse_args
+run_test test_invalid_session_user
+run_test test_valid_session_user
+run_test test_build_drop_gid_prefix_empty
+run_test test_build_drop_gid_prefix_setpriv
 
 echo ""
 echo "=== Results: $TESTS_PASSED/$TESTS_RUN passed, $TESTS_FAILED failed ==="

--- a/tests/test_ob_session_recorder.sh
+++ b/tests/test_ob_session_recorder.sh
@@ -343,7 +343,7 @@ test_invalid_session_user() {
     if [ $rc -ne 0 ]; then
         pass "Invalid SESSION_USER (path traversal) is rejected"
     else
-        fail "Invalid SESSION_USER (path traversal) is rejected"
+        fail "Invalid SESSION_USER (path traversal) was unexpectedly accepted" "exit=$rc"
     fi
 }
 
@@ -360,41 +360,6 @@ test_valid_session_user() {
     fi
 }
 
-# ── Test 15: build_drop_gid_prefix returns empty when OB_ORIG_GID unset ──
-test_build_drop_gid_prefix_empty() {
-    (
-        source_script "ob-session-recorder"
-        unset OB_ORIG_GID 2>/dev/null || true
-        local prefix
-        prefix=$(build_drop_gid_prefix)
-        [ -z "$prefix" ] && exit 0 || exit 1
-    )
-    if [ $? -eq 0 ]; then
-        pass "build_drop_gid_prefix: empty when OB_ORIG_GID unset"
-    else
-        fail "build_drop_gid_prefix: empty when OB_ORIG_GID unset"
-    fi
-}
-
-# ── Test 16: build_drop_gid_prefix includes setpriv when OB_ORIG_GID set ──
-test_build_drop_gid_prefix_setpriv() {
-    (
-        source_script "ob-session-recorder"
-        if ! command -v setpriv >/dev/null 2>&1; then
-            # setpriv not installed; skip by passing
-            exit 0
-        fi
-        OB_ORIG_GID=1000
-        local prefix
-        prefix=$(build_drop_gid_prefix)
-        echo "$prefix" | grep -q "setpriv" && exit 0 || exit 1
-    )
-    if [ $? -eq 0 ]; then
-        pass "build_drop_gid_prefix: setpriv prefix when OB_ORIG_GID set"
-    else
-        fail "build_drop_gid_prefix: setpriv prefix when OB_ORIG_GID set"
-    fi
-}
 
 # ── Run all tests ──
 echo "=== Testing ob-session-recorder ==="
@@ -416,8 +381,6 @@ run_test test_env_defaults
 run_test test_parse_args
 run_test test_invalid_session_user
 run_test test_valid_session_user
-run_test test_build_drop_gid_prefix_empty
-run_test test_build_drop_gid_prefix_setpriv
 
 echo ""
 echo "=== Results: $TESTS_PASSED/$TESTS_RUN passed, $TESTS_FAILED failed ==="

--- a/tests/test_ob_session_recorder.sh
+++ b/tests/test_ob_session_recorder.sh
@@ -333,30 +333,50 @@ test_parse_args() {
     fi
 }
 
-# ── Test 13: Invalid SESSION_USER is rejected (path traversal prevention) ──
+# ── Test 13: Invalid SESSION_USER regex rejects path traversal ──
 test_invalid_session_user() {
-    # Run the script with a path-traversal username; it should exit non-zero.
-    local rc
-    USER="../../../etc/passwd" SSH_CLIENT="" SSH_TTY="" SSH_ORIGINAL_COMMAND="" \
-        bash "$SCRIPT_DIR/ob-session-recorder" --version >/dev/null 2>&1
-    rc=$?
-    if [ $rc -ne 0 ]; then
-        pass "Invalid SESSION_USER (path traversal) is rejected"
+    # Test the validation regex directly (SESSION_USER is now derived from
+    # id -un, not $USER, so we can't inject via environment).
+    (
+        SESSION_USER="../../../etc/passwd"
+        if [[ ! "$SESSION_USER" =~ ^[a-z_][a-z0-9_.-]*$ ]]; then
+            exit 0  # correctly rejected
+        else
+            exit 1  # incorrectly accepted
+        fi
+    )
+    if [ $? -eq 0 ]; then
+        pass "Invalid SESSION_USER (path traversal) is rejected by regex"
     else
-        fail "Invalid SESSION_USER (path traversal) was unexpectedly accepted" "exit=$rc"
+        fail "Invalid SESSION_USER (path traversal) was unexpectedly accepted by regex"
     fi
 }
 
-# ── Test 14: Valid SESSION_USER passes validation ──
+# ── Test 14: Valid SESSION_USER passes regex validation ──
 test_valid_session_user() {
-    local out rc
-    out=$(USER="alice" SSH_CLIENT="" SSH_TTY="" SSH_ORIGINAL_COMMAND="" \
-        bash "$SCRIPT_DIR/ob-session-recorder" --version 2>&1)
-    rc=$?
-    if [ $rc -eq 0 ] && echo "$out" | grep -q "version"; then
-        pass "Valid SESSION_USER passes validation"
+    (
+        SESSION_USER="alice"
+        if [[ "$SESSION_USER" =~ ^[a-z_][a-z0-9_.-]*$ ]]; then
+            exit 0  # correctly accepted
+        else
+            exit 1  # incorrectly rejected
+        fi
+    )
+    if [ $? -eq 0 ]; then
+        pass "Valid SESSION_USER passes regex validation"
     else
-        fail "Valid SESSION_USER passes validation" "exit=$rc out=$out"
+        fail "Valid SESSION_USER was unexpectedly rejected by regex"
+    fi
+}
+
+# ── Test 15: Script uses id -un, not $USER ──
+test_session_user_from_uid() {
+    # Verify the script source contains 'id -un' and not '${USER'
+    if grep -q 'id -un' "$SCRIPT_DIR/ob-session-recorder" && \
+       ! grep -q 'SESSION_USER=.*\${USER' "$SCRIPT_DIR/ob-session-recorder"; then
+        pass "SESSION_USER derived from id -un, not \$USER"
+    else
+        fail "SESSION_USER should use id -un, not \$USER"
     fi
 }
 
@@ -381,6 +401,7 @@ run_test test_env_defaults
 run_test test_parse_args
 run_test test_invalid_session_user
 run_test test_valid_session_user
+run_test test_session_user_from_uid
 
 echo ""
 echo "=== Results: $TESTS_PASSED/$TESTS_RUN passed, $TESTS_FAILED failed ==="


### PR DESCRIPTION
## Summary

- Sanitize dangerous environment variables (LD_PRELOAD, LD_LIBRARY_PATH, etc.) in the setgid wrapper before `execve()`. After `setregid()`, the kernel no longer auto-strips these because `real gid == effective gid`, so we must do it ourselves.
- Switch from `execve()` with original `envp` snapshot to `execv()` which inherits the sanitized in-process environment.
- Export original user gid as `OB_ORIG_GID` so the session recorder script can drop elevated group before spawning user shells.
- Validate `$SESSION_USER` against `^[a-z_][a-z0-9_.-]*$` to prevent path traversal.
- Drop `ob-sessions` gid via `setpriv` before spawning user commands in all record functions.

## Security Impact

**Without this fix:** A user could set `LD_PRELOAD=/tmp/evil.so` and get code execution with `ob-sessions` group, allowing read/write to all session recordings. User commands via `script -c` also ran with elevated gid.

**With this fix:** LD_* variables are stripped, user shells run with original gid, and usernames are validated.

## Test plan

- [ ] Verify session recording still works (script, asciinema, ttyrec formats)
- [ ] Verify `LD_PRELOAD` is stripped: `LD_PRELOAD=/tmp/test.so ssh bastion whoami` should not load the library
- [ ] Verify path traversal blocked: username with `../` should be rejected
- [ ] Verify `setpriv` gid drop works when available
- [ ] Run existing tests: `tests/test_ob_session_recorder.sh`