### PR TITLE
Security: add symlink and permission checks to NSS config loading

### DIFF
--- a/nss/libnss_openbastion.c
+++ b/nss/libnss_openbastion.c
@@ -312,10 +312,18 @@ static int load_server_token(nss_llng_config_t *config)
      * Matches the pattern used in pam_openbastion.c for token loading.
      */
     int fd = open(config->server_token_file, O_RDONLY | O_NOFOLLOW);
-    if (fd < 0) return -1;
+    if (fd < 0) {
+        if (errno == ELOOP) {
+            syslog(LOG_WARNING, "libnss_llng: token file %s is a symlink (rejected)",
+                   config->server_token_file);
+        }
+        return -1;
+    }
 
     struct stat st;
     if (fstat(fd, &st) != 0) {
+        syslog(LOG_WARNING, "libnss_llng: cannot stat token file %s: %s",
+               config->server_token_file, strerror(errno));
         close(fd);
         return -1;
     }
@@ -332,6 +340,8 @@ static int load_server_token(nss_llng_config_t *config)
         return -1;
     }
     if (!S_ISREG(st.st_mode)) {
+        syslog(LOG_WARNING, "libnss_llng: token file %s is not a regular file",
+               config->server_token_file);
         close(fd);
         return -1;
     }
@@ -389,11 +399,19 @@ static int load_config(nss_llng_config_t *config)
      * Matches the pattern used in config.c for pam_openbastion.
      */
     int fd = open(NSS_LLNG_CONF, O_RDONLY | O_NOFOLLOW);
-    if (fd < 0) return -1;
+    if (fd < 0) {
+        if (errno == ELOOP) {
+            syslog(LOG_ERR, "libnss_llng: config file %s is a symlink (rejected)",
+                   NSS_LLNG_CONF);
+        }
+        return -1;
+    }
 
     /* Verify file ownership and permissions */
     struct stat st;
     if (fstat(fd, &st) != 0) {
+        syslog(LOG_ERR, "libnss_llng: cannot stat config file %s: %s",
+               NSS_LLNG_CONF, strerror(errno));
         close(fd);
         return -1;
     }

--- a/nss/libnss_openbastion.c
+++ b/nss/libnss_openbastion.c
@@ -25,6 +25,7 @@
 #include <curl/curl.h>
 #include <json-c/json.h>
 #include <stdint.h>
+#include <fcntl.h>
 
 /* Shared path validation functions */
 #include "path_validator.h"
@@ -303,8 +304,43 @@ static int load_server_token(nss_llng_config_t *config)
 {
     if (!config->server_token_file) return -1;
 
-    FILE *f = fopen(config->server_token_file, "r");
-    if (!f) return -1;
+    /*
+     * Security: open with O_NOFOLLOW to prevent symlink attacks,
+     * then verify ownership and permissions via fstat to avoid TOCTOU.
+     * The token file contains a Bearer token granting API access to
+     * the LLNG portal - it must be protected.
+     * Matches the pattern used in pam_openbastion.c for token loading.
+     */
+    int fd = open(config->server_token_file, O_RDONLY | O_NOFOLLOW);
+    if (fd < 0) return -1;
+
+    struct stat st;
+    if (fstat(fd, &st) != 0) {
+        close(fd);
+        return -1;
+    }
+    if (st.st_uid != 0) {
+        syslog(LOG_WARNING, "libnss_llng: token file %s not owned by root",
+               config->server_token_file);
+        close(fd);
+        return -1;
+    }
+    if (st.st_mode & (S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH)) {
+        syslog(LOG_WARNING, "libnss_llng: token file %s has insecure permissions",
+               config->server_token_file);
+        close(fd);
+        return -1;
+    }
+    if (!S_ISREG(st.st_mode)) {
+        close(fd);
+        return -1;
+    }
+
+    FILE *f = fdopen(fd, "r");
+    if (!f) {
+        close(fd);
+        return -1;
+    }
 
     char buffer[8192];
     size_t len = fread(buffer, 1, sizeof(buffer) - 1, f);
@@ -347,8 +383,41 @@ static int load_server_token(nss_llng_config_t *config)
 /* Load configuration */
 static int load_config(nss_llng_config_t *config)
 {
-    FILE *f = fopen(NSS_LLNG_CONF, "r");
-    if (!f) return -1;
+    /*
+     * Security: open with O_NOFOLLOW to prevent symlink attacks,
+     * then check permissions on the opened fd to avoid TOCTOU.
+     * Matches the pattern used in config.c for pam_openbastion.
+     */
+    int fd = open(NSS_LLNG_CONF, O_RDONLY | O_NOFOLLOW);
+    if (fd < 0) return -1;
+
+    /* Verify file ownership and permissions */
+    struct stat st;
+    if (fstat(fd, &st) != 0) {
+        close(fd);
+        return -1;
+    }
+    if (st.st_uid != 0) {
+        syslog(LOG_ERR, "libnss_llng: config file %s not owned by root", NSS_LLNG_CONF);
+        close(fd);
+        return -1;
+    }
+    if (st.st_mode & (S_IWGRP | S_IWOTH)) {
+        syslog(LOG_ERR, "libnss_llng: config file %s is group/world-writable", NSS_LLNG_CONF);
+        close(fd);
+        return -1;
+    }
+    if (!S_ISREG(st.st_mode)) {
+        syslog(LOG_ERR, "libnss_llng: config file %s is not a regular file", NSS_LLNG_CONF);
+        close(fd);
+        return -1;
+    }
+
+    FILE *f = fdopen(fd, "r");
+    if (!f) {
+        close(fd);
+        return -1;
+    }
 
     /* Set defaults */
     config->timeout = 5;


### PR DESCRIPTION
## Summary

- Replace `fopen()` with `open(O_RDONLY | O_NOFOLLOW)` + `fstat()` + `fdopen()` for NSS config file loading
- Verify root ownership, reject group/world-writable files, ensure regular file
- Matches the secure pattern already used in `src/config.c` for the PAM module

## Security Impact

**Without this fix:** The NSS module opened `/etc/nss_llng.conf` with plain `fopen()`, vulnerable to symlink attacks. An attacker could redirect the module to a malicious LLNG server. The NSS module runs in every process resolving users (sshd, sudo, login).

**With this fix:** Symlink attacks are blocked, and config files must be root-owned with restrictive permissions.

## Test plan

- [ ] Verify NSS module still loads config correctly on a properly configured system
- [ ] Verify symlink to config is rejected (create symlink, check syslog)
- [ ] Verify non-root-owned config is rejected
- [ ] Verify group-writable config is rejected