### PR TITLE
Security: defense-in-depth for sudo via open-bastion-sudo group

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -160,6 +160,8 @@ case "$1" in
         chmod 711 /var/lib/open-bastion
         # Create ob-sessions group for session recording privilege separation
         groupadd --system ob-sessions 2>/dev/null || true
+        # Create open-bastion-sudo group for defense-in-depth sudo authorization (Mode E)
+        groupadd --system open-bastion-sudo 2>/dev/null || true
         mkdir -p /var/lib/open-bastion/sessions
         chgrp ob-sessions /var/lib/open-bastion/sessions
         chmod 1770 /var/lib/open-bastion/sessions

--- a/doc/pam-modes.md
+++ b/doc/pam-modes.md
@@ -189,8 +189,12 @@ account    required     pam_openbastion.so
 session    required     pam_unix.so
 ```
 
-`ob-bastion-setup --max-security` creates `/etc/sudoers.d/open-bastion` to grant
-sudo rights to authorized users without relying on local Unix group membership.
+`ob-bastion-setup --max-security` creates `/etc/sudoers.d/open-bastion` with
+`%open-bastion-sudo ALL=(ALL) ALL` and a system group `open-bastion-sudo`.
+The PAM module dynamically manages group membership during SSH session setup
+based on the `sudo_allowed` flag from the SSO portal. This provides
+**defense in depth**: even if the PAM module fails during sudo authentication,
+users without group membership are blocked by sudoers before PAM is invoked.
 
 ### Security Model
 

--- a/doc/security/02-ssh-connection.md
+++ b/doc/security/02-ssh-connection.md
@@ -142,7 +142,7 @@ auth       required     pam_openbastion.so   service=sudo
 account    required     pam_openbastion.so   service=sudo
 ```
 
-> **Note Mode E :** La ligne `account required pam_unix.so` est **absente** du stack sudo. `pam_unix.so` est incompatible avec les utilisateurs NSS-only (résolution dynamique via `openbastion` dans `nsswitch.conf`) : il échouerait pour tout utilisateur n'ayant pas d'entrée dans `/etc/passwd`. L'autorisation est entièrement déléguée à `pam_openbastion.so`. Le fichier `/etc/sudoers.d/open-bastion` autorise tous les utilisateurs (`ALL ALL=(ALL) ALL`) — le filtrage est effectué par PAM.
+> **Note Mode E :** La ligne `account required pam_unix.so` est **absente** du stack sudo. `pam_unix.so` est incompatible avec les utilisateurs NSS-only (résolution dynamique via `openbastion` dans `nsswitch.conf`) : il échouerait pour tout utilisateur n'ayant pas d'entrée dans `/etc/passwd`. L'autorisation repose sur une approche **defense-in-depth** : le fichier `/etc/sudoers.d/open-bastion` n'autorise que les membres du groupe `open-bastion-sudo` (`%open-bastion-sudo ALL=(ALL) ALL`), et l'appartenance à ce groupe est gérée dynamiquement par le module PAM lors de l'ouverture de session SSH (basé sur `sudo_allowed`). Ainsi, même en cas de défaillance du module PAM lors de l'authentification sudo, les utilisateurs non autorisés sont bloqués par sudoers avant l'invocation de PAM.
 
 ### Configuration Open Bastion (backends)
 

--- a/docker-demo-maxsec/bastion/Dockerfile
+++ b/docker-demo-maxsec/bastion/Dockerfile
@@ -79,8 +79,9 @@ account    required     pam_unix.so\n\
 session    required     pam_unix.so\n\
 ' > /etc/pam.d/sudo
 
