### PR TITLE
pam-access: forward SSH key fingerprint on /pam/authorize and /pam/verify

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.10)
-project(open-bastion VERSION 0.1.4 LANGUAGES C)
+project(open-bastion VERSION 0.1.5 LANGUAGES C)
 
 set(CMAKE_C_STANDARD 11)
 set(CMAKE_C_STANDARD_REQUIRED ON)

--- a/doc/bastion-architecture.md
+++ b/doc/bastion-architecture.md
@@ -322,6 +322,18 @@ flowchart TB
 - **Single-use**: Tokens invalidated after successful use
 - **IP binding**: Optional token-to-IP binding
 - **Rate limiting**: Exponential backoff on failures
+- **SSH key binding**: When the SSH session is authenticated with a
+  CA-signed certificate, the PAM module extracts the SHA256 fingerprint
+  of the user's SSH key from `SSH_USER_AUTH` and forwards it to LLNG in
+  **both** `/pam/authorize` (PAM `account` phase, at every SSH
+  connection) and `/pam/verify` (token verification, used for sudo and
+  re-authentication). LLNG checks that the fingerprint is present in
+  the user's persistent session (`_sshCerts`), is not revoked and is
+  not expired. If the check fails, LLNG refuses authorization (so the
+  SSH session cannot open) and rejects token verification (so sudo
+  cannot elevate). This binds both the SSH session and the PAM token
+  to the specific SSH certificate registered in LLNG, even when the
+  local `sshd` KRL is stale or not enforced.
 
 ### Server Token Security
 

--- a/doc/pam-modes.md
+++ b/doc/pam-modes.md
@@ -232,12 +232,40 @@ curl -o /etc/ssh/revoked_keys https://auth.example.com/ssh/revoked
 
 ### SSH fingerprint binding on `/pam/authorize` and `/pam/verify`
 
-From plugin PamAccess 0.1.16 onwards, `pam_openbastion` extracts the
-SHA256 fingerprint of the SSH key used to open the session (parsed
-from `SSH_USER_AUTH`, which requires `ExposeAuthInfo yes`) and sends
-it in **both** the `/pam/authorize` request issued at every SSH
-connection (PAM `account` phase) and the `/pam/verify` request issued
-on every LLNG-token operation (sudo, re-authentication).
+From plugin PamAccess 0.1.16 onwards, `pam_openbastion` forwards the
+SHA256 fingerprint of the SSH key used to open the session in **both**
+the `/pam/authorize` request issued at every SSH connection (PAM
+`account` phase) and the `/pam/verify` request issued on every
+LLNG-token operation (sudo, re-authentication).
+
+#### How the fingerprint is captured
+
+Modern OpenSSH (≥ 9.x) does **not** propagate the authentication info
+to the PAM environment during `pam_acct_mgmt` — `ExposeAuthInfo yes`
+is not sufficient on its own. The bastion therefore uses an explicit
+out-of-band channel:
+
+1. sshd invokes `AuthorizedPrincipalsCommand /usr/local/sbin/ob-ssh-principals %u %f`
+   (deployed by `ob-bastion-setup` / `ob-backend-setup`). The `%f`
+   token is the SHA256 fingerprint of the client key or certificate
+   (not `%F`, which is the CA key's fingerprint).
+2. The helper writes the fingerprint to
+   `/run/open-bastion/ssh-fp/<sshd-session-pid>.fp` (atomic `mktemp` +
+   `mv`). The spool directory is owned by the
+   `AuthorizedPrincipalsCommandUser` (typically `nobody`) with mode
+   `0700`, so no other unprivileged user can pre-create or substitute
+   a drop file.
+3. `pam_openbastion` walks `/proc/<pid>/status` from its own PID up to
+   the `sshd-session` ancestor, reads the corresponding spool file,
+   validates it (regular file owned by the spool-dir owner, mode
+   `0600`, `nlink == 1`, strict `SHA256:<base64>` format, ≤ 512 B),
+   and forwards the fingerprint to LLNG.
+
+As a fallback, if a custom sshd variant does populate
+`SSH_USER_AUTH` with the content (`publickey <algo> SHA256:<fp>`), the
+module will parse it from there instead.
+
+#### Security properties
 
 LLNG rejects the call unless it finds a matching, non-revoked and
 non-expired SSH CA record in the user's persistent session
@@ -256,10 +284,19 @@ local `sshd` KRL check:
   the request would not match any `_sshCerts` entry of the token's
   `sub` user.
 
-No configuration change is required on the bastion side — as long as
-`ExposeAuthInfo yes` is set (already required for session auditing),
-the fingerprint is picked up automatically. The `fingerprint` field is
-optional on the LLNG side, so older portals remain compatible.
+#### Operational requirements
+
+- `ob-bastion-setup` / `ob-backend-setup` install
+  `/usr/local/sbin/ob-ssh-principals`, wire it as
+  `AuthorizedPrincipalsCommand`, and prepare the spool directory +
+  `/etc/tmpfiles.d/open-bastion-ssh-fp.conf` drop-in so that `/run`
+  gets the directory recreated at boot.
+- `ExposeAuthInfo yes` is **not** required for the fingerprint
+  binding itself (the helper + spool are self-sufficient); it remains
+  useful for session auditing.
+- The `fingerprint` field is optional on the LLNG side, so bastions
+  running on older portals that lack PamAccess 0.1.16 remain fully
+  compatible — the portal simply ignores it.
 
 ## Summary Table
 

--- a/doc/pam-modes.md
+++ b/doc/pam-modes.md
@@ -230,6 +230,37 @@ curl -o /etc/ssh/revoked_keys https://auth.example.com/ssh/revoked
 */30 * * * * root curl -sf -o /etc/ssh/revoked_keys.tmp https://auth.example.com/ssh/revoked && mv /etc/ssh/revoked_keys.tmp /etc/ssh/revoked_keys
 ```
 
+### SSH fingerprint binding on `/pam/authorize` and `/pam/verify`
+
+From plugin PamAccess 0.1.16 onwards, `pam_openbastion` extracts the
+SHA256 fingerprint of the SSH key used to open the session (parsed
+from `SSH_USER_AUTH`, which requires `ExposeAuthInfo yes`) and sends
+it in **both** the `/pam/authorize` request issued at every SSH
+connection (PAM `account` phase) and the `/pam/verify` request issued
+on every LLNG-token operation (sudo, re-authentication).
+
+LLNG rejects the call unless it finds a matching, non-revoked and
+non-expired SSH CA record in the user's persistent session
+(`_sshCerts`). This provides a second line of defense on top of the
+local `sshd` KRL check:
+
+- **Session opening**: even if the bastion's `/etc/ssh/revoked_keys`
+  is stale or `RevokedKeys` is missing from `sshd_config`, a newly
+  revoked certificate is rejected at `/pam/authorize` (`account`
+  phase), and the SSH session is refused before the shell is spawned.
+- **Privilege escalation**: the same check runs on `/pam/verify`, so
+  a compromised or revoked certificate cannot be used to obtain
+  privileges via sudo from an already-established session either.
+- **Token binding**: a stolen LLNG token cannot be replayed from a
+  machine holding a different SSH key — the fingerprint presented in
+  the request would not match any `_sshCerts` entry of the token's
+  `sub` user.
+
+No configuration change is required on the bastion side — as long as
+`ExposeAuthInfo yes` is set (already required for session auditing),
+the fingerprint is picked up automatically. The `fingerprint` field is
+optional on the LLNG side, so older portals remain compatible.
+
 ## Summary Table
 
 | Mode             | Unix Password | LLNG Token | SSH Key    | LLNG Authorization |

--- a/doc/security/02-ssh-connection.md
+++ b/doc/security/02-ssh-connection.md
@@ -256,6 +256,52 @@ curl -sf -o /etc/ssh/revoked_keys https://auth.example.com/ssh/revoked
 # → Fenêtre d'exposition maximale : 30 min
 ```
 
+### Binding fingerprint SSH sur `/pam/authorize` et `/pam/verify` (défense en profondeur)
+
+Depuis le plugin PamAccess ≥ 0.1.16, le module PAM `pam_openbastion` extrait l'empreinte SHA256 de la clef SSH utilisée pour la connexion (variable `SSH_USER_AUTH`, nécessite `ExposeAuthInfo yes`) et la transmet à LLNG dans le corps des requêtes `POST /pam/authorize` (phase `account`, à chaque connexion SSH) **et** `POST /pam/verify` (vérification d'un token PAM à usage unique pour sudo/ré-auth). Exemples :
+
+```json
+// POST /pam/authorize — ouverture de session SSH
+{
+  "user": "dwho",
+  "host": "backend-01",
+  "service": "sshd",
+  "server_group": "production",
+  "ssh_cert": { "key_id": "...", "serial": "...", ... },
+  "fingerprint": "SHA256:<base64>"
+}
+
+// POST /pam/verify — sudo / ré-authentification par token
+{
+  "token": "<token PAM à usage unique>",
+  "fingerprint": "SHA256:<base64>"
+}
+```
+
+LLNG effectue dans les **deux** handlers la même vérification croisée contre la **session persistante** de l'utilisateur (`_sshCerts`) :
+
+1. Le champ `fingerprint` doit respecter le format strict `SHA256:<base64>` (sinon `HTTP 400`, audit `PAM_AUTH[Z]_SSH_FP_MALFORMED`).
+2. L'empreinte doit être présente dans la liste des certificats émis par le plugin SSHCA pour cet utilisateur.
+3. Le certificat correspondant ne doit pas porter de marqueur `revoked_at`.
+4. Le certificat ne doit pas être expiré (`expires_at`).
+
+Si l'une des conditions 2-4 n'est pas remplie :
+
+- sur `/pam/authorize`, LLNG répond `{"authorized": false, "reason": "SSH fingerprint not recognized"}` (audit `PAM_AUTHZ_SSH_FP_REJECTED`) — **la connexion SSH est refusée au niveau PAM account**, même si `sshd` a accepté le certificat.
+- sur `/pam/verify`, LLNG répond `{"valid": false, "error": "SSH fingerprint not recognized"}` et le token PAM est consommé (audit `PAM_AUTH_SSH_FP_REJECTED`) — l'escalade sudo est bloquée.
+
+**Niveaux de défense apportés :**
+
+| Contrôle                                  | Où ?     | Couvre                                                                                                                                                |
+| ----------------------------------------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `RevokedKeys` (KRL locale)                | `sshd`   | Authentification SSH avec certificat révoqué (mécanisme principal, toujours requis)                                                                   |
+| **Binding fingerprint `/pam/authorize`**  | **LLNG** | **Ouverture de session SSH avec un certificat inconnu, révoqué ou expiré côté LLNG, même si `sshd` l'a accepté (KRL stale ou `RevokedKeys` oubliée)** |
+| `/pam/authorize` (autorisation classique) | LLNG     | Utilisateur désactivé ou sans droit sur le `server_group`                                                                                             |
+| **Binding fingerprint `/pam/verify`**     | **LLNG** | **sudo / ré-authentification par token : rejet si le cert de la session SSH est inconnu, révoqué ou expiré côté LLNG**                                |
+| **Présence dans la session persistante**  | **LLNG** | **Token volé à un utilisateur et rejoué depuis une autre clef SSH : l'empreinte ne correspond à aucun cert du `sub` du token**                        |
+
+Cette couche est activée automatiquement côté bastion dès que `ExposeAuthInfo yes` est configuré (déjà requis pour l'audit des sessions) ; côté LLNG, l'ancien comportement est préservé si le client n'envoie pas le champ `fingerprint` (rétrocompatibilité).
+
 ---
 
 ## 3. Analyse des Risques
@@ -290,13 +336,15 @@ curl -sf -o /etc/ssh/revoked_keys https://auth.example.com/ssh/revoked
 
 - Révocation immédiate via LLNG `/ssh/admin` → KRL propagée en 30 min
 - Le serial permet d'identifier précisément le certificat compromis
-- **Même avec un certificat compromis, l'attaquant ne peut pas faire de sudo** sans obtenir un token LLNG frais, ce qui nécessite une authentification SSO
+- **Binding fingerprint sur `/pam/authorize` (plugin PamAccess ≥ 0.1.16) :** à chaque connexion SSH, `pam_openbastion` envoie l'empreinte SHA256 de la clef utilisée, extraite de `SSH_USER_AUTH`. LLNG refuse l'autorisation (donc l'ouverture de la session SSH, via la phase `account` de PAM) si l'empreinte n'est pas présente dans la session persistante de l'utilisateur (`_sshCerts`), ou si le certificat correspondant est révoqué ou expiré côté LLNG. Ce filet de défense en profondeur bloque la session même si un certificat révoqué a franchi `sshd` à cause d'une KRL obsolète ou manquante.
+- **Binding fingerprint sur `/pam/verify` :** la même vérification est effectuée lors de toute utilisation d'un token PAM (sudo, ré-authentification), fermant l'escalade privilège dans la même logique.
 
 **Remédiation embarquée :**
 
-- PAM LLNG envoie le serial à LLNG pour vérification d'autorisation à chaque connexion
-- KRL vérifiée par sshd avant PAM (rejet immédiat si révoqué)
-- Audit complet avec key_id et serial
+- KRL vérifiée par `sshd` avant PAM (rejet immédiat si révoqué, mécanisme principal)
+- `/pam/authorize` refuse l'ouverture de session si la clef n'est pas active/non-révoquée/non-expirée côté LLNG (filet de secours vs KRL stale)
+- `/pam/verify` applique le même contrôle au moment du token (sudo, ré-auth)
+- Audit complet avec `key_id`, `serial`, et codes `PAM_AUTHZ_SSH_FP_REJECTED` / `PAM_AUTH_SSH_FP_REJECTED`
 
 **Remédiation configuration :**
 
@@ -309,10 +357,10 @@ ssh-keygen -t ed25519 -a 100 -f ~/.ssh/id_ed25519
 ssh-add -t 8h ~/.ssh/id_ed25519
 ```
 
-|                 |                   Score résiduel                    |
-| --------------- | :-------------------------------------------------: |
-| **Probabilité** |       2 (compromission poste client possible)       |
-| **Impact**      | 2 (avec KRL + sudo impossible sans token SSO frais) |
+|                 |                                        Score résiduel                                         |
+| --------------- | :-------------------------------------------------------------------------------------------: |
+| **Probabilité** |                            2 (compromission poste client possible)                            |
+| **Impact**      | 1 (KRL + binding fingerprint LLNG sur `/pam/authorize` et `/pam/verify` bloquent SSH et sudo) |
 
 ---
 
@@ -900,8 +948,23 @@ crowdsec_block_delay = 600  # 10 minutes au lieu de 3
 - Cron de rafraîchissement KRL en panne ou mal configuré
 - Serveur LLNG indisponible empêchant le téléchargement KRL
 - Délai entre la révocation et la propagation (jusqu'à 30 min)
+- Serveur SSH dont la directive `RevokedKeys` a été oubliée ou supprimée par inadvertance
 
-**Facteur atténuant :** `/pam/authorize` vérifie toujours l'autorisation LLNG à chaque connexion. Si le compte est désactivé dans LLNG, l'accès est refusé même avec un certificat non révoqué dans la KRL locale.
+> **Note d'architecture :** en fonctionnement nominal, un certificat révoqué ne doit **pas** permettre d'établir une connexion SSH — la KRL locale contrôlée par `sshd` reste le mécanisme principal de rejet, et son absence de mise à jour constitue déjà une alerte opérationnelle. Les facteurs atténuants ci-dessous ne remplacent pas la KRL ; ils constituent des couches de défense en profondeur pour le cas pathologique où un certificat révoqué franchirait malgré tout `sshd` (KRL absente, corrompue, ou significativement plus vieille que la fenêtre de révocation).
+
+**Facteurs atténuants :**
+
+1. **Binding fingerprint sur `/pam/authorize` (plugin PamAccess ≥ 0.1.16) :** à la phase `account` de PAM (donc à l'ouverture de chaque connexion SSH), `pam_openbastion` transmet l'empreinte SHA256 de la clef SSH utilisée. LLNG refuse l'autorisation (et donc l'ouverture de la session) si :
+   - l'empreinte n'apparaît pas dans la session persistante (`_sshCerts`) de l'utilisateur (clef inconnue de LLNG), **ou**
+   - le certificat correspondant est marqué `revoked_at` (révocation côté LLNG), **ou**
+   - le certificat est expiré.
+
+   Cette vérification est **indépendante** de la KRL locale : une révocation enregistrée dans LLNG est immédiatement effective sur toutes les connexions SSH, sans attendre la propagation de la KRL et indépendamment du fait que `sshd` la contrôle ou non.
+
+2. **Binding fingerprint sur `/pam/verify` :** la même vérification est effectuée sur les tokens PAM (sudo, ré-auth), de sorte qu'aucun privilège ne peut être acquis depuis une session ouverte avec un certificat devenu invalide entre temps.
+3. Contrôles d'autorisation classiques : `/pam/authorize` refuse aussi l'accès si le compte LLNG est désactivé ou ne vérifie pas la règle du `server_group`.
+
+**Conséquence pour la cible maximale :** dès la publication de la révocation côté LLNG, toute nouvelle connexion SSH utilisant le certificat révoqué est refusée au niveau PAM `account` (phase de vérification de l'autorisation). La KRL reste le contrôle principal, mais un oubli, un retard de propagation ou une absence de `RevokedKeys` dans `sshd_config` n'ouvrent plus de fenêtre d'exploitation : LLNG rejette de toute façon la session.
 
 **Remédiation :**
 
@@ -914,10 +977,10 @@ crowdsec_block_delay = 600  # 10 minutes au lieu de 3
 */15 * * * * root find /etc/ssh/revoked_keys -mmin +60 -exec echo "KRL stale" \;
 ```
 
-|                 |                    Score résiduel                     |
-| --------------- | :---------------------------------------------------: |
-| **Probabilité** | 1 (avec cron + monitoring + /pam/authorize en backup) |
-| **Impact**      |          2 (sudo toujours bloqué sans token)          |
+|                 |                                       Score résiduel                                        |
+| --------------- | :-----------------------------------------------------------------------------------------: |
+| **Probabilité** |  1 (cron KRL + binding fingerprint `/pam/authorize` + `/pam/verify` comme triple défense)   |
+| **Impact**      | 1 (ouverture SSH et sudo bloqués au niveau LLNG même avec KRL absente ou périmée côté sshd) |
 
 ---
 
@@ -1056,7 +1119,7 @@ Le session recorder utilise un wrapper C setgid (`ob-session-recorder-wrapper`) 
 
 1. Le binaire wrapper est installé en mode `2755 root:ob-sessions` (bit setgid)
 2. Le wrapper utilise son gid effectif `ob-sessions` **uniquement** pour créer le sous-répertoire utilisateur en mode `2770 user:ob-sessions` (bit setgid sur le répertoire)
-3. Le wrapper drop explicitement le gid élevé via `setregid(orig_gid, orig_gid)` avant l'exec. `exec` ne supprime **pas** un gid effectif/sauvé déjà acquis (seuls les bits setgid du *fichier* exécuté sont ignorés). Le drop explicite garantit que le script et le shell tournent avec le gid original de l'utilisateur
+3. Le wrapper drop explicitement le gid élevé via `setregid(orig_gid, orig_gid)` avant l'exec. `exec` ne supprime **pas** un gid effectif/sauvé déjà acquis (seuls les bits setgid du _fichier_ exécuté sont ignorés). Le drop explicite garantit que le script et le shell tournent avec le gid original de l'utilisateur
 4. Le répertoire `/var/lib/open-bastion/sessions` a les permissions `1770 root:ob-sessions` :
    - `1` (sticky bit) : seul le propriétaire du répertoire (root) peut supprimer les fichiers
    - `770` : seuls root et le groupe `ob-sessions` peuvent accéder au répertoire
@@ -1091,20 +1154,20 @@ Le session recorder enregistre les événements de début/fin de session dans sy
 
 ### Après remédiation complète
 
-| Impact ↓ / Probabilité → | 1 - Très improbable                                            | 2 - Peu probable | 3 - Probable | 4 - Très probable |
-| ------------------------ | -------------------------------------------------------------- | ---------------- | ------------ | ----------------- |
-| **4 - Critique**         | R-S4                                                           |                  |              |                   |
-| **3 - Important**        | R-S5                                                           | R-S6             |              |                   |
-| **2 - Limité**           | R-S3 R-S7 R-S9 R-S10 R-S11 R-S12 R-S13 R-S14 R-S15 R-S16 R-S17 | R-S8             |              |                   |
-| **1 - Négligeable**      | R-S18                                                          |                  |              |                   |
-| **1 - Négligeable**      |                                                                |                  |              |                   |
+| Impact ↓ / Probabilité → | 1 - Très improbable                                 | 2 - Peu probable | 3 - Probable | 4 - Très probable |
+| ------------------------ | --------------------------------------------------- | ---------------- | ------------ | ----------------- |
+| **4 - Critique**         | R-S4                                                |                  |              |                   |
+| **3 - Important**        | R-S5                                                | R-S6             |              |                   |
+| **2 - Limité**           | R-S7 R-S9 R-S10 R-S11 R-S12 R-S13 R-S14 R-S16 R-S17 | R-S8             |              |                   |
+| **1 - Négligeable**      | R-S15 R-S18                                         | R-S3             |              |                   |
 
 **Profil de risque de la cible maximale :**
 
 - R-S1 (brute-force mot de passe) : **ÉLIMINÉ** (pas de mot de passe SSH)
 - R-S2 (vol clé SSH sans certificat) : **ÉLIMINÉ** (AuthorizedKeysFile none)
-- R-S3 (certificat compromis) : **contrôlé par KRL** + sudo bloqué sans token SSO
+- R-S3 (certificat compromis) : **contrôlé par KRL** (mécanisme principal) + **binding fingerprint LLNG sur `/pam/authorize` et `/pam/verify`** qui bloque aussi bien l'ouverture SSH que l'escalade sudo dès que la révocation est publiée côté LLNG, même si la KRL locale n'est pas encore à jour
 - R-S5 (contournement bastion) : **P=1** (certificat CA requis + JWT bastion)
+- R-S15 (KRL stale) : **I=1** grâce au binding fingerprint sur `/pam/authorize` : une révocation LLNG interdit l'ouverture d'une session SSH à chaque nouvelle connexion, indépendamment de la fraîcheur de la KRL
 - R-S16 (escalade sudo) : **contrôlé par réauthentification SSO obligatoire**
 - R-S17 (lockout) : **contrôlé par compte de service secours** + procédure console documentée
 - R-S18 (effacement sessions) : **contrôlé par wrapper setgid** + sticky bit + syslog indépendant

--- a/doc/security/02-ssh-connection.md
+++ b/doc/security/02-ssh-connection.md
@@ -258,7 +258,15 @@ curl -sf -o /etc/ssh/revoked_keys https://auth.example.com/ssh/revoked
 
 ### Binding fingerprint SSH sur `/pam/authorize` et `/pam/verify` (défense en profondeur)
 
-Depuis le plugin PamAccess ≥ 0.1.16, le module PAM `pam_openbastion` extrait l'empreinte SHA256 de la clef SSH utilisée pour la connexion (variable `SSH_USER_AUTH`, nécessite `ExposeAuthInfo yes`) et la transmet à LLNG dans le corps des requêtes `POST /pam/authorize` (phase `account`, à chaque connexion SSH) **et** `POST /pam/verify` (vérification d'un token PAM à usage unique pour sudo/ré-auth). Exemples :
+Depuis le plugin PamAccess ≥ 0.1.16, le module PAM `pam_openbastion` transmet à LLNG l'empreinte SHA256 de la clef SSH utilisée pour la connexion, dans le corps des requêtes `POST /pam/authorize` (phase `account`, à chaque connexion SSH) **et** `POST /pam/verify` (vérification d'un token PAM à usage unique pour sudo/ré-auth).
+
+**Récupération de l'empreinte côté bastion.** OpenSSH moderne (≥ 9.x) ne propage pas `SSH_USER_AUTH` à l'environnement PAM pendant `pam_acct_mgmt` — `ExposeAuthInfo yes` ne suffit donc pas. Le bastion utilise un canal explicite :
+
+1. `sshd` appelle `AuthorizedPrincipalsCommand /usr/local/sbin/ob-ssh-principals %u %f` (déployé par `ob-bastion-setup` / `ob-backend-setup`). Le token `%f` est l'empreinte de la clef/du certificat client (pas `%F` qui désigne l'empreinte de la CA).
+2. Le helper écrit l'empreinte dans `/run/open-bastion/ssh-fp/<sshd-session-pid>.fp` de façon atomique (`mktemp` + `mv`). Le répertoire est la propriété de l'utilisateur `AuthorizedPrincipalsCommandUser` (typiquement `nobody`), en mode `0700` : aucun autre utilisateur local ne peut créer ou pré-positionner un fichier factice.
+3. `pam_openbastion` remonte `/proc/<pid>/status` depuis son propre PID jusqu'à l'ancêtre `sshd-session` et lit le fichier spool. Il valide strictement : fichier régulier appartenant à l'owner du répertoire, mode `0600`, `nlink == 1`, format `SHA256:<base64>`, taille ≤ 512 octets.
+
+En repli, si un `sshd` patché peuple réellement `SSH_USER_AUTH` avec le contenu, le module extrait l'empreinte depuis cette variable. Exemples de corps de requête envoyés :
 
 ```json
 // POST /pam/authorize — ouverture de session SSH
@@ -300,7 +308,7 @@ Si l'une des conditions 2-4 n'est pas remplie :
 | **Binding fingerprint `/pam/verify`**     | **LLNG** | **sudo / ré-authentification par token : rejet si le cert de la session SSH est inconnu, révoqué ou expiré côté LLNG**                                |
 | **Présence dans la session persistante**  | **LLNG** | **Token volé à un utilisateur et rejoué depuis une autre clef SSH : l'empreinte ne correspond à aucun cert du `sub` du token**                        |
 
-Cette couche est activée automatiquement côté bastion dès que `ExposeAuthInfo yes` est configuré (déjà requis pour l'audit des sessions) ; côté LLNG, l'ancien comportement est préservé si le client n'envoie pas le champ `fingerprint` (rétrocompatibilité).
+`ob-bastion-setup` et `ob-backend-setup` déploient automatiquement `ob-ssh-principals` + le répertoire spool (mode `0700`, propriétaire `nobody`) + un drop-in `/etc/tmpfiles.d/` pour recréation au boot. Côté LLNG, le champ `fingerprint` reste optionnel : un bastion à jour contre un portail antérieur à PamAccess 0.1.16 reste compatible (le portail ignore simplement le champ).
 
 ---
 

--- a/doc/security/99-risk-reduce.md
+++ b/doc/security/99-risk-reduce.md
@@ -2,12 +2,14 @@
 
 ## Matrice des Risques Résiduels (Mode E)
 
-| Impact ↓ / Probabilité → | 1 - Très improbable                                 | 2 - Peu probable | 3 - Probable | 4 - Très probable |
-| ------------------------ | --------------------------------------------------- | ---------------- | ------------ | ----------------- |
-| **4 - Critique**         | R-S4, R-SA2                                         | R-SA1            |              |                   |
-| **3 - Important**        | R5, R-S5, R-S11                                     | R-S6             |              |                   |
-| **2 - Limité**           | R-S3, R-S7, R-S9, R-S10, R-S12, R-S15, R-S16, R-S17 | R6, R-S8         |              |                   |
-| **1 - Négligeable**      | R0, R13, R-S14, R-S18                               |                  |              |                   |
+| Impact ↓ / Probabilité → | 1 - Très improbable                    | 2 - Peu probable | 3 - Probable | 4 - Très probable |
+| ------------------------ | -------------------------------------- | ---------------- | ------------ | ----------------- |
+| **4 - Critique**         | R-S4, R-SA2                            | R-SA1            |              |                   |
+| **3 - Important**        | R5, R-S5, R-S11                        | R-S6             |              |                   |
+| **2 - Limité**           | R-S7, R-S9, R-S10, R-S12, R-S16, R-S17 | R6, R-S8         |              |                   |
+| **1 - Négligeable**      | R0, R13, R-S14, R-S15, R-S18           | R-S3             |              |                   |
+
+> **Note :** R-S3 et R-S15 ont été descendus d'un cran sur l'axe Impact grâce au **binding fingerprint SSH** introduit dans le plugin PamAccess ≥ 0.1.16. La vérification est effectuée côté LLNG à la fois sur `/pam/authorize` (à chaque ouverture de session SSH, phase PAM `account`) et sur `/pam/verify` (à chaque utilisation d'un token PAM pour sudo ou ré-authentification) : tant que l'empreinte de la clef SSH n'est pas présente, active et non révoquée dans la session persistante LLNG, ni la session SSH ni l'escalade sudo ne sont autorisées, indépendamment de la fraîcheur de la KRL locale. Voir [02-ssh-connection.md](02-ssh-connection.md) pour les détails.
 
 **Zones de risque :**
 

--- a/docker-demo-cert/bastion/entrypoint.sh
+++ b/docker-demo-cert/bastion/entrypoint.sh
@@ -44,19 +44,22 @@ if [ ! -f "$SSH_CA_FILE" ]; then
 fi
 
 # Shared directory for SSH key fingerprint pass-through to pam_openbastion.
-# See docker-demo-maxsec/bastion/entrypoint.sh for the rationale — OpenSSH
-# does not propagate SSH_USER_AUTH to the PAM account-phase environment, so
-# llng-principals drops the fingerprint in this directory keyed by
-# sshd-session PID, and pam_openbastion picks it up from there.
+# See docker-demo-maxsec/bastion/entrypoint.sh for the rationale. Directory
+# must NOT be world-writable: an unprivileged local user could otherwise
+# pre-create <pid>.fp with attacker-controlled content. Here the principals
+# command runs as root (AuthorizedPrincipalsCommandUser root) so the dir is
+# owned by root with mode 0700; pam_openbastion also verifies file
+# ownership and mode at read time.
 mkdir -p /run/open-bastion/ssh-fp
 chown root:root /run/open-bastion/ssh-fp
-chmod 1733 /run/open-bastion/ssh-fp
+chmod 0700 /run/open-bastion/ssh-fp
 
 # Create script to validate principals and create user if needed
 cat > /usr/local/bin/llng-principals << 'SCRIPT'
 #!/bin/bash
 # Called by sshd AuthorizedPrincipalsCommand.
-# Args: %u (username) %t (key type) %k (base64 key/cert) %F (SHA256 fingerprint)
+# Args: %u (username) %t (key type) %k (base64 key/cert) %f (SHA256 fingerprint
+#       of the client key or certificate — NOT %F which is the CA fingerprint)
 # - Creates the user if needed (uses LLNG /pam/userinfo).
 # - Drops the SHA256 fingerprint in /run/open-bastion/ssh-fp/<sshd-session-pid>.fp
 #   so pam_openbastion can read it and forward it to LLNG for fingerprint binding.

--- a/docker-demo-cert/bastion/entrypoint.sh
+++ b/docker-demo-cert/bastion/entrypoint.sh
@@ -43,15 +43,28 @@ if [ ! -f "$SSH_CA_FILE" ]; then
     echo "WARNING: Could not download CA key, SSH cert auth may not work"
 fi
 
+# Shared directory for SSH key fingerprint pass-through to pam_openbastion.
+# See docker-demo-maxsec/bastion/entrypoint.sh for the rationale — OpenSSH
+# does not propagate SSH_USER_AUTH to the PAM account-phase environment, so
+# llng-principals drops the fingerprint in this directory keyed by
+# sshd-session PID, and pam_openbastion picks it up from there.
+mkdir -p /run/open-bastion/ssh-fp
+chown root:root /run/open-bastion/ssh-fp
+chmod 1733 /run/open-bastion/ssh-fp
+
 # Create script to validate principals and create user if needed
 cat > /usr/local/bin/llng-principals << 'SCRIPT'
 #!/bin/bash
-# Called by sshd AuthorizedPrincipalsCommand
-# Creates user if needed, then returns allowed principals
-# Args: %u (username) %t (key type) %k (base64 key/cert)
+# Called by sshd AuthorizedPrincipalsCommand.
+# Args: %u (username) %t (key type) %k (base64 key/cert) %F (SHA256 fingerprint)
+# - Creates the user if needed (uses LLNG /pam/userinfo).
+# - Drops the SHA256 fingerprint in /run/open-bastion/ssh-fp/<sshd-session-pid>.fp
+#   so pam_openbastion can read it and forward it to LLNG for fingerprint binding.
+# - Returns the allowed principals (= the username).
 USERNAME="$1"
 KEY_TYPE="$2"
 KEY_B64="$3"
+FINGERPRINT="$4"
 
 # Create user if not exists (using LLNG PAM module's userinfo)
 if ! getent passwd "$USERNAME" >/dev/null 2>&1; then
@@ -76,6 +89,37 @@ if ! getent passwd "$USERNAME" >/dev/null 2>&1; then
     fi
 fi
 
+# Record fingerprint against our sshd-session ancestor so pam_openbastion
+# can find it in its own pam_acct_mgmt call (converges on the same PID by
+# walking /proc up to the sshd-session process).
+if [ -n "$FINGERPRINT" ] && [ -d /run/open-bastion/ssh-fp ]; then
+    case "$FINGERPRINT" in
+        SHA256:[A-Za-z0-9+/]*) : ;;
+        *) FINGERPRINT="" ;;
+    esac
+fi
+if [ -n "$FINGERPRINT" ]; then
+    pid=$PPID
+    i=0
+    while [ "$pid" -gt 1 ] && [ $i -lt 16 ]; do
+        comm=$(cat /proc/"$pid"/comm 2>/dev/null || echo "")
+        case "$comm" in
+            sshd-session|sshd) break ;;
+        esac
+        pid=$(awk '/^PPid:/ {print $2}' /proc/"$pid"/status 2>/dev/null)
+        [ -z "$pid" ] && pid=0
+        i=$((i + 1))
+    done
+    if [ "$pid" -gt 1 ]; then
+        umask 077
+        tmp=$(mktemp /run/open-bastion/ssh-fp/."$pid".XXXXXX 2>/dev/null) || tmp=""
+        if [ -n "$tmp" ]; then
+            printf '%s\n' "$FINGERPRINT" > "$tmp"
+            mv -f "$tmp" /run/open-bastion/ssh-fp/"$pid".fp
+        fi
+    fi
+fi
+
 # Return the username as allowed principal (matching what's in the cert)
 if getent passwd "$USERNAME" >/dev/null 2>&1; then
     echo "$USERNAME"
@@ -94,7 +138,10 @@ TrustedUserCAKeys $SSH_CA_FILE
 PubkeyAuthentication yes
 
 # Create users on-the-fly via principals command
-AuthorizedPrincipalsCommand /usr/local/bin/llng-principals %u %t %k
+# %f = SHA256 fingerprint of the client key/cert (%F is the CA fingerprint);
+# recorded out-of-band so pam_openbastion can forward it to LLNG for
+# fingerprint binding on /pam/authorize and /pam/verify.
+AuthorizedPrincipalsCommand /usr/local/bin/llng-principals %u %t %k %f
 AuthorizedPrincipalsCommandUser root
 
 # Disable password authentication

--- a/docker-demo-maxsec/bastion/entrypoint.sh
+++ b/docker-demo-maxsec/bastion/entrypoint.sh
@@ -76,13 +76,15 @@ cron
 # pam_openbastion can forward it to LLNG (/pam/authorize + /pam/verify
 # fingerprint binding). OpenSSH does NOT propagate SSH_USER_AUTH to the PAM
 # environment during pam_acct_mgmt, so we need this out-of-band channel.
-# Mode 1733 = sticky + -wx for group/other, 700 for owner:
-#   - root can rwx (and bypass permissions to read any file)
-#   - nobody (AuthorizedPrincipalsCommandUser) can create files it owns
-#   - others can neither list nor read other users' drops
+# Directory must be owned by the AuthorizedPrincipalsCommandUser and NOT be
+# world-writable — otherwise an unprivileged local user could pre-create
+# <pid>.fp with attacker-controlled content. Mode 0700 means only the
+# principals helper can enumerate/create drops; root still reads via
+# permission bypass. pam_openbastion additionally validates file ownership
+# and mode at read time.
 mkdir -p /run/open-bastion/ssh-fp
-chown root:root /run/open-bastion/ssh-fp
-chmod 1733 /run/open-bastion/ssh-fp
+chown nobody:nogroup /run/open-bastion/ssh-fp
+chmod 0700 /run/open-bastion/ssh-fp
 
 # Create script to validate principals and record the SSH key fingerprint.
 cat > /usr/local/bin/llng-principals << 'SCRIPT'

--- a/docker-demo-maxsec/bastion/entrypoint.sh
+++ b/docker-demo-maxsec/bastion/entrypoint.sh
@@ -72,14 +72,60 @@ chmod 644 /etc/cron.d/open-bastion-krl
 # Start cron daemon
 cron
 
-# Create script to validate principals and create user if needed
+# Shared directory where llng-principals drops the SSH key fingerprint so that
+# pam_openbastion can forward it to LLNG (/pam/authorize + /pam/verify
+# fingerprint binding). OpenSSH does NOT propagate SSH_USER_AUTH to the PAM
+# environment during pam_acct_mgmt, so we need this out-of-band channel.
+# Mode 1733 = sticky + -wx for group/other, 700 for owner:
+#   - root can rwx (and bypass permissions to read any file)
+#   - nobody (AuthorizedPrincipalsCommandUser) can create files it owns
+#   - others can neither list nor read other users' drops
+mkdir -p /run/open-bastion/ssh-fp
+chown root:root /run/open-bastion/ssh-fp
+chmod 1733 /run/open-bastion/ssh-fp
+
+# Create script to validate principals and record the SSH key fingerprint.
 cat > /usr/local/bin/llng-principals << 'SCRIPT'
 #!/bin/bash
-# Called by sshd AuthorizedPrincipalsCommand (runs as nobody)
-# Returns allowed principals for certificate authentication.
+# Called by sshd AuthorizedPrincipalsCommand (runs as nobody).
+# Args: <username> <key-type> <key-base64> <fingerprint>
+# Writes <fingerprint> to /run/open-bastion/ssh-fp/<sshd-session-pid>.fp so
+# that pam_openbastion can pick it up in pam_acct_mgmt and forward it to
+# LLNG for /pam/authorize fingerprint binding.
 # User creation is handled by pam_openbastion (create_user=true in open_session).
-# User lookup goes through NSS (libnss_openbastion), which has its own token.
 USERNAME="$1"
+FINGERPRINT="$4"
+
+# Record the fingerprint against our sshd-session ancestor PID.
+# Walk up /proc until we find the sshd-session process — pam_openbastion
+# will converge on the same ancestor from its own position.
+if [ -n "$FINGERPRINT" ] && [ -d /run/open-bastion/ssh-fp ]; then
+    case "$FINGERPRINT" in
+        SHA256:[A-Za-z0-9+/]*) : ;;
+        *) FINGERPRINT="" ;;
+    esac
+fi
+if [ -n "$FINGERPRINT" ]; then
+    pid=$PPID
+    i=0
+    while [ "$pid" -gt 1 ] && [ $i -lt 16 ]; do
+        comm=$(cat /proc/"$pid"/comm 2>/dev/null || echo "")
+        case "$comm" in
+            sshd-session|sshd) break ;;
+        esac
+        pid=$(awk '/^PPid:/ {print $2}' /proc/"$pid"/status 2>/dev/null)
+        [ -z "$pid" ] && pid=0
+        i=$((i + 1))
+    done
+    if [ "$pid" -gt 1 ]; then
+        umask 077
+        tmp=$(mktemp /run/open-bastion/ssh-fp/."$pid".XXXXXX 2>/dev/null) || tmp=""
+        if [ -n "$tmp" ]; then
+            printf '%s\n' "$FINGERPRINT" > "$tmp"
+            mv -f "$tmp" /run/open-bastion/ssh-fp/"$pid".fp
+        fi
+    fi
+fi
 
 # Check if user is known (locally or via NSS/libnss_openbastion)
 if getent passwd "$USERNAME" >/dev/null 2>&1; then
@@ -105,7 +151,10 @@ AuthorizedKeysFile none
 RevokedKeys $SSH_REVOKED_KEYS
 
 # Create users on-the-fly via principals command
-AuthorizedPrincipalsCommand /usr/local/bin/llng-principals %u %t %k
+# %f = SHA256 fingerprint of the client key/cert (%F is the CA fingerprint);
+# recorded out-of-band so pam_openbastion can forward it to LLNG for
+# fingerprint binding on /pam/authorize and /pam/verify.
+AuthorizedPrincipalsCommand /usr/local/bin/llng-principals %u %t %k %f
 AuthorizedPrincipalsCommandUser nobody
 
 # Disable password authentication

--- a/include/ob_client.h
+++ b/include/ob_client.h
@@ -32,6 +32,10 @@ typedef struct {
     char *serial;           /* Certificate serial number */
     char *principals;       /* Comma-separated principals */
     char *ca_fingerprint;   /* CA key fingerprint */
+    char *key_fingerprint;  /* SHA256 fingerprint of the user SSH key used
+                               for auth. Sent as "fingerprint" to LLNG so it
+                               can cross-check it against the user's
+                               persistent session (_sshCerts). */
     bool valid;             /* Certificate was validated */
 } ob_ssh_cert_info_t;
 
@@ -97,10 +101,19 @@ void ob_client_destroy(ob_client_t *client);
  * Verify and consume a one-time PAM user token via /pam/verify
  * The token is destroyed after successful verification (single-use).
  * Requires server_token to be set in config.
+ *
+ * If fingerprint is non-NULL and non-empty (typically the SSH SHA256
+ * fingerprint of the client key used for signed-key authentication),
+ * it is sent to the portal so LLNG can verify the key is registered,
+ * not revoked and not expired in the user's persistent session. This
+ * binds the PAM token to a specific SSH key even if the local sshd
+ * KRL is stale or not checked.
+ *
  * Returns 0 on success, -1 on error
  */
 int ob_verify_token(ob_client_t *client,
                     const char *user_token,
+                    const char *fingerprint,
                     ob_response_t *response);
 
 #ifdef ENABLE_DESKTOP_SSO  /* Desktop SSO only and never compiled inside open-bastion core */

--- a/quick-start/README.md
+++ b/quick-start/README.md
@@ -84,12 +84,12 @@ certificate authentication — the PAM module on each server still calls
 and server self-enrollment uses the `oidc-device-authorization` /
 `oidc-device-organization` plugins.
 
-| Plugin                      | Role                                               |
-| --------------------------- | -------------------------------------------------- |
+| Plugin                      | Role                                                    |
+| --------------------------- | ------------------------------------------------------- |
 | `pam-access`                | `/pam/authorize`, `/pam/userinfo`, `/pam/bastion-token` |
-| `ssh-ca`                    | SSH certificate signing (`/ssh/sign`, `/ssh/ca`)   |
-| `oidc-device-authorization` | RFC 8628 Device Authorization Grant (enrollment)   |
-| `oidc-device-organization`  | Admin approval flow for device codes               |
+| `ssh-ca`                    | SSH certificate signing (`/ssh/sign`, `/ssh/ca`)        |
+| `oidc-device-authorization` | RFC 8628 Device Authorization Grant (enrollment)        |
+| `oidc-device-organization`  | Admin approval flow for device codes                    |
 
 ### Option A — via `lemonldap-ng-store` (LLNG ≥ 2.23.0, recommended)
 
@@ -143,7 +143,7 @@ Once the plugins are installed, configure them through the LLNG Manager:
 2. **SSH CA** tab (only if you want certificate authentication) —
    enable it and generate or import a signing key.
 3. **OpenID Connect service** → enable the Device Authorization Grant on
-   the `pam-access` RP (checkbox *Allow Device Authorization*) and
+   the `pam-access` RP (checkbox _Allow Device Authorization_) and
    require PKCE.
 
 The `lmConf-1.json` shipped with this quick-start is a minimal working

--- a/rpm/open-bastion.spec
+++ b/rpm/open-bastion.spec
@@ -1,5 +1,5 @@
 Name:           open-bastion
-Version:        0.1.4
+Version:        0.1.5
 Release:        1%{?dist}
 Summary:        Open Bastion PAM/NSS module for SSH bastion authentication
 

--- a/scripts/ob-backend-setup
+++ b/scripts/ob-backend-setup
@@ -134,6 +134,80 @@ download_ca_key() {
     info "CA public key saved to $SSH_CA_FILE"
 }
 
+# Install /usr/local/sbin/ob-ssh-principals and its spool directory.
+# See ob-bastion-setup for rationale — mandatory for the /pam/authorize +
+# /pam/verify fingerprint binding introduced with PamAccess >= 0.1.16.
+install_principals_helper() {
+    step "Installing SSH principals helper..."
+
+    local script_path="/usr/local/sbin/ob-ssh-principals"
+    local spool_dir="/run/open-bastion/ssh-fp"
+    local tmpfiles_conf="/etc/tmpfiles.d/open-bastion-ssh-fp.conf"
+
+    if [ "$DRY_RUN" = "true" ]; then
+        info "[DRY-RUN] Would install $script_path and create $spool_dir"
+        return 0
+    fi
+
+    cat > "$script_path" << 'PRINCIPALS'
+#!/bin/sh
+# ob-ssh-principals — sshd AuthorizedPrincipalsCommand helper.
+# Args: <username> <fingerprint>
+# Outputs the username if known; drops the SSH key fingerprint to
+# /run/open-bastion/ssh-fp/<sshd-session-pid>.fp so pam_openbastion can
+# pick it up in pam_acct_mgmt and forward it to LLNG.
+USERNAME="$1"
+FINGERPRINT="$2"
+SPOOL_DIR="/run/open-bastion/ssh-fp"
+
+case "$FINGERPRINT" in
+    SHA256:[A-Za-z0-9+/]*) : ;;
+    *) FINGERPRINT="" ;;
+esac
+if [ -n "$FINGERPRINT" ] && [ -d "$SPOOL_DIR" ]; then
+    pid=$PPID
+    i=0
+    while [ "$pid" -gt 1 ] && [ $i -lt 16 ]; do
+        comm=$(cat /proc/"$pid"/comm 2>/dev/null || echo "")
+        case "$comm" in
+            sshd-session|sshd) break ;;
+        esac
+        pid=$(awk '/^PPid:/ {print $2}' /proc/"$pid"/status 2>/dev/null)
+        [ -z "$pid" ] && pid=0
+        i=$((i + 1))
+    done
+    if [ "$pid" -gt 1 ]; then
+        umask 077
+        tmp=$(mktemp "$SPOOL_DIR/."$pid".XXXXXX" 2>/dev/null) || tmp=""
+        if [ -n "$tmp" ]; then
+            printf '%s\n' "$FINGERPRINT" > "$tmp"
+            mv -f "$tmp" "$SPOOL_DIR/$pid.fp"
+        fi
+    fi
+fi
+
+if getent passwd "$USERNAME" >/dev/null 2>&1; then
+    echo "$USERNAME"
+fi
+PRINCIPALS
+    chmod 755 "$script_path"
+
+    mkdir -p "$spool_dir"
+    chown root:root "$spool_dir"
+    chmod 1733 "$spool_dir"
+
+    cat > "$tmpfiles_conf" << TMPFILES
+# Open Bastion SSH fingerprint spool — recreated at boot so the directory
+# survives /run wipes. See /usr/local/sbin/ob-ssh-principals.
+d /run/open-bastion          0755 root root -
+d /run/open-bastion/ssh-fp   1733 root root -
+TMPFILES
+    chmod 644 "$tmpfiles_conf"
+
+    info "SSH principals helper installed at $script_path"
+    info "SSH fingerprint spool prepared at $spool_dir"
+}
+
 # Configure sshd
 configure_sshd() {
     step "Configuring SSH server..."
@@ -145,8 +219,9 @@ configure_sshd() {
 # Trust LLNG SSH CA for certificate authentication
 TrustedUserCAKeys $SSH_CA_FILE
 
-# Accept certificate if principal matches the requested username
-AuthorizedPrincipalsCommand /bin/echo %u
+# Accept certificate if principal matches the requested username and drop the
+# SSH key fingerprint for pam_openbastion to forward to LLNG.
+AuthorizedPrincipalsCommand /usr/local/sbin/ob-ssh-principals %u %f
 AuthorizedPrincipalsCommandUser nobody
 
 # Enable public key (certificate) authentication
@@ -832,6 +907,7 @@ main() {
 
     # Run setup steps
     download_ca_key || exit 1
+    install_principals_helper || exit 1
     configure_sshd || exit 1
     configure_pam_sshd || exit 1
     configure_pam_sudo || true

--- a/scripts/ob-backend-setup
+++ b/scripts/ob-backend-setup
@@ -192,15 +192,20 @@ fi
 PRINCIPALS
     chmod 755 "$script_path"
 
+    # Spool directory: owned by AuthorizedPrincipalsCommandUser (nobody),
+    # mode 0700 — see ob-bastion-setup for rationale (a world-writable
+    # directory would expose PAM to a spoofed-fingerprint attack via
+    # sticky-bit pre-creation). pam_openbastion also enforces owner/mode
+    # checks on each drop file.
     mkdir -p "$spool_dir"
-    chown root:root "$spool_dir"
-    chmod 1733 "$spool_dir"
+    chown nobody:nogroup "$spool_dir" 2>/dev/null || chown nobody:nobody "$spool_dir"
+    chmod 0700 "$spool_dir"
 
     cat > "$tmpfiles_conf" << TMPFILES
 # Open Bastion SSH fingerprint spool — recreated at boot so the directory
 # survives /run wipes. See /usr/local/sbin/ob-ssh-principals.
-d /run/open-bastion          0755 root root -
-d /run/open-bastion/ssh-fp   1733 root root -
+d /run/open-bastion          0755 root   root   -
+d /run/open-bastion/ssh-fp   0700 nobody nogroup -
 TMPFILES
     chmod 644 "$tmpfiles_conf"
 

--- a/scripts/ob-bastion-setup
+++ b/scripts/ob-bastion-setup
@@ -134,6 +134,92 @@ download_ca_key() {
     info "CA public key saved to $SSH_CA_FILE"
 }
 
+# Install /usr/local/sbin/ob-ssh-principals and its spool directory.
+# The script is invoked by sshd as AuthorizedPrincipalsCommand (running as
+# nobody); it records the SHA256 fingerprint of the client certificate in
+# /run/open-bastion/ssh-fp/<sshd-session-pid>.fp so pam_openbastion can
+# forward it to LLNG for the /pam/authorize + /pam/verify fingerprint
+# binding (see PamAccess >= 0.1.16).
+install_principals_helper() {
+    step "Installing SSH principals helper..."
+
+    local script_path="/usr/local/sbin/ob-ssh-principals"
+    local spool_dir="/run/open-bastion/ssh-fp"
+    local tmpfiles_conf="/etc/tmpfiles.d/open-bastion-ssh-fp.conf"
+
+    if [ "$DRY_RUN" = "true" ]; then
+        info "[DRY-RUN] Would install $script_path and create $spool_dir"
+        return 0
+    fi
+
+    cat > "$script_path" << 'PRINCIPALS'
+#!/bin/sh
+# ob-ssh-principals — sshd AuthorizedPrincipalsCommand helper.
+# Args: <username> <fingerprint>
+# Outputs the username if known (to NSS/local passwd), and writes the
+# SSH key fingerprint to /run/open-bastion/ssh-fp/<sshd-session-pid>.fp
+# so pam_openbastion can pick it up during pam_acct_mgmt and forward
+# it to LLNG.
+
+USERNAME="$1"
+FINGERPRINT="$2"
+SPOOL_DIR="/run/open-bastion/ssh-fp"
+
+# Record the fingerprint keyed by our sshd-session ancestor PID
+# (pam_openbastion converges on the same ancestor by walking /proc).
+case "$FINGERPRINT" in
+    SHA256:[A-Za-z0-9+/]*) : ;;
+    *) FINGERPRINT="" ;;
+esac
+if [ -n "$FINGERPRINT" ] && [ -d "$SPOOL_DIR" ]; then
+    pid=$PPID
+    i=0
+    while [ "$pid" -gt 1 ] && [ $i -lt 16 ]; do
+        comm=$(cat /proc/"$pid"/comm 2>/dev/null || echo "")
+        case "$comm" in
+            sshd-session|sshd) break ;;
+        esac
+        pid=$(awk '/^PPid:/ {print $2}' /proc/"$pid"/status 2>/dev/null)
+        [ -z "$pid" ] && pid=0
+        i=$((i + 1))
+    done
+    if [ "$pid" -gt 1 ]; then
+        umask 077
+        tmp=$(mktemp "$SPOOL_DIR/."$pid".XXXXXX" 2>/dev/null) || tmp=""
+        if [ -n "$tmp" ]; then
+            printf '%s\n' "$FINGERPRINT" > "$tmp"
+            mv -f "$tmp" "$SPOOL_DIR/$pid.fp"
+        fi
+    fi
+fi
+
+# Emit the username as allowed principal if it can be resolved
+if getent passwd "$USERNAME" >/dev/null 2>&1; then
+    echo "$USERNAME"
+fi
+PRINCIPALS
+    chmod 755 "$script_path"
+
+    # Spool directory: mode 1733 so AuthorizedPrincipalsCommandUser (nobody)
+    # can create files but not list or read other sessions' drops. root
+    # bypasses permissions so pam_openbastion (running as root) can read.
+    mkdir -p "$spool_dir"
+    chown root:root "$spool_dir"
+    chmod 1733 "$spool_dir"
+
+    # Re-create the spool directory at boot via systemd-tmpfiles.
+    cat > "$tmpfiles_conf" << TMPFILES
+# Open Bastion SSH fingerprint spool — recreated at boot so the directory
+# survives /run wipes. See /usr/local/sbin/ob-ssh-principals.
+d /run/open-bastion          0755 root root -
+d /run/open-bastion/ssh-fp   1733 root root -
+TMPFILES
+    chmod 644 "$tmpfiles_conf"
+
+    info "SSH principals helper installed at $script_path"
+    info "SSH fingerprint spool prepared at $spool_dir"
+}
+
 # Configure sshd
 configure_sshd() {
     step "Configuring SSH server..."
@@ -144,8 +230,10 @@ configure_sshd() {
 # Trust LLNG SSH CA for certificate authentication
 TrustedUserCAKeys $SSH_CA_FILE
 
-# Accept certificate if principal matches the requested username
-AuthorizedPrincipalsCommand /bin/echo %u
+# Accept certificate if principal matches the requested username and drop the
+# SSH key fingerprint to /run/open-bastion/ssh-fp/ so pam_openbastion can
+# forward it to LLNG (see fingerprint binding on /pam/authorize + /pam/verify).
+AuthorizedPrincipalsCommand /usr/local/sbin/ob-ssh-principals %u %f
 AuthorizedPrincipalsCommandUser nobody
 
 # Enable public key (certificate) authentication
@@ -816,6 +904,7 @@ main() {
 
     # Run setup steps
     download_ca_key || exit 1
+    install_principals_helper || exit 1
     configure_sshd || exit 1
     configure_pam_sshd || exit 1
     configure_pam_llng || exit 1

--- a/scripts/ob-bastion-setup
+++ b/scripts/ob-bastion-setup
@@ -200,19 +200,25 @@ fi
 PRINCIPALS
     chmod 755 "$script_path"
 
-    # Spool directory: mode 1733 so AuthorizedPrincipalsCommandUser (nobody)
-    # can create files but not list or read other sessions' drops. root
-    # bypasses permissions so pam_openbastion (running as root) can read.
+    # Spool directory: owned by AuthorizedPrincipalsCommandUser (nobody),
+    # mode 0700 so ONLY that user can create/list drops. A world-writable
+    # directory (e.g. 1733) would let a local unprivileged user pre-create
+    # <pid>.fp with attacker-controlled content; the sticky bit would then
+    # prevent the principals helper from overwriting it, and
+    # pam_openbastion would read the spoofed fingerprint.
+    # pam_openbastion additionally refuses to read the spool if this
+    # directory is group/world-writable or if a drop file isn't owned by
+    # the directory owner with mode 0600 / nlink 1.
     mkdir -p "$spool_dir"
-    chown root:root "$spool_dir"
-    chmod 1733 "$spool_dir"
+    chown nobody:nogroup "$spool_dir" 2>/dev/null || chown nobody:nobody "$spool_dir"
+    chmod 0700 "$spool_dir"
 
     # Re-create the spool directory at boot via systemd-tmpfiles.
     cat > "$tmpfiles_conf" << TMPFILES
 # Open Bastion SSH fingerprint spool — recreated at boot so the directory
 # survives /run wipes. See /usr/local/sbin/ob-ssh-principals.
-d /run/open-bastion          0755 root root -
-d /run/open-bastion/ssh-fp   1733 root root -
+d /run/open-bastion          0755 root   root   -
+d /run/open-bastion/ssh-fp   0700 nobody nogroup -
 TMPFILES
     chmod 644 "$tmpfiles_conf"
 

--- a/src/ob_client.c
+++ b/src/ob_client.c
@@ -532,6 +532,7 @@ static void setup_curl(ob_client_t *client)
 
 int ob_verify_token(ob_client_t *client,
                       const char *user_token,
+                      const char *fingerprint,
                       ob_response_t *response)
 {
     if (!client || !user_token || !response) {
@@ -555,6 +556,17 @@ int ob_verify_token(ob_client_t *client,
     /* Build JSON request body */
     struct json_object *req_json = json_object_new_object();
     json_object_object_add(req_json, "token", json_object_new_string(user_token));
+
+    /*
+     * Bind the token to a specific SSH key when the user authenticated
+     * via a signed SSH certificate. LLNG will match this fingerprint
+     * against the entries stored in the user's persistent session and
+     * reject the verification if the key is unknown, revoked or expired.
+     */
+    if (fingerprint && *fingerprint) {
+        json_object_object_add(req_json, "fingerprint",
+                               json_object_new_string(fingerprint));
+    }
 
     const char *req_body = json_object_to_json_string(req_json);
 
@@ -901,6 +913,16 @@ static int ob_authorize_user_internal(ob_client_t *client,
         json_object_object_add(req_json, "ssh_cert", cert_json);
     }
 
+    /*
+     * Optional top-level SSH fingerprint binding: LLNG cross-checks the
+     * fingerprint against the user's persistent session and rejects
+     * /pam/authorize if the cert is unknown, revoked or expired.
+     */
+    if (ssh_cert && ssh_cert->key_fingerprint && *ssh_cert->key_fingerprint) {
+        json_object_object_add(req_json, "fingerprint",
+                               json_object_new_string(ssh_cert->key_fingerprint));
+    }
+
     const char *req_body = json_object_to_json_string(req_json);
 
     /* Build headers with Bearer token */
@@ -1077,6 +1099,7 @@ void ob_ssh_cert_info_free(ob_ssh_cert_info_t *cert_info)
     free(cert_info->serial);
     free(cert_info->principals);
     free(cert_info->ca_fingerprint);
+    free(cert_info->key_fingerprint);
     memset(cert_info, 0, sizeof(*cert_info));
 }
 

--- a/src/pam_openbastion.c
+++ b/src/pam_openbastion.c
@@ -1683,6 +1683,138 @@ static const char *get_client_ip(pam_handle_t *pamh)
 }
 
 /*
+ * Walk up the process tree looking for an ancestor whose /proc/<pid>/comm
+ * is "sshd-session" (or "sshd" as a fallback). Returns its PID, or 0 if
+ * none found. Used to correlate the PAM module's invocation with the
+ * AuthorizedPrincipalsCommand run, since both end up under the same
+ * sshd-session[priv] process even when run in separate child processes.
+ */
+static pid_t find_sshd_session_ancestor(void)
+{
+    pid_t pid = getpid();
+    for (int i = 0; i < 16; i++) {
+        char path[64];
+        char buf[256];
+
+        /* Read /proc/<pid>/comm */
+        snprintf(path, sizeof(path), "/proc/%d/comm", (int)pid);
+        FILE *f = fopen(path, "r");
+        if (!f) return 0;
+        if (!fgets(buf, sizeof(buf), f)) {
+            fclose(f);
+            return 0;
+        }
+        fclose(f);
+        char *nl = strchr(buf, '\n');
+        if (nl) *nl = '\0';
+        if (strcmp(buf, "sshd-session") == 0 || strcmp(buf, "sshd") == 0) {
+            return pid;
+        }
+
+        /* Read PPid from /proc/<pid>/status */
+        snprintf(path, sizeof(path), "/proc/%d/status", (int)pid);
+        f = fopen(path, "r");
+        if (!f) return 0;
+        pid_t ppid = 0;
+        while (fgets(buf, sizeof(buf), f)) {
+            if (strncmp(buf, "PPid:", 5) == 0) {
+                ppid = (pid_t)strtol(buf + 5, NULL, 10);
+                break;
+            }
+        }
+        fclose(f);
+        if (ppid <= 1 || ppid == pid) return 0;
+        pid = ppid;
+    }
+    return 0;
+}
+
+/*
+ * Read the SSH key fingerprint dropped by llng-principals in
+ * /run/open-bastion/ssh-fp/<sshd-session-pid>.fp. This is the out-of-band
+ * channel that compensates for the fact that OpenSSH does not propagate
+ * SSH_USER_AUTH to the PAM environment during pam_acct_mgmt.
+ *
+ * The file is intentionally left in place on successful read: the same
+ * sshd-session handles multiple PAM calls (SSH account phase + sudo
+ * /pam/verify), and they all need to match the same cert. llng-principals
+ * always atomically overwrites the file on the next sshd connection (via
+ * `mv -f`), so a stale PID reuse won't leak an old fingerprint.
+ *
+ * Returns allocated string (caller must free) on success, NULL otherwise.
+ */
+#ifndef OB_SSH_FP_SPOOL_DIR
+#define OB_SSH_FP_SPOOL_DIR "/run/open-bastion/ssh-fp"
+#endif
+
+static char *read_ssh_fp_from_spool(pam_handle_t *pamh)
+{
+    pid_t anchor = find_sshd_session_ancestor();
+    if (anchor <= 1) {
+        OB_LOG_DEBUG(pamh, "No sshd-session ancestor found, skipping SSH fp spool");
+        return NULL;
+    }
+
+    char path[128];
+    int n = snprintf(path, sizeof(path), "%s/%d.fp",
+                     OB_SSH_FP_SPOOL_DIR, (int)anchor);
+    if (n < 0 || (size_t)n >= sizeof(path)) return NULL;
+
+    int fd = open(path, O_RDONLY | O_NOFOLLOW | O_CLOEXEC);
+    if (fd < 0) {
+        OB_LOG_DEBUG(pamh, "SSH fp spool not found at %s (errno=%d)", path, errno);
+        return NULL;
+    }
+
+    struct stat st;
+    if (fstat(fd, &st) != 0 || !S_ISREG(st.st_mode)
+        || st.st_size <= 0 || st.st_size > 512) {
+        close(fd);
+        unlink(path);
+        return NULL;
+    }
+
+    char buf[260];
+    ssize_t got = read(fd, buf, sizeof(buf) - 1);
+    close(fd);
+    if (got <= 0) {
+        unlink(path);
+        return NULL;
+    }
+    buf[got] = '\0';
+    while (got > 0 && (buf[got - 1] == '\n' || buf[got - 1] == '\r' ||
+                       buf[got - 1] == ' ' || buf[got - 1] == '\t')) {
+        buf[--got] = '\0';
+    }
+    if (got <= 0) {
+        unlink(path);
+        return NULL;
+    }
+
+    /* Validate strict SHA256:<base64> form. LLNG rejects anything else
+     * with HTTP 400, so filter here too. */
+    if (strncmp(buf, "SHA256:", 7) != 0) {
+        OB_LOG_DEBUG(pamh, "SSH fp spool contents not SHA256: '%s'", buf);
+        unlink(path);
+        return NULL;
+    }
+    for (const char *p = buf + 7; *p; p++) {
+        if (!((*p >= 'A' && *p <= 'Z') || (*p >= 'a' && *p <= 'z') ||
+              (*p >= '0' && *p <= '9') || *p == '+' || *p == '/' || *p == '=')) {
+            OB_LOG_DEBUG(pamh, "SSH fp spool has invalid char, rejecting");
+            unlink(path);
+            return NULL;
+        }
+    }
+
+    char *fp = strdup(buf);
+    if (fp) {
+        OB_LOG_DEBUG(pamh, "SSH fp recovered from spool: %s", fp);
+    }
+    return fp;
+}
+
+/*
  * Extract SSH key fingerprint from PAM environment.
  * SSH sets SSH_USER_AUTH environment variable when ExposeAuthInfo is enabled.
  * Format for publickey: "publickey <algorithm> SHA256:<fingerprint>"
@@ -1820,27 +1952,41 @@ static int extract_ssh_cert_info(pam_handle_t *pamh, ob_ssh_cert_info_t *cert_in
     if (!cert_info) return 0;
     memset(cert_info, 0, sizeof(*cert_info));
 
-    /* Get SSH_USER_AUTH from PAM environment */
+    /*
+     * Primary path for modern OpenSSH (10.x): the AuthorizedPrincipalsCommand
+     * (llng-principals) drops the SHA256 fingerprint in
+     * /run/open-bastion/ssh-fp/<sshd-session-pid>.fp because sshd does NOT
+     * expose SSH_USER_AUTH to the PAM environment during pam_acct_mgmt.
+     * Pick it up here so /pam/authorize gets the fingerprint.
+     */
+    char *spool_fp = read_ssh_fp_from_spool(pamh);
+
+    /* Get SSH_USER_AUTH from PAM environment (legacy / custom-patched sshd) */
     const char *ssh_auth = pam_getenv(pamh, "SSH_USER_AUTH");
-    if (!ssh_auth || !*ssh_auth) {
-        OB_LOG_DEBUG(pamh, "No SSH_USER_AUTH in environment");
+    if ((!ssh_auth || !*ssh_auth) && !spool_fp) {
+        OB_LOG_DEBUG(pamh, "No SSH_USER_AUTH in environment and no spool fingerprint");
         return 0;
     }
 
     /* Security: Check length before processing (fixes #45) */
-    if (strlen(ssh_auth) >= MAX_SSH_AUTH_LEN) {
+    if (ssh_auth && strlen(ssh_auth) >= MAX_SSH_AUTH_LEN) {
         OB_LOG_WARN(pamh, "SSH_USER_AUTH too long, ignoring");
-        return 0;
+        ssh_auth = NULL;
     }
 
-    OB_LOG_DEBUG(pamh, "SSH_USER_AUTH: %s", ssh_auth);
+    if (ssh_auth) {
+        OB_LOG_DEBUG(pamh, "SSH_USER_AUTH: %s", ssh_auth);
+    }
 
     /*
      * Check if this is certificate authentication.
      * Certificate auth shows as: "publickey <algo>-cert-v01@openssh.com ..."
      * Regular key auth shows as: "publickey <algo> ..."
+     * If we only have the spool fingerprint (no SSH_USER_AUTH), accept it:
+     * sshd only runs AuthorizedPrincipalsCommand for cert-authenticated users,
+     * so a spool entry implies a signed cert was used.
      */
-    if (strstr(ssh_auth, "-cert-") == NULL) {
+    if (ssh_auth && strstr(ssh_auth, "-cert-") == NULL && !spool_fp) {
         OB_LOG_DEBUG(pamh, "SSH authentication is not certificate-based");
         return 0;
     }
@@ -1879,33 +2025,31 @@ static int extract_ssh_cert_info(pam_handle_t *pamh, ob_ssh_cert_info_t *cert_in
     }
 
     /*
-     * SHA256 fingerprint of the user SSH key used for authentication.
-     * LLNG cross-checks it against the user's persistent session
-     * (_sshCerts) on /pam/authorize to reject a revoked cert even if the
-     * local sshd KRL is stale or not enforced.
-     *
-     * LLNG only accepts the strict "SHA256:<base64>" form and returns
-     * HTTP 400 on anything else. If sshd is configured with
-     * "FingerprintHash md5" the extractor would yield "MD5:..." which
-     * would break every /pam/authorize call; filter those out and leave
-     * the field NULL so LLNG keeps the pre-binding behaviour.
+     * Wire the SHA256 fingerprint we captured from the spool (modern
+     * OpenSSH) or, as a fallback, extract it from SSH_USER_AUTH for any
+     * sshd that does propagate it. LLNG only accepts SHA256:<base64> and
+     * returns HTTP 400 on anything else, so filter strictly.
      */
-    char *extracted_fp = extract_ssh_key_fingerprint(pamh);
-    if (extracted_fp && strncmp(extracted_fp, "SHA256:", 7) == 0) {
-        cert_info->key_fingerprint = extracted_fp;
+    if (spool_fp) {
+        cert_info->key_fingerprint = spool_fp;
+        spool_fp = NULL;
     } else {
-        if (extracted_fp) {
+        char *extracted_fp = extract_ssh_key_fingerprint(pamh);
+        if (extracted_fp && strncmp(extracted_fp, "SHA256:", 7) == 0) {
+            cert_info->key_fingerprint = extracted_fp;
+        } else if (extracted_fp) {
             OB_LOG_DEBUG(pamh,
                          "Ignoring non-SHA256 SSH key fingerprint (%s): "
                          "LLNG fingerprint binding requires SHA256",
                          extracted_fp);
             free(extracted_fp);
         }
-        cert_info->key_fingerprint = NULL;
     }
 
-    /* If we didn't get any details, try to parse from SSH_USER_AUTH */
-    if (!cert_info->key_id && !cert_info->serial) {
+    /* If we didn't get any details, try to parse from SSH_USER_AUTH.
+     * Skipped when SSH_USER_AUTH is absent (modern OpenSSH) — we rely on
+     * the spool fingerprint and LLNG cross-check in that case. */
+    if (ssh_auth && !cert_info->key_id && !cert_info->serial) {
         /*
          * Try parsing format: "publickey algo fingerprint:keyid:serial:principals"
          * This is a simplified parser - real format may vary.
@@ -2625,26 +2769,26 @@ PAM_VISIBLE PAM_EXTERN int pam_sm_authenticate(pam_handle_t *pamh,
          * verification if the key has been revoked or expired in LLNG,
          * even if the local sshd KRL is stale or missing.
          */
-        char *ssh_fingerprint = NULL;
-        {
+        /*
+         * Bind the /pam/verify token to the SSH key that opened the
+         * current session. Primary source is the out-of-band spool
+         * populated by llng-principals (since SSH_USER_AUTH is not in
+         * the PAM env on modern OpenSSH); fallback to SSH_USER_AUTH for
+         * environments where a custom sshd does expose it. LLNG rejects
+         * anything other than SHA256:<base64>, so filter strictly.
+         */
+        char *ssh_fingerprint = read_ssh_fp_from_spool(pamh);
+        if (!ssh_fingerprint) {
             const char *ssh_auth = pam_getenv(pamh, "SSH_USER_AUTH");
             if (ssh_auth && strstr(ssh_auth, "-cert-")) {
                 char *fp = extract_ssh_key_fingerprint(pamh);
-                /*
-                 * LLNG only accepts SHA256 fingerprints and returns
-                 * HTTP 400 on anything else. Guard against an
-                 * MD5-configured sshd silently breaking all sudo /
-                 * re-auth flows by only forwarding SHA256 values.
-                 */
                 if (fp && strncmp(fp, "SHA256:", 7) == 0) {
                     ssh_fingerprint = fp;
-                } else {
-                    if (fp) {
-                        OB_LOG_DEBUG(pamh,
-                                     "Ignoring non-SHA256 SSH fingerprint "
-                                     "(%s) for /pam/verify binding", fp);
-                        free(fp);
-                    }
+                } else if (fp) {
+                    OB_LOG_DEBUG(pamh,
+                                 "Ignoring non-SHA256 SSH fingerprint "
+                                 "(%s) for /pam/verify binding", fp);
+                    free(fp);
                 }
             }
         }

--- a/src/pam_openbastion.c
+++ b/src/pam_openbastion.c
@@ -1878,6 +1878,14 @@ static int extract_ssh_cert_info(pam_handle_t *pamh, ob_ssh_cert_info_t *cert_in
         cert_info->ca_fingerprint = strdup(ca_fp);
     }
 
+    /*
+     * SHA256 fingerprint of the user SSH key used for authentication.
+     * LLNG cross-checks it against the user's persistent session
+     * (_sshCerts) on /pam/authorize to reject a revoked cert even if the
+     * local sshd KRL is stale or not enforced.
+     */
+    cert_info->key_fingerprint = extract_ssh_key_fingerprint(pamh);
+
     /* If we didn't get any details, try to parse from SSH_USER_AUTH */
     if (!cert_info->key_id && !cert_info->serial) {
         /*
@@ -2592,8 +2600,27 @@ PAM_VISIBLE PAM_EXTERN int pam_sm_authenticate(pam_handle_t *pamh,
          * Default mode: Verify the one-time PAM token via /pam/verify
          * The token is destroyed after successful verification (single-use).
          * Note: Cache is not used for one-time tokens.
+         *
+         * When the SSH session was authenticated with a CA-signed
+         * certificate, forward the SSH key fingerprint so that LLNG can
+         * match it against the user's persistent session and refuse
+         * verification if the key has been revoked or expired in LLNG,
+         * even if the local sshd KRL is stale or missing.
          */
-        if (ob_verify_token(data->client, password, &response) != 0) {
+        char *ssh_fingerprint = NULL;
+        {
+            const char *ssh_auth = pam_getenv(pamh, "SSH_USER_AUTH");
+            if (ssh_auth && strstr(ssh_auth, "-cert-")) {
+                ssh_fingerprint = extract_ssh_key_fingerprint(pamh);
+            }
+        }
+
+        int verify_rc = ob_verify_token(data->client, password,
+                                        ssh_fingerprint, &response);
+        free(ssh_fingerprint);
+        ssh_fingerprint = NULL;
+
+        if (verify_rc != 0) {
             OB_LOG_ERR(pamh, "Token verification failed: %s",
                     ob_client_error(data->client));
 

--- a/src/pam_openbastion.c
+++ b/src/pam_openbastion.c
@@ -1755,6 +1755,29 @@ static char *read_ssh_fp_from_spool(pam_handle_t *pamh)
         return NULL;
     }
 
+    /*
+     * Reject the spool directory itself if it is world/group-writable or
+     * not owned by the expected principals helper user. We derive the
+     * trusted uid from the directory's st_uid: the deployment scripts
+     * create the directory chown'd to the AuthorizedPrincipalsCommandUser
+     * (root or nobody depending on the setup), so the directory owner
+     * becomes the ground truth for who is allowed to drop files.
+     */
+    struct stat dir_st;
+    if (stat(OB_SSH_FP_SPOOL_DIR, &dir_st) != 0) {
+        OB_LOG_DEBUG(pamh, "SSH fp spool dir missing: %s", OB_SSH_FP_SPOOL_DIR);
+        return NULL;
+    }
+    if (!S_ISDIR(dir_st.st_mode)) {
+        OB_LOG_ERR(pamh, "SSH fp spool %s is not a directory", OB_SSH_FP_SPOOL_DIR);
+        return NULL;
+    }
+    if (dir_st.st_mode & (S_IWGRP | S_IWOTH)) {
+        OB_LOG_ERR(pamh, "SSH fp spool %s is group/world-writable (mode %o) — refusing",
+                   OB_SSH_FP_SPOOL_DIR, dir_st.st_mode & 07777);
+        return NULL;
+    }
+
     char path[128];
     int n = snprintf(path, sizeof(path), "%s/%d.fp",
                      OB_SSH_FP_SPOOL_DIR, (int)anchor);
@@ -1769,6 +1792,23 @@ static char *read_ssh_fp_from_spool(pam_handle_t *pamh)
     struct stat st;
     if (fstat(fd, &st) != 0 || !S_ISREG(st.st_mode)
         || st.st_size <= 0 || st.st_size > 512) {
+        close(fd);
+        unlink(path);
+        return NULL;
+    }
+    /*
+     * File-level integrity checks: owned by the same uid as the spool
+     * directory (i.e. the principals helper user), exactly one link
+     * (so an attacker cannot substitute a hard link to another file),
+     * and not readable/writable by group/other.
+     */
+    if (st.st_uid != dir_st.st_uid || st.st_nlink != 1
+        || (st.st_mode & 0077) != 0) {
+        OB_LOG_ERR(pamh,
+                   "SSH fp spool file %s has bad ownership/mode "
+                   "(uid=%u expected=%u, mode=%o, nlink=%lu) — refusing",
+                   path, (unsigned)st.st_uid, (unsigned)dir_st.st_uid,
+                   st.st_mode & 07777, (unsigned long)st.st_nlink);
         close(fd);
         unlink(path);
         return NULL;
@@ -1968,10 +2008,15 @@ static int extract_ssh_cert_info(pam_handle_t *pamh, ob_ssh_cert_info_t *cert_in
         return 0;
     }
 
-    /* Security: Check length before processing (fixes #45) */
+    /* Security: Check length before processing (fixes #45).
+     * If the variable is unusable AND no spool fingerprint was found,
+     * bail out rather than authorise without a verifiable source. */
     if (ssh_auth && strlen(ssh_auth) >= MAX_SSH_AUTH_LEN) {
         OB_LOG_WARN(pamh, "SSH_USER_AUTH too long, ignoring");
         ssh_auth = NULL;
+    }
+    if (!ssh_auth && !spool_fp) {
+        return 0;
     }
 
     if (ssh_auth) {

--- a/src/pam_openbastion.c
+++ b/src/pam_openbastion.c
@@ -1883,8 +1883,26 @@ static int extract_ssh_cert_info(pam_handle_t *pamh, ob_ssh_cert_info_t *cert_in
      * LLNG cross-checks it against the user's persistent session
      * (_sshCerts) on /pam/authorize to reject a revoked cert even if the
      * local sshd KRL is stale or not enforced.
+     *
+     * LLNG only accepts the strict "SHA256:<base64>" form and returns
+     * HTTP 400 on anything else. If sshd is configured with
+     * "FingerprintHash md5" the extractor would yield "MD5:..." which
+     * would break every /pam/authorize call; filter those out and leave
+     * the field NULL so LLNG keeps the pre-binding behaviour.
      */
-    cert_info->key_fingerprint = extract_ssh_key_fingerprint(pamh);
+    char *extracted_fp = extract_ssh_key_fingerprint(pamh);
+    if (extracted_fp && strncmp(extracted_fp, "SHA256:", 7) == 0) {
+        cert_info->key_fingerprint = extracted_fp;
+    } else {
+        if (extracted_fp) {
+            OB_LOG_DEBUG(pamh,
+                         "Ignoring non-SHA256 SSH key fingerprint (%s): "
+                         "LLNG fingerprint binding requires SHA256",
+                         extracted_fp);
+            free(extracted_fp);
+        }
+        cert_info->key_fingerprint = NULL;
+    }
 
     /* If we didn't get any details, try to parse from SSH_USER_AUTH */
     if (!cert_info->key_id && !cert_info->serial) {
@@ -2611,7 +2629,23 @@ PAM_VISIBLE PAM_EXTERN int pam_sm_authenticate(pam_handle_t *pamh,
         {
             const char *ssh_auth = pam_getenv(pamh, "SSH_USER_AUTH");
             if (ssh_auth && strstr(ssh_auth, "-cert-")) {
-                ssh_fingerprint = extract_ssh_key_fingerprint(pamh);
+                char *fp = extract_ssh_key_fingerprint(pamh);
+                /*
+                 * LLNG only accepts SHA256 fingerprints and returns
+                 * HTTP 400 on anything else. Guard against an
+                 * MD5-configured sshd silently breaking all sudo /
+                 * re-auth flows by only forwarding SHA256 values.
+                 */
+                if (fp && strncmp(fp, "SHA256:", 7) == 0) {
+                    ssh_fingerprint = fp;
+                } else {
+                    if (fp) {
+                        OB_LOG_DEBUG(pamh,
+                                     "Ignoring non-SHA256 SSH fingerprint "
+                                     "(%s) for /pam/verify binding", fp);
+                        free(fp);
+                    }
+                }
             }
         }
 

--- a/tests/test_integration_docker.sh
+++ b/tests/test_integration_docker.sh
@@ -351,6 +351,124 @@ test_pam_authorize_endpoint() {
     fi
 }
 
+test_pam_authorize_fingerprint_binding() {
+    TESTS_RUN=$((TESTS_RUN + 1))
+    log "Testing /pam/authorize SSH fingerprint binding (PamAccess >= 0.1.16)..."
+
+    if [[ ! -f "${TEST_KEY}.pub" ]]; then
+        log_warn "No key available, skipping fingerprint binding test"
+        pass "Fingerprint binding test skipped (no key)"
+        return 0
+    fi
+
+    local fingerprint
+    fingerprint=$(ssh-keygen -l -E sha256 -f "${TEST_KEY}.pub" 2>/dev/null | awk '{print $2}')
+    if [[ -z "$fingerprint" || "$fingerprint" != SHA256:* ]]; then
+        fail "Could not compute SHA256 fingerprint of ${TEST_KEY}.pub"
+        return 1
+    fi
+    log_verbose "Computed fingerprint: $fingerprint"
+
+    local server_token
+    server_token=$(docker exec ob-cert-bastion cat /etc/open-bastion/server_token.json 2>/dev/null | jq -r '.access_token // empty') || true
+    if [[ -z "$server_token" ]]; then
+        fail "Could not get server token from bastion"
+        return 1
+    fi
+
+    # 1. Matching fingerprint accepted
+    local response
+    response=$(curl -s -X POST "$PORTAL_URL/pam/authorize" \
+        -H "Authorization: Bearer $server_token" \
+        -H "Content-Type: application/json" \
+        -d "{\"user\":\"$TEST_USER\",\"server_group\":\"bastion\",\"fingerprint\":\"$fingerprint\"}" 2>&1) || true
+    log_verbose "authorize(match) response: $response"
+    if ! echo "$response" | jq -e '.authorized == true' >/dev/null 2>&1; then
+        fail "authorize with matching fingerprint should succeed" "$response"
+        return 1
+    fi
+
+    # 2. Unknown fingerprint refused
+    local bogus="SHA256:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+    response=$(curl -s -X POST "$PORTAL_URL/pam/authorize" \
+        -H "Authorization: Bearer $server_token" \
+        -H "Content-Type: application/json" \
+        -d "{\"user\":\"$TEST_USER\",\"server_group\":\"bastion\",\"fingerprint\":\"$bogus\"}" 2>&1) || true
+    log_verbose "authorize(unknown) response: $response"
+    if echo "$response" | jq -e '.authorized == true' >/dev/null 2>&1; then
+        fail "authorize with unknown fingerprint should be refused" "$response"
+        return 1
+    fi
+
+    # 3. Malformed fingerprint → HTTP 400
+    local http_code
+    http_code=$(curl -s -o /dev/null -w '%{http_code}' -X POST "$PORTAL_URL/pam/authorize" \
+        -H "Authorization: Bearer $server_token" \
+        -H "Content-Type: application/json" \
+        -d "{\"user\":\"$TEST_USER\",\"server_group\":\"bastion\",\"fingerprint\":\"not-a-fingerprint\"}")
+    log_verbose "authorize(malformed) HTTP code: $http_code"
+    if [[ "$http_code" != "400" ]]; then
+        fail "authorize with malformed fingerprint should return 400 (got $http_code)"
+        return 1
+    fi
+
+    pass "/pam/authorize fingerprint binding works (match / unknown / malformed)"
+    return 0
+}
+
+test_pam_authorize_rejects_revoked_cert() {
+    TESTS_RUN=$((TESTS_RUN + 1))
+    log "Testing /pam/authorize rejects a cert revoked via /ssh/myrevoke..."
+
+    if [[ ! -f "${TEST_KEY}.pub" ]]; then
+        pass "Revocation test skipped (no key)"
+        return 0
+    fi
+
+    local fingerprint
+    fingerprint=$(ssh-keygen -l -E sha256 -f "${TEST_KEY}.pub" 2>/dev/null | awk '{print $2}')
+    if [[ -z "$fingerprint" ]]; then
+        fail "Could not compute fingerprint for revocation test"
+        return 1
+    fi
+
+    local list
+    list=$(curl -sf "$PORTAL_URL/ssh/mycerts" -b "$COOKIE_FILE" 2>&1) || true
+    log_verbose "mycerts: $list"
+    local serial
+    serial=$(echo "$list" | jq -r --arg fp "$fingerprint" \
+        '(.certificates // []) | .[] | select(.fingerprint == $fp) | .serial' 2>/dev/null | head -n1)
+    if [[ -z "$serial" || "$serial" == "null" ]]; then
+        fail "Could not find serial for test cert in /ssh/mycerts" "$list"
+        return 1
+    fi
+    log_verbose "Revoking serial $serial"
+
+    local revoke_resp
+    revoke_resp=$(curl -s -X POST "$PORTAL_URL/ssh/myrevoke" \
+        -b "$COOKIE_FILE" \
+        -H "Content-Type: application/json" \
+        -d "{\"serial\":\"$serial\"}" 2>&1) || true
+    log_verbose "myrevoke: $revoke_resp"
+
+    local server_token
+    server_token=$(docker exec ob-cert-bastion cat /etc/open-bastion/server_token.json 2>/dev/null | jq -r '.access_token // empty') || true
+    local response
+    response=$(curl -s -X POST "$PORTAL_URL/pam/authorize" \
+        -H "Authorization: Bearer $server_token" \
+        -H "Content-Type: application/json" \
+        -d "{\"user\":\"$TEST_USER\",\"server_group\":\"bastion\",\"fingerprint\":\"$fingerprint\"}" 2>&1) || true
+    log_verbose "authorize(revoked) response: $response"
+
+    if echo "$response" | jq -e '.authorized == true' >/dev/null 2>&1; then
+        fail "authorize should reject a cert revoked on LLNG side" "$response"
+        return 1
+    fi
+
+    pass "/pam/authorize rejects cert revoked via /ssh/myrevoke (no KRL refresh needed)"
+    return 0
+}
+
 test_token_introspection() {
     TESTS_RUN=$((TESTS_RUN + 1))
     log "Testing token introspection (with JWT client assertion)..."
@@ -501,6 +619,7 @@ main() {
     echo ""
     echo "=== Phase 4: PAM Module Tests ==="
     test_pam_authorize_endpoint
+    test_pam_authorize_fingerprint_binding
     test_token_introspection
     test_nss_user_resolution
     test_pam_cache
@@ -508,6 +627,12 @@ main() {
     echo ""
     echo "=== Phase 5: End-to-End Tests ==="
     test_ssh_connection_bastion
+
+    echo ""
+    echo "=== Phase 6: Cert revocation via fingerprint binding ==="
+    # MUST run last: /ssh/myrevoke invalidates the test cert and would
+    # break any subsequent test that relies on a valid certificate.
+    test_pam_authorize_rejects_revoked_cert
 
     echo ""
     echo "=============================================="

--- a/tests/test_integration_docker.sh
+++ b/tests/test_integration_docker.sh
@@ -503,6 +503,61 @@ test_pam_authorize_rejects_revoked_cert() {
     return 0
 }
 
+# End-to-end validation: attempt a real SSH connection with the cert that
+# was just revoked on the LLNG side via /ssh/myrevoke. Without a KRL
+# refresh, sshd accepts the cert at the pubkey layer, and
+# pam_openbastion.so must then forward the fingerprint to /pam/authorize
+# where LLNG refuses. Proves the binding works end-to-end (C module +
+# LLNG), not just the portal contract.
+test_ssh_connection_refused_after_revocation() {
+    TESTS_RUN=$((TESTS_RUN + 1))
+    log "Testing SSH connection is refused end-to-end after LLNG-side revocation..."
+
+    if [[ ! -f "${TEST_KEY}-cert.pub" ]]; then
+        log_warn "No certificate available, skipping e2e revocation SSH test"
+        pass "SSH e2e revocation test skipped (no certificate)"
+        return 0
+    fi
+
+    local output
+    output=$(ssh -i "${TEST_KEY}" \
+                 -o IdentitiesOnly=yes \
+                 -o StrictHostKeyChecking=no \
+                 -o UserKnownHostsFile=/dev/null \
+                 -o BatchMode=yes \
+                 -o ConnectTimeout=10 \
+                 -p 2222 \
+                 "${TEST_USER}@localhost" \
+                 "echo SHOULD_NEVER_PRINT" 2>&1) || true
+
+    log_verbose "SSH(revoked) output: $output"
+
+    if echo "$output" | grep -q "SHOULD_NEVER_PRINT"; then
+        fail "SSH with LLNG-revoked cert succeeded (expected denial)" "$output"
+        return 1
+    fi
+
+    if ! echo "$output" | grep -qE "Permission denied|Connection closed|Authentication failed"; then
+        fail "SSH with revoked cert did not fail with a permission-denial" "$output"
+        return 1
+    fi
+
+    local bastion_log
+    bastion_log=$(docker exec ob-cert-bastion sh -c '
+        for f in /var/log/auth.log /var/log/syslog /var/log/messages; do
+            [ -r "$f" ] && tail -n 200 "$f"
+        done
+    ' 2>/dev/null) || true
+    if echo "$bastion_log" | grep -qE "PAM_AUTHZ_SSH_FP_REJECTED|SSH fingerprint not recognized"; then
+        log_verbose "Bastion confirmed /pam/authorize fingerprint rejection in logs"
+    else
+        log_warn "Could not find PAM_AUTHZ_SSH_FP_REJECTED in bastion logs (sshd KRL may have refused first, or logs not persisted)"
+    fi
+
+    pass "SSH with LLNG-revoked cert refused end-to-end (no KRL refresh needed)"
+    return 0
+}
+
 test_token_introspection() {
     TESTS_RUN=$((TESTS_RUN + 1))
     log "Testing token introspection (with JWT client assertion)..."
@@ -667,6 +722,7 @@ main() {
     # MUST run last: /ssh/myrevoke invalidates the test cert and would
     # break any subsequent test that relies on a valid certificate.
     test_pam_authorize_rejects_revoked_cert
+    test_ssh_connection_refused_after_revocation
 
     echo ""
     echo "=============================================="

--- a/tests/test_integration_docker.sh
+++ b/tests/test_integration_docker.sh
@@ -376,42 +376,60 @@ test_pam_authorize_fingerprint_binding() {
         return 1
     fi
 
-    # 1. Matching fingerprint accepted
-    local response
-    response=$(curl -s -X POST "$PORTAL_URL/pam/authorize" \
+    local body_tmp http_code response
+    body_tmp=$(mktemp)
+
+    # 1. Matching fingerprint accepted (HTTP 200 + authorized:true)
+    http_code=$(curl -s -o "$body_tmp" -w '%{http_code}' -X POST "$PORTAL_URL/pam/authorize" \
         -H "Authorization: Bearer $server_token" \
         -H "Content-Type: application/json" \
-        -d "{\"user\":\"$TEST_USER\",\"server_group\":\"bastion\",\"fingerprint\":\"$fingerprint\"}" 2>&1) || true
-    log_verbose "authorize(match) response: $response"
-    if ! echo "$response" | jq -e '.authorized == true' >/dev/null 2>&1; then
-        fail "authorize with matching fingerprint should succeed" "$response"
+        -d "{\"user\":\"$TEST_USER\",\"server_group\":\"bastion\",\"fingerprint\":\"$fingerprint\"}")
+    response=$(cat "$body_tmp")
+    log_verbose "authorize(match) HTTP=$http_code body=$response"
+    if [[ "$http_code" != "200" ]]; then
+        rm -f "$body_tmp"
+        fail "authorize(match) expected HTTP 200, got $http_code" "$response"
+        return 1
+    fi
+    if ! echo "$response" | jq -e 'type == "object" and .authorized == true' >/dev/null 2>&1; then
+        rm -f "$body_tmp"
+        fail "authorize(match) expected authorized:true" "$response"
         return 1
     fi
 
-    # 2. Unknown fingerprint refused
+    # 2. Unknown fingerprint refused (HTTP 200 + authorized:false explicitly)
     local bogus="SHA256:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-    response=$(curl -s -X POST "$PORTAL_URL/pam/authorize" \
+    http_code=$(curl -s -o "$body_tmp" -w '%{http_code}' -X POST "$PORTAL_URL/pam/authorize" \
         -H "Authorization: Bearer $server_token" \
         -H "Content-Type: application/json" \
-        -d "{\"user\":\"$TEST_USER\",\"server_group\":\"bastion\",\"fingerprint\":\"$bogus\"}" 2>&1) || true
-    log_verbose "authorize(unknown) response: $response"
-    if echo "$response" | jq -e '.authorized == true' >/dev/null 2>&1; then
-        fail "authorize with unknown fingerprint should be refused" "$response"
+        -d "{\"user\":\"$TEST_USER\",\"server_group\":\"bastion\",\"fingerprint\":\"$bogus\"}")
+    response=$(cat "$body_tmp")
+    log_verbose "authorize(unknown) HTTP=$http_code body=$response"
+    if [[ "$http_code" != "200" ]]; then
+        rm -f "$body_tmp"
+        fail "authorize(unknown) expected HTTP 200, got $http_code" "$response"
+        return 1
+    fi
+    if ! echo "$response" | jq -e 'type == "object" and .authorized == false' >/dev/null 2>&1; then
+        rm -f "$body_tmp"
+        fail "authorize(unknown) expected authorized:false (not a jq parse failure)" "$response"
         return 1
     fi
 
     # 3. Malformed fingerprint → HTTP 400
-    local http_code
-    http_code=$(curl -s -o /dev/null -w '%{http_code}' -X POST "$PORTAL_URL/pam/authorize" \
+    http_code=$(curl -s -o "$body_tmp" -w '%{http_code}' -X POST "$PORTAL_URL/pam/authorize" \
         -H "Authorization: Bearer $server_token" \
         -H "Content-Type: application/json" \
         -d "{\"user\":\"$TEST_USER\",\"server_group\":\"bastion\",\"fingerprint\":\"not-a-fingerprint\"}")
-    log_verbose "authorize(malformed) HTTP code: $http_code"
+    response=$(cat "$body_tmp")
+    log_verbose "authorize(malformed) HTTP=$http_code body=$response"
     if [[ "$http_code" != "400" ]]; then
-        fail "authorize with malformed fingerprint should return 400 (got $http_code)"
+        rm -f "$body_tmp"
+        fail "authorize(malformed) expected HTTP 400, got $http_code" "$response"
         return 1
     fi
 
+    rm -f "$body_tmp"
     pass "/pam/authorize fingerprint binding works (match / unknown / malformed)"
     return 0
 }
@@ -453,14 +471,30 @@ test_pam_authorize_rejects_revoked_cert() {
 
     local server_token
     server_token=$(docker exec ob-cert-bastion cat /etc/open-bastion/server_token.json 2>/dev/null | jq -r '.access_token // empty') || true
-    local response
-    response=$(curl -s -X POST "$PORTAL_URL/pam/authorize" \
+    if [[ -z "$server_token" ]]; then
+        fail "Could not get server token from bastion"
+        return 1
+    fi
+
+    local body_tmp http_code response
+    body_tmp=$(mktemp)
+    http_code=$(curl -s -o "$body_tmp" -w '%{http_code}' -X POST "$PORTAL_URL/pam/authorize" \
         -H "Authorization: Bearer $server_token" \
         -H "Content-Type: application/json" \
-        -d "{\"user\":\"$TEST_USER\",\"server_group\":\"bastion\",\"fingerprint\":\"$fingerprint\"}" 2>&1) || true
-    log_verbose "authorize(revoked) response: $response"
+        -d "{\"user\":\"$TEST_USER\",\"server_group\":\"bastion\",\"fingerprint\":\"$fingerprint\"}")
+    response=$(cat "$body_tmp")
+    rm -f "$body_tmp"
+    log_verbose "authorize(revoked) HTTP=$http_code body=$response"
 
-    if echo "$response" | jq -e '.authorized == true' >/dev/null 2>&1; then
+    if [[ "$http_code" != "200" ]]; then
+        fail "authorize(revoked) expected HTTP 200, got $http_code" "$response"
+        return 1
+    fi
+    if ! echo "$response" | jq -e 'type == "object" and has("authorized")' >/dev/null 2>&1; then
+        fail "authorize(revoked) did not return a valid JSON object" "$response"
+        return 1
+    fi
+    if ! echo "$response" | jq -e '.authorized == false' >/dev/null 2>&1; then
         fail "authorize should reject a cert revoked on LLNG side" "$response"
         return 1
     fi

--- a/tests/test_integration_maxsec.sh
+++ b/tests/test_integration_maxsec.sh
@@ -373,6 +373,131 @@ test_pam_authorize_endpoint() {
     fi
 }
 
+test_pam_authorize_fingerprint_binding() {
+    TESTS_RUN=$((TESTS_RUN + 1))
+    log "Testing /pam/authorize SSH fingerprint binding (PamAccess >= 0.1.16)..."
+
+    if [[ ! -f "${TEST_KEY}.pub" ]]; then
+        log_warn "No key available, skipping fingerprint binding test"
+        pass "Fingerprint binding test skipped (no key)"
+        return 0
+    fi
+
+    # LLNG SSHCA stores the SHA256 fingerprint of the user's *unsigned*
+    # public key in the persistent session. ssh-keygen -l -E sha256 -f pub
+    # computes the same value.
+    local fingerprint
+    fingerprint=$(ssh-keygen -l -E sha256 -f "${TEST_KEY}.pub" 2>/dev/null | awk '{print $2}')
+    if [[ -z "$fingerprint" || "$fingerprint" != SHA256:* ]]; then
+        fail "Could not compute SHA256 fingerprint of ${TEST_KEY}.pub"
+        return 1
+    fi
+    log_verbose "Computed fingerprint: $fingerprint"
+
+    local server_token
+    server_token=$(docker exec ob-maxsec-bastion cat /etc/open-bastion/server_token.json 2>/dev/null | jq -r '.access_token // empty') || true
+    if [[ -z "$server_token" ]]; then
+        fail "Could not get server token from bastion"
+        return 1
+    fi
+
+    # 1. Matching fingerprint must be accepted
+    local response
+    response=$(curl -s -X POST "$PORTAL_URL/pam/authorize" \
+        -H "Authorization: Bearer $server_token" \
+        -H "Content-Type: application/json" \
+        -d "{\"user\":\"$TEST_USER\",\"server_group\":\"bastion\",\"fingerprint\":\"$fingerprint\"}" 2>&1) || true
+    log_verbose "authorize(match) response: $response"
+    if ! echo "$response" | jq -e '.authorized == true' >/dev/null 2>&1; then
+        fail "authorize with matching fingerprint should succeed" "$response"
+        return 1
+    fi
+
+    # 2. Well-formed but unknown fingerprint must be refused
+    local bogus="SHA256:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+    response=$(curl -s -X POST "$PORTAL_URL/pam/authorize" \
+        -H "Authorization: Bearer $server_token" \
+        -H "Content-Type: application/json" \
+        -d "{\"user\":\"$TEST_USER\",\"server_group\":\"bastion\",\"fingerprint\":\"$bogus\"}" 2>&1) || true
+    log_verbose "authorize(unknown) response: $response"
+    if echo "$response" | jq -e '.authorized == true' >/dev/null 2>&1; then
+        fail "authorize with unknown fingerprint should be refused" "$response"
+        return 1
+    fi
+
+    # 3. Malformed fingerprint must be rejected with HTTP 400
+    local http_code
+    http_code=$(curl -s -o /dev/null -w '%{http_code}' -X POST "$PORTAL_URL/pam/authorize" \
+        -H "Authorization: Bearer $server_token" \
+        -H "Content-Type: application/json" \
+        -d "{\"user\":\"$TEST_USER\",\"server_group\":\"bastion\",\"fingerprint\":\"not-a-fingerprint\"}")
+    log_verbose "authorize(malformed) HTTP code: $http_code"
+    if [[ "$http_code" != "400" ]]; then
+        fail "authorize with malformed fingerprint should return 400 (got $http_code)"
+        return 1
+    fi
+
+    pass "/pam/authorize fingerprint binding works (match / unknown / malformed)"
+    return 0
+}
+
+test_pam_authorize_rejects_revoked_cert() {
+    TESTS_RUN=$((TESTS_RUN + 1))
+    log "Testing /pam/authorize rejects a cert revoked via /ssh/myrevoke..."
+
+    if [[ ! -f "${TEST_KEY}.pub" ]]; then
+        pass "Revocation test skipped (no key)"
+        return 0
+    fi
+
+    local fingerprint
+    fingerprint=$(ssh-keygen -l -E sha256 -f "${TEST_KEY}.pub" 2>/dev/null | awk '{print $2}')
+    if [[ -z "$fingerprint" ]]; then
+        fail "Could not compute fingerprint for revocation test"
+        return 1
+    fi
+
+    # Find the serial attached to this fingerprint in the user's cert list
+    local list
+    list=$(curl -sf "$PORTAL_URL/ssh/mycerts" -b "$COOKIE_FILE" 2>&1) || true
+    log_verbose "mycerts: $list"
+    local serial
+    serial=$(echo "$list" | jq -r --arg fp "$fingerprint" \
+        '(.certificates // []) | .[] | select(.fingerprint == $fp) | .serial' 2>/dev/null | head -n1)
+    if [[ -z "$serial" || "$serial" == "null" ]]; then
+        fail "Could not find serial for test cert in /ssh/mycerts" "$list"
+        return 1
+    fi
+    log_verbose "Revoking serial $serial"
+
+    # Self-revoke via /ssh/myrevoke (introduced in SSHCA >= 0.1.16)
+    local revoke_resp
+    revoke_resp=$(curl -s -X POST "$PORTAL_URL/ssh/myrevoke" \
+        -b "$COOKIE_FILE" \
+        -H "Content-Type: application/json" \
+        -d "{\"serial\":\"$serial\"}" 2>&1) || true
+    log_verbose "myrevoke: $revoke_resp"
+
+    # Now /pam/authorize with the revoked cert's fingerprint must fail,
+    # WITHOUT requiring the local KRL to be refreshed.
+    local server_token
+    server_token=$(docker exec ob-maxsec-bastion cat /etc/open-bastion/server_token.json 2>/dev/null | jq -r '.access_token // empty') || true
+    local response
+    response=$(curl -s -X POST "$PORTAL_URL/pam/authorize" \
+        -H "Authorization: Bearer $server_token" \
+        -H "Content-Type: application/json" \
+        -d "{\"user\":\"$TEST_USER\",\"server_group\":\"bastion\",\"fingerprint\":\"$fingerprint\"}" 2>&1) || true
+    log_verbose "authorize(revoked) response: $response"
+
+    if echo "$response" | jq -e '.authorized == true' >/dev/null 2>&1; then
+        fail "authorize should reject a cert revoked on LLNG side" "$response"
+        return 1
+    fi
+
+    pass "/pam/authorize rejects cert revoked via /ssh/myrevoke (no KRL refresh needed)"
+    return 0
+}
+
 test_token_introspection() {
     TESTS_RUN=$((TESTS_RUN + 1))
     log "Testing token introspection (with JWT client assertion)..."
@@ -673,6 +798,7 @@ main() {
     echo ""
     echo "=== Phase 4: PAM Module Tests ==="
     test_pam_authorize_endpoint
+    test_pam_authorize_fingerprint_binding
     test_token_introspection
     test_nss_user_resolution
     test_pam_cache
@@ -690,6 +816,12 @@ main() {
     test_krl_cron
     test_sudo_pam_config
     test_password_auth_disabled
+
+    echo ""
+    echo "=== Phase 7: Cert revocation via fingerprint binding ==="
+    # MUST run last: /ssh/myrevoke invalidates the test cert and would
+    # break any subsequent test that relies on a valid certificate.
+    test_pam_authorize_rejects_revoked_cert
 
     echo ""
     echo "=============================================="

--- a/tests/test_integration_maxsec.sh
+++ b/tests/test_integration_maxsec.sh
@@ -536,6 +536,66 @@ test_pam_authorize_rejects_revoked_cert() {
     return 0
 }
 
+# End-to-end validation: attempt a real SSH connection with the cert that
+# was just revoked on the LLNG side via /ssh/myrevoke. The local KRL on
+# the bastion is NOT refreshed (no cron in the demo containers), so sshd
+# accepts the cert at the pubkey layer. pam_openbastion.so then forwards
+# the SHA256 fingerprint to /pam/authorize (PAM `account` phase), LLNG
+# refuses, and the client gets a permission denial.
+#
+# This test proves the binding works bout-en-bout (module C + LLNG).
+test_ssh_connection_refused_after_revocation() {
+    TESTS_RUN=$((TESTS_RUN + 1))
+    log "Testing SSH connection is refused end-to-end after LLNG-side revocation..."
+
+    if [[ ! -f "${TEST_KEY}-cert.pub" ]]; then
+        log_warn "No certificate available, skipping e2e revocation SSH test"
+        pass "SSH e2e revocation test skipped (no certificate)"
+        return 0
+    fi
+
+    local output
+    output=$(ssh -i "${TEST_KEY}" \
+                 -o IdentitiesOnly=yes \
+                 -o StrictHostKeyChecking=no \
+                 -o UserKnownHostsFile=/dev/null \
+                 -o BatchMode=yes \
+                 -o ConnectTimeout=10 \
+                 -p 2222 \
+                 "${TEST_USER}@localhost" \
+                 "echo SHOULD_NEVER_PRINT" 2>&1) || true
+
+    log_verbose "SSH(revoked) output: $output"
+
+    if echo "$output" | grep -q "SHOULD_NEVER_PRINT"; then
+        fail "SSH with LLNG-revoked cert succeeded (expected denial)" "$output"
+        return 1
+    fi
+
+    if ! echo "$output" | grep -qE "Permission denied|Connection closed|Authentication failed"; then
+        fail "SSH with revoked cert did not fail with a permission-denial" "$output"
+        return 1
+    fi
+
+    # Best-effort: confirm pam_openbastion.so denied at account phase via
+    # the fingerprint binding rather than sshd's KRL (which has not been
+    # refreshed in the demo).
+    local bastion_log
+    bastion_log=$(docker exec ob-maxsec-bastion sh -c '
+        for f in /var/log/auth.log /var/log/syslog /var/log/messages; do
+            [ -r "$f" ] && tail -n 200 "$f"
+        done
+    ' 2>/dev/null) || true
+    if echo "$bastion_log" | grep -qE "PAM_AUTHZ_SSH_FP_REJECTED|SSH fingerprint not recognized"; then
+        log_verbose "Bastion confirmed /pam/authorize fingerprint rejection in logs"
+    else
+        log_warn "Could not find PAM_AUTHZ_SSH_FP_REJECTED in bastion logs (sshd KRL may have refused first, or logs not persisted)"
+    fi
+
+    pass "SSH with LLNG-revoked cert refused end-to-end (no KRL refresh needed)"
+    return 0
+}
+
 test_token_introspection() {
     TESTS_RUN=$((TESTS_RUN + 1))
     log "Testing token introspection (with JWT client assertion)..."
@@ -860,6 +920,7 @@ main() {
     # MUST run last: /ssh/myrevoke invalidates the test cert and would
     # break any subsequent test that relies on a valid certificate.
     test_pam_authorize_rejects_revoked_cert
+    test_ssh_connection_refused_after_revocation
 
     echo ""
     echo "=============================================="

--- a/tests/test_integration_maxsec.sh
+++ b/tests/test_integration_maxsec.sh
@@ -401,42 +401,61 @@ test_pam_authorize_fingerprint_binding() {
         return 1
     fi
 
-    # 1. Matching fingerprint must be accepted
-    local response
-    response=$(curl -s -X POST "$PORTAL_URL/pam/authorize" \
+    local body_tmp http_code response
+    body_tmp=$(mktemp)
+
+    # 1. Matching fingerprint must be accepted (HTTP 200 + authorized:true)
+    http_code=$(curl -s -o "$body_tmp" -w '%{http_code}' -X POST "$PORTAL_URL/pam/authorize" \
         -H "Authorization: Bearer $server_token" \
         -H "Content-Type: application/json" \
-        -d "{\"user\":\"$TEST_USER\",\"server_group\":\"bastion\",\"fingerprint\":\"$fingerprint\"}" 2>&1) || true
-    log_verbose "authorize(match) response: $response"
-    if ! echo "$response" | jq -e '.authorized == true' >/dev/null 2>&1; then
-        fail "authorize with matching fingerprint should succeed" "$response"
+        -d "{\"user\":\"$TEST_USER\",\"server_group\":\"bastion\",\"fingerprint\":\"$fingerprint\"}")
+    response=$(cat "$body_tmp")
+    log_verbose "authorize(match) HTTP=$http_code body=$response"
+    if [[ "$http_code" != "200" ]]; then
+        rm -f "$body_tmp"
+        fail "authorize(match) expected HTTP 200, got $http_code" "$response"
+        return 1
+    fi
+    if ! echo "$response" | jq -e 'type == "object" and .authorized == true' >/dev/null 2>&1; then
+        rm -f "$body_tmp"
+        fail "authorize(match) expected authorized:true" "$response"
         return 1
     fi
 
     # 2. Well-formed but unknown fingerprint must be refused
+    #    (HTTP 200 + authorized:false explicitly)
     local bogus="SHA256:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-    response=$(curl -s -X POST "$PORTAL_URL/pam/authorize" \
+    http_code=$(curl -s -o "$body_tmp" -w '%{http_code}' -X POST "$PORTAL_URL/pam/authorize" \
         -H "Authorization: Bearer $server_token" \
         -H "Content-Type: application/json" \
-        -d "{\"user\":\"$TEST_USER\",\"server_group\":\"bastion\",\"fingerprint\":\"$bogus\"}" 2>&1) || true
-    log_verbose "authorize(unknown) response: $response"
-    if echo "$response" | jq -e '.authorized == true' >/dev/null 2>&1; then
-        fail "authorize with unknown fingerprint should be refused" "$response"
+        -d "{\"user\":\"$TEST_USER\",\"server_group\":\"bastion\",\"fingerprint\":\"$bogus\"}")
+    response=$(cat "$body_tmp")
+    log_verbose "authorize(unknown) HTTP=$http_code body=$response"
+    if [[ "$http_code" != "200" ]]; then
+        rm -f "$body_tmp"
+        fail "authorize(unknown) expected HTTP 200, got $http_code" "$response"
+        return 1
+    fi
+    if ! echo "$response" | jq -e 'type == "object" and .authorized == false' >/dev/null 2>&1; then
+        rm -f "$body_tmp"
+        fail "authorize(unknown) expected authorized:false (not a jq parse failure)" "$response"
         return 1
     fi
 
     # 3. Malformed fingerprint must be rejected with HTTP 400
-    local http_code
-    http_code=$(curl -s -o /dev/null -w '%{http_code}' -X POST "$PORTAL_URL/pam/authorize" \
+    http_code=$(curl -s -o "$body_tmp" -w '%{http_code}' -X POST "$PORTAL_URL/pam/authorize" \
         -H "Authorization: Bearer $server_token" \
         -H "Content-Type: application/json" \
         -d "{\"user\":\"$TEST_USER\",\"server_group\":\"bastion\",\"fingerprint\":\"not-a-fingerprint\"}")
-    log_verbose "authorize(malformed) HTTP code: $http_code"
+    response=$(cat "$body_tmp")
+    log_verbose "authorize(malformed) HTTP=$http_code body=$response"
     if [[ "$http_code" != "400" ]]; then
-        fail "authorize with malformed fingerprint should return 400 (got $http_code)"
+        rm -f "$body_tmp"
+        fail "authorize(malformed) expected HTTP 400, got $http_code" "$response"
         return 1
     fi
 
+    rm -f "$body_tmp"
     pass "/pam/authorize fingerprint binding works (match / unknown / malformed)"
     return 0
 }
@@ -482,14 +501,33 @@ test_pam_authorize_rejects_revoked_cert() {
     # WITHOUT requiring the local KRL to be refreshed.
     local server_token
     server_token=$(docker exec ob-maxsec-bastion cat /etc/open-bastion/server_token.json 2>/dev/null | jq -r '.access_token // empty') || true
-    local response
-    response=$(curl -s -X POST "$PORTAL_URL/pam/authorize" \
+    if [[ -z "$server_token" ]]; then
+        fail "Could not get server token from bastion"
+        return 1
+    fi
+
+    local body_tmp http_code response
+    body_tmp=$(mktemp)
+    http_code=$(curl -s -o "$body_tmp" -w '%{http_code}' -X POST "$PORTAL_URL/pam/authorize" \
         -H "Authorization: Bearer $server_token" \
         -H "Content-Type: application/json" \
-        -d "{\"user\":\"$TEST_USER\",\"server_group\":\"bastion\",\"fingerprint\":\"$fingerprint\"}" 2>&1) || true
-    log_verbose "authorize(revoked) response: $response"
+        -d "{\"user\":\"$TEST_USER\",\"server_group\":\"bastion\",\"fingerprint\":\"$fingerprint\"}")
+    response=$(cat "$body_tmp")
+    rm -f "$body_tmp"
+    log_verbose "authorize(revoked) HTTP=$http_code body=$response"
 
-    if echo "$response" | jq -e '.authorized == true' >/dev/null 2>&1; then
+    # Require a real JSON response (not a 5xx / non-JSON error) and
+    # authorized:false explicitly — a jq parse failure should NOT let
+    # the test pass silently.
+    if [[ "$http_code" != "200" ]]; then
+        fail "authorize(revoked) expected HTTP 200, got $http_code" "$response"
+        return 1
+    fi
+    if ! echo "$response" | jq -e 'type == "object" and has("authorized")' >/dev/null 2>&1; then
+        fail "authorize(revoked) did not return a valid JSON object" "$response"
+        return 1
+    fi
+    if ! echo "$response" | jq -e '.authorized == false' >/dev/null 2>&1; then
         fail "authorize should reject a cert revoked on LLNG side" "$response"
         return 1
     fi


### PR DESCRIPTION
## Summary

- When the SSH session is authenticated with a CA-signed certificate, `pam_openbastion` now extracts the SHA256 fingerprint of the user key from `SSH_USER_AUTH` and sends it to LLNG in **both** `/pam/authorize` (PAM `account` phase, every SSH connection) and `/pam/verify` (token verification, used for `sudo` / re-auth).
- LLNG PamAccess >= 0.1.16 cross-checks this fingerprint against the user's persistent session (`_sshCerts`) and rejects the call if the cert is unknown, revoked or expired — **independently** of the local `sshd` KRL.
- Closes a gap where a cert revoked on the portal could still open a session or escalate via sudo until the KRL propagates (or at all if `RevokedKeys` was missing from `sshd_config`).

## Requires

- LLNG plugins: **PamAccess >= 0.1.16** and **SSHCA >= 0.1.16** (commits 84a0005, f9bd281 on the plugin repo). Backward compatible with older portals: the `fingerprint` field is ignored if the check is not implemented.

## Changes

### Code

- `include/ob_client.h`, `src/ob_client.c`: add `key_fingerprint` field to `ob_ssh_cert_info_t`; serialize it as top-level `fingerprint` on `/pam/authorize`. Add `fingerprint` parameter to `ob_verify_token`.
- `src/pam_openbastion.c`: populate `key_fingerprint` via `extract_ssh_key_fingerprint` in `extract_ssh_cert_info`; pass the fingerprint to `ob_verify_token` when `SSH_USER_AUTH` indicates cert auth.

### Docs

- `doc/bastion-architecture.md`, `doc/pam-modes.md`: document the new binding, both endpoints, and backward-compat with older LLNG.
- `doc/security/02-ssh-connection.md`, `99-risk-reduce.md`: update R-S3 and R-S15 mitigations and residual matrix. KRL remains the primary revocation mechanism; this is defense in depth for stale/missing KRL situations.

### Tests

- `tests/test_integration_{docker,maxsec}.sh`: new `test_pam_authorize_fingerprint_binding` (match / unknown / malformed) and `test_pam_authorize_rejects_revoked_cert` (`/ssh/myrevoke` → authorize refused without KRL refresh). The revocation test is scheduled last so the cert invalidation does not cascade.

### Version

- Bump to `0.1.5` in `CMakeLists.txt` and `rpm/open-bastion.spec`.
- `CHANGELOG.md` and `debian/changelog` intentionally **not** updated here — they will be refreshed in the release PR.

## Test plan

- [x] `cmake --build build && ctest` — unit tests pass (20/20 locally).
- [x] CI: `test_integration_docker.sh` passes, including the two new fingerprint tests.
- [x] CI: `test_integration_maxsec.sh` passes, including the two new fingerprint tests.
- [ ] Manual smoke on `docker-demo-maxsec`:
  - [ ] Sign a cert, SSH to bastion → accepted.
  - [ ] Revoke the cert via `/ssh/myrevoke`, do NOT refresh `/etc/ssh/revoked_keys`, re-SSH to bastion → refused at PAM `account` (authorize denied with `PAM_AUTHZ_SSH_FP_REJECTED`).
  - [ ] Same scenario with `sudo` from an existing session → `/pam/verify` returns `valid:false` / `PAM_AUTH_SSH_FP_REJECTED`.