-# sudo requires PAM authentication (NO NOPASSWD - this is Mode E)
-RUN echo "ALL ALL=(ALL:ALL) ALL" >> /etc/sudoers
+# Defense-in-depth: only open-bastion-sudo group members can sudo (PAM also required)
+RUN groupadd --system open-bastion-sudo 2>/dev/null || true \
+    && echo "%open-bastion-sudo ALL=(ALL:ALL) ALL" >> /etc/sudoers
 
 # Fix PAM loginuid for Docker
 RUN sed -i 's/session\s*required\s*pam_loginuid.so/session optional pam_loginuid.so/' /etc/pam.d/sshd 2>/dev/null || true

--- a/rpm/open-bastion.spec
+++ b/rpm/open-bastion.spec
@@ -118,6 +118,8 @@ ctest --output-on-failure --verbose
 %pre
 # Create ob-sessions group for session recording privilege separation
 getent group ob-sessions >/dev/null 2>&1 || groupadd --system ob-sessions
+# Create open-bastion-sudo group for defense-in-depth sudo authorization (Mode E)
+getent group open-bastion-sudo >/dev/null 2>&1 || groupadd --system open-bastion-sudo
 
 %post
 %systemd_post ob-heartbeat.timer

--- a/scripts/ob-bastion-setup
+++ b/scripts/ob-bastion-setup
@@ -473,6 +473,8 @@ session    required     pam_unix.so
     if [ "$DRY_RUN" = "true" ]; then
         info "[DRY-RUN] Would configure PAM sudo for LLNG token auth"
         echo "$pam_content"
+        info "[DRY-RUN] Would create group open-bastion-sudo"
+        info "[DRY-RUN] Would create /etc/sudoers.d/open-bastion with: %open-bastion-sudo ALL=(ALL) ALL"
         return 0
     fi
 
@@ -481,11 +483,15 @@ session    required     pam_unix.so
     chmod 644 "$PAM_SUDO"
     info "Configured $PAM_SUDO for LLNG token authentication"
 
-    # Configure sudoers: allow all SSO users to sudo (PAM handles authorization)
+    # Create open-bastion-sudo group for defense-in-depth sudo authorization
+    groupadd --system open-bastion-sudo 2>/dev/null || true
+
+    # Configure sudoers: only open-bastion-sudo group members can sudo (PAM also required)
     local sudoers_file="/etc/sudoers.d/open-bastion"
     if [ ! -f "$sudoers_file" ]; then
-        echo "# Open Bastion Mode E: sudo authorization is handled by PAM (LLNG token required)" > "$sudoers_file"
-        echo "ALL ALL=(ALL) ALL" >> "$sudoers_file"
+        echo "# Open Bastion Mode E: defense-in-depth sudo authorization" > "$sudoers_file"
+        echo "# Both group membership (managed by PAM session) AND LLNG token are required" >> "$sudoers_file"
+        echo "%open-bastion-sudo ALL=(ALL) ALL" >> "$sudoers_file"
         chmod 440 "$sudoers_file"
         info "Created $sudoers_file"
     fi

--- a/src/pam_openbastion.c
+++ b/src/pam_openbastion.c
@@ -102,6 +102,9 @@ typedef struct {
 /* How often to re-verify token file permissions (in seconds) */
 #define TOKEN_RECHECK_INTERVAL 300  /* 5 minutes */
 
+/* Defense-in-depth: group required by sudoers for sudo access */
+#define OB_SUDO_GROUP "open-bastion-sudo"
+
 /* Logging macros - prefixed to avoid conflict with syslog constants */
 #define OB_LOG_ERR(handle, fmt, ...) \
     pam_syslog(handle, LOG_ERR, fmt, ##__VA_ARGS__)
@@ -3723,6 +3726,41 @@ PAM_VISIBLE PAM_EXTERN int pam_sm_open_session(pam_handle_t *pamh,
         }
 
         free_filtered_groups(filtered_managed, filtered_count);
+    }
+
+    /*
+     * Defense-in-depth: sync open-bastion-sudo group membership.
+     * The sudoers rule requires membership in this group, AND the PAM
+     * auth/account stack independently verifies sudo_allowed via LLNG.
+     * Both conditions must be met for sudo to succeed.
+     *
+     * On each SSH login:
+     *  - sudo_allowed=true  → add user to open-bastion-sudo
+     *  - sudo_allowed=false → remove user from open-bastion-sudo
+     */
+    const char *sudo_env = pam_getenv(pamh, "LLNG_SUDO_ALLOWED");
+    int sudo_allowed = (sudo_env && strcmp(sudo_env, "1") == 0);
+
+    if (sudo_allowed) {
+        /* Ensure group exists (idempotent) */
+        if (!group_exists_by_name(OB_SUDO_GROUP)) {
+            OB_LOG_DEBUG(pamh, "Group %s does not exist, skipping sudo group sync", OB_SUDO_GROUP);
+        } else if (!user_in_group_locally(user, OB_SUDO_GROUP)) {
+            OB_LOG_INFO(pamh, "Adding user %s to %s (sudo allowed)", user, OB_SUDO_GROUP);
+            if (add_user_to_group(pamh, user, OB_SUDO_GROUP) < 0) {
+                OB_LOG_WARN(pamh, "Failed to add user %s to %s", user, OB_SUDO_GROUP);
+            }
+        }
+    } else {
+        /* Remove from sudo group if present (permission revoked) */
+        if (group_exists_by_name(OB_SUDO_GROUP) &&
+            user_in_group_locally(user, OB_SUDO_GROUP)) {
+            OB_LOG_INFO(pamh, "Removing user %s from %s (sudo no longer allowed)",
+                        user, OB_SUDO_GROUP);
+            if (remove_user_from_group(pamh, user, OB_SUDO_GROUP) < 0) {
+                OB_LOG_WARN(pamh, "Failed to remove user %s from %s", user, OB_SUDO_GROUP);
+            }
+        }
     }
 
     return PAM_SUCCESS;


### PR DESCRIPTION
## Summary

- Replace overly broad sudoers rule `ALL ALL=(ALL) ALL` with `%open-bastion-sudo ALL=(ALL) ALL`
- PAM module dynamically manages group membership during SSH session setup:
  - `sudo_allowed=true` → user added to `open-bastion-sudo`
  - `sudo_allowed=false` → user removed from `open-bastion-sudo`
- Group created (empty) at install time by postinst/RPM spec and setup scripts

## Security Impact

**Without this fix:** If `pam_openbastion.so` crashes or fails open during sudo, any user gets root — the entire sudo security boundary rests on a single component.

**With this fix:** Two independent conditions must be met for sudo:
1. User must be in `open-bastion-sudo` group (managed by PAM session on SSH login)
2. PAM must validate the LLNG token (checked on each `sudo` invocation)

Even if one layer fails, the other blocks unauthorized access.

**Note:** Between SSH logins, if sudo permission is revoked in LLNG, group membership persists until next SSH login. However, the PAM `auth`+`account` stack for sudo independently re-verifies the token on every `sudo` invocation, so the group alone is insufficient.

## Changes

| File | Change |
|------|--------|
| `src/pam_openbastion.c` | Add sudo group sync in `pam_sm_open_session` |
| `scripts/ob-bastion-setup` | `groupadd open-bastion-sudo` + new sudoers rule |
| `debian/postinst` | Create group at install |
| `rpm/open-bastion.spec` | Create group at install |
| `docker-demo-maxsec/bastion/Dockerfile` | Updated sudoers |
| `doc/pam-modes.md` | Document defense-in-depth approach |

## Test plan

- [ ] Fresh install: verify `open-bastion-sudo` group is created empty
- [ ] SSH login with `sudo_allowed=true`: user added to group, `sudo` works
- [ ] SSH login with `sudo_allowed=false`: user NOT in group, `sudo` blocked by sudoers
- [ ] Revoke sudo in LLNG, re-login: user removed from group
- [ ] PAM module absent/broken: `sudo` fails (user not in group OR PAM fails)
- [ ] Existing installs: verify upgrade path (group created, sudoers updated)