### PR TITLE
Service accounts: auto-create Unix user + NSS pre-auth + Mode E pubkey

### DIFF
--- a/docker-demo-maxsec/bastion/Dockerfile
+++ b/docker-demo-maxsec/bastion/Dockerfile
@@ -49,8 +49,11 @@ RUN mkdir -p build && cd build && \
     cp nss/libnss_openbastion.so.2 /lib/x86_64-linux-gnu/ && \
     cp ../scripts/ob-session-recorder /usr/sbin/ && \
     cp ../scripts/ob-ssh-proxy /usr/bin/ && \
+    cp ../scripts/ob-service-account-keys /usr/local/bin/ && \
     chmod 755 /usr/sbin/ob-session-recorder && \
     chmod 755 /usr/bin/ob-ssh-proxy && \
+    chown root:root /usr/local/bin/ob-service-account-keys && \
+    chmod 755 /usr/local/bin/ob-service-account-keys && \
     ldconfig && \
     cd / && rm -rf /src/open-bastion/build
 

--- a/docker-demo-maxsec/bastion/entrypoint.sh
+++ b/docker-demo-maxsec/bastion/entrypoint.sh
@@ -146,8 +146,17 @@ TrustedUserCAKeys $SSH_CA_FILE
 # Enable certificate authentication
 PubkeyAuthentication yes
 
-# MAXIMUM SECURITY: No unsigned keys allowed
+# MAXIMUM SECURITY: No unsigned keys allowed via authorized_keys file
 AuthorizedKeysFile none
+
+# Service accounts (ansible, backup, ...) authenticate with a plain SSH key
+# that is NOT signed by the LLNG SSH CA. Mode E still accepts those keys
+# because AuthorizedKeysCommand yields the authorized public key only for
+# usernames registered in /etc/open-bastion/service-accounts.conf. Regular
+# human users continue to authenticate with an LLNG-signed certificate via
+# TrustedUserCAKeys above.
+AuthorizedKeysCommand /usr/local/bin/ob-service-account-keys %u
+AuthorizedKeysCommandUser nobody
 
 # MAXIMUM SECURITY: Key Revocation List (mandatory)
 RevokedKeys $SSH_REVOKED_KEYS
@@ -311,11 +320,39 @@ cache_enabled = true
 cache_dir = /var/cache/open-bastion
 cache_ttl = 300
 
+# Service accounts (ansible, backup, ...). Empty by default; the integration
+# test populates this file at runtime with a real fingerprint + matching
+# public key in /etc/open-bastion/service-accounts.d/.
+service_accounts_file = /etc/open-bastion/service-accounts.conf
+
+# Auto-create the local Unix account on first login. Required for service
+# accounts unknown to LLNG: pam_openbastion uses the uid/gid declared in
+# service-accounts.conf instead of NSS.
+create_user = true
+create_home = true
+default_shell = /bin/bash
+
 # Logging
 log_level = info
 EOF
 
 chmod 600 /etc/open-bastion/openbastion.conf
+
+# Provide a root-owned, empty service-accounts.conf so pam_openbastion's
+# permission check (root:root, 0600) succeeds at module init even when no
+# service account is registered yet. Integration tests append real entries.
+if [ ! -f /etc/open-bastion/service-accounts.conf ]; then
+    : > /etc/open-bastion/service-accounts.conf
+    chown root:root /etc/open-bastion/service-accounts.conf
+    chmod 600 /etc/open-bastion/service-accounts.conf
+fi
+
+# Directory for per-account authorized public keys used by
+# ob-service-account-keys (AuthorizedKeysCommand). Must be traversable by
+# the AuthorizedKeysCommandUser (nobody), files themselves are root:root 0644.
+mkdir -p /etc/open-bastion/service-accounts.d
+chown root:root /etc/open-bastion/service-accounts.d
+chmod 755 /etc/open-bastion/service-accounts.d
 
 # Create NSS configuration
 cat > /etc/open-bastion/nss_openbastion.conf << EOF
@@ -362,10 +399,21 @@ if command -v nscd >/dev/null 2>&1; then
 fi
 
 # Configure PAM for SSH (Mode E)
+# The "auth" phase runs pam_openbastion with authorize_only=yes so that:
+#   - for service accounts: the SSH key fingerprint is re-validated against
+#     service-accounts.conf (defense-in-depth on top of sshd's
+#     AuthorizedKeysCommand) and the ob_service_account marker is stored
+#     for pam_sm_open_session;
+#   - for regular users: the cert has already been validated by sshd, the
+#     module just returns success without asking for a password.
+# The "session" phase runs pam_openbastion with create_user=true so that
+# service accounts unknown to LLNG are materialised in /etc/passwd using
+# the uid/gid declared in service-accounts.conf.
 cat > /etc/pam.d/sshd << EOF
 # PAM configuration for SSH with Open Bastion (Mode E - Maximum Security)
-auth       required     pam_permit.so
+auth       required     pam_openbastion.so authorize_only
 account    required     pam_openbastion.so
+session    required     pam_openbastion.so create_user=true
 session    required     pam_unix.so
 session    optional     pam_mkhomedir.so skel=/etc/skel umask=0077
 EOF

--- a/docker-demo-token-svc/README.md
+++ b/docker-demo-token-svc/README.md
@@ -1,0 +1,95 @@
+# Open Bastion Demo — Token + Service Accounts
+
+Same as `docker-demo-token/` (LLNG tokens used as SSH passwords for human
+users) but also wires up **local service accounts** (`ansible`, `backup`,
+...) that authenticate via a plain SSH key declared in
+`/etc/open-bastion/service-accounts.conf` — **no SSH CA, no SSO
+signature, no LLNG involvement on the auth path**.
+
+## Two authentication flows in one bastion
+
+| User kind       | SSH auth         | How              |
+| --------------- | ---------------- | ---------------- |
+| Human           | Password (token) | Paste LLNG access token as the SSH password |
+| Service account | Public key       | sshd accepts the key via `AuthorizedKeysCommand` → pam_openbastion verifies the fingerprint against `service-accounts.conf` |
+
+Regular users can still `sudo` by re-entering their token (stock
+behaviour). Service accounts get `sudo` via `sudo_nopasswd = true`
+combined with a per-user `NOPASSWD:` rule in `/etc/sudoers`.
+
+## Quick start
+
+```bash
+cd docker-demo-token-svc
+docker compose up -d --build
+```
+
+### Human-user login (unchanged from docker-demo-token)
+
+```bash
+# Get an access token
+TOKEN=$(llng --llng-url http://localhost:80 \
+             --login dwho --password dwho \
+             --client-id pam-access --client-secret pamsecret \
+             access_token)
+
+ssh -p 2222 dwho@localhost
+# Password prompt: paste $TOKEN
+```
+
+### Register a service account
+
+```bash
+# Generate an SSH key locally
+ssh-keygen -t ed25519 -f ~/.ssh/ansible-ci -N ""
+
+# Install fingerprint + metadata on the bastion
+docker exec -i ob-token-svc-bastion sh -c \
+    'cat > /etc/open-bastion/service-accounts.conf' <<EOF
+[ansible-ci]
+key_fingerprint = $(ssh-keygen -l -E sha256 -f ~/.ssh/ansible-ci.pub | awk '{print $2}')
+sudo_allowed = true
+sudo_nopasswd = true
+gecos = Ansible Automation
+shell = /bin/bash
+home = /home/ansible-ci
+uid = 5000
+gid = 5000
+EOF
+docker exec ob-token-svc-bastion chmod 600 /etc/open-bastion/service-accounts.conf
+
+# Install the authorized public key
+docker cp ~/.ssh/ansible-ci.pub \
+    ob-token-svc-bastion:/etc/open-bastion/service-accounts.d/ansible-ci.pub
+docker exec ob-token-svc-bastion \
+    chmod 644 /etc/open-bastion/service-accounts.d/ansible-ci.pub
+
+# Allow passwordless sudo for this account
+docker exec ob-token-svc-bastion sh -c \
+    'echo "ansible-ci ALL=(ALL:ALL) NOPASSWD: ALL" >> /etc/sudoers'
+```
+
+### Log in as the service account
+
+```bash
+ssh -i ~/.ssh/ansible-ci -p 2222 ansible-ci@localhost
+# First login materialises /etc/passwd, /etc/group and /home/ansible-ci
+sudo id
+# uid=0(root) ...
+```
+
+## Integration test
+
+```bash
+./tests/test_integration_token_svc.sh --verbose
+```
+
+Covers: human-user LLNG auth, service-account provisioning, SSH login
+with plain key, local account materialisation, `sudo -n` via nopasswd,
+rejection of non-registered keys.
+
+## See also
+
+- `docker-demo-token/`  — token auth for humans only (no service accounts)
+- `docker-demo-maxsec/` — Mode E (SSH certificates) + service accounts
+- `doc/service-accounts.md` — canonical documentation

--- a/docker-demo-token-svc/backend/Dockerfile
+++ b/docker-demo-token-svc/backend/Dockerfile
@@ -1,0 +1,88 @@
+# Open Bastion SSH Backend - Token-based Authentication with User Creation
+#
+# This container provides:
+# - SSH password authentication using Open Bastion tokens
+# - Automatic user creation from Open Bastion attributes
+# - NSS module for user/group resolution
+# - Sudo authorization via Open Bastion
+
+FROM debian:13-slim
+
+# Install dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    openssh-server \
+    nscd \
+    sudo \
+    libcurl4-gnutls-dev \
+    libjson-c-dev \
+    libssl-dev \
+    libpam0g-dev \
+    curl \
+    jq \
+    openssl \
+    cmake \
+    gcc \
+    make \
+    && rm -rf /var/lib/apt/lists/*
+
+# Create directories (including JWKS cache for bastion JWT verification)
+RUN mkdir -p /var/run/sshd \
+    /var/cache/open-bastion \
+    && chmod 750 /var/cache/open-bastion
+
+# Build PAM and NSS modules from source (context is open-bastion/)
+COPY CMakeLists.txt /src/open-bastion/
+COPY src/ /src/open-bastion/src/
+COPY include/ /src/open-bastion/include/
+COPY nss/ /src/open-bastion/nss/
+COPY scripts/ /src/open-bastion/scripts/
+WORKDIR /src/open-bastion
+RUN mkdir -p build && cd build && \
+    cmake -DBUILD_TESTING=OFF .. && \
+    make -j$(nproc) && \
+    cp pam_openbastion.so /usr/lib/x86_64-linux-gnu/security/ && \
+    cp nss/libnss_openbastion.so.2 /lib/x86_64-linux-gnu/ && \
+    ldconfig && \
+    cd / && rm -rf /src/open-bastion/build
+
+# Configure PAM for SSH (backend mode with user creation and token auth)
+RUN echo '# PAM configuration for SSH Backend with Open Bastion\n\
+# Authentication via Open Bastion tokens (user pastes token as password)\n\
+auth       required     pam_openbastion.so\n\
+\n\
+# Authorization - check with Open Bastion\n\
+account    required     pam_openbastion.so\n\
+\n\
+# Session - create user if needed, then standard Unix\n\
+session    required     pam_openbastion.so create_user=true\n\
+session    required     pam_unix.so\n\
+' > /etc/pam.d/sshd
+
+# Configure PAM for sudo (Open Bastion authorization)
+RUN echo '# PAM configuration for sudo with Open Bastion\n\
+auth       required     pam_openbastion.so service_type=sudo\n\
+account    required     pam_openbastion.so service_type=sudo\n\
+session    required     pam_unix.so\n\
+' > /etc/pam.d/sudo
+
+# Configure NSS to use Open Bastion for passwd/group resolution
+RUN sed -i 's/^passwd:.*/passwd:         files openbastion/' /etc/nsswitch.conf && \
+    sed -i 's/^group:.*/group:          files openbastion/' /etc/nsswitch.conf
+
+# Sudo requires PAM authentication (no NOPASSWD)
+RUN echo "ALL ALL=(ALL:ALL) ALL" >> /etc/sudoers
+
+# Fix PAM loginuid for Docker
+RUN sed -i 's/session\s*required\s*pam_loginuid.so/session optional pam_loginuid.so/' /etc/pam.d/sshd 2>/dev/null || true
+
+# Generate SSH host keys
+RUN ssh-keygen -A
+
+# Startup script
+COPY docker-demo-token-svc/backend/entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+EXPOSE 22
+
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["/usr/sbin/sshd", "-D", "-e"]

--- a/docker-demo-token-svc/backend/entrypoint.sh
+++ b/docker-demo-token-svc/backend/entrypoint.sh
@@ -1,0 +1,304 @@
+#!/bin/bash
+# LLNG Backend Entrypoint - Token-based authentication
+# Uses LLNG tokens as SSH passwords (no SSH certificates)
+
+set -e
+
+PORTAL_URL="${LLNG_PORTAL_URL:-http://sso}"
+SERVER_GROUP="${LLNG_SERVER_GROUP:-backend}"
+CLIENT_ID="${LLNG_CLIENT_ID:-pam-access}"
+CLIENT_SECRET="${LLNG_CLIENT_SECRET:-pamsecret}"
+ADMIN_USER="${LLNG_ADMIN_USER:-dwho}"
+ADMIN_PASSWORD="${LLNG_ADMIN_PASSWORD:-dwho}"
+TOKEN_FILE="/etc/open-bastion/server_token.json"
+
+echo "=== LLNG Backend Starting (Token Auth Mode) ==="
+echo "Portal URL: $PORTAL_URL"
+echo "Server Group: $SERVER_GROUP"
+
+# Wait for SSO to be available
+echo "Waiting for SSO..."
+for i in {1..60}; do
+    if curl -sf "$PORTAL_URL/" >/dev/null 2>&1; then
+        echo "SSO is available"
+        break
+    fi
+    sleep 1
+done
+
+# Configure sshd for password authentication via PAM
+cat > /etc/ssh/sshd_config.d/llng-backend.conf << EOF
+# LemonLDAP::NG Backend Configuration (Token Auth Mode)
+
+# Disable public key authentication
+PubkeyAuthentication no
+
+# Enable password authentication via PAM
+PasswordAuthentication yes
+KbdInteractiveAuthentication yes
+
+# No agent forwarding on backend
+AllowAgentForwarding no
+
+# Use PAM for authentication AND authorization
+UsePAM yes
+
+# Security settings
+X11Forwarding no
+PermitRootLogin no
+
+# Accept bastion JWT environment variable from SSH connection
+AcceptEnv LLNG_BASTION_JWT
+EOF
+
+# Enroll server via Device Authorization Grant
+echo "=== Server Enrollment via Device Authorization ==="
+COOKIE_FILE="/tmp/admin_cookies"
+touch "$COOKIE_FILE"
+
+# Step 1: Get login token
+echo "Getting login token..."
+LOGIN_TOKEN=$(curl -s "$PORTAL_URL/" | grep -oP 'name="token" value="\K[^"]+' | head -1)
+echo "  Token: $LOGIN_TOKEN"
+
+# Step 2: Login as admin (don't follow redirect, cookie is set on 302 response)
+echo "Logging in as $ADMIN_USER..."
+LOGIN_RESP=$(curl -s -c "$COOKIE_FILE" \
+    -d "user=$ADMIN_USER" \
+    -d "password=$ADMIN_PASSWORD" \
+    -d "token=$LOGIN_TOKEN" \
+    "$PORTAL_URL/")
+
+# Verify login succeeded by checking cookie file
+if grep -q "lemonldap" "$COOKIE_FILE"; then
+    echo "Admin login successful"
+else
+    echo "ERROR: Failed to login as admin"
+    echo "Cookie file contents:"
+    cat "$COOKIE_FILE" || true
+    exit 1
+fi
+
+# Step 3: Initiate Device Authorization Grant with PKCE
+echo "Initiating Device Authorization Grant..."
+
+# Generate PKCE code_verifier (43-128 chars, URL-safe)
+CODE_VERIFIER=$(head -c 32 /dev/urandom | base64 | tr -d '=' | tr '+/' '-_')
+echo "  Generated code_verifier"
+
+# Calculate code_challenge = BASE64URL(SHA256(code_verifier))
+CODE_CHALLENGE=$(echo -n "$CODE_VERIFIER" | openssl sha256 -binary | base64 | tr -d '=' | tr '+/' '-_')
+echo "  Generated code_challenge"
+
+DEVICE_RESP=$(curl -s -X POST "$PORTAL_URL/oauth2/device" \
+    -d "client_id=$CLIENT_ID" \
+    -d "client_secret=$CLIENT_SECRET" \
+    -d "scope=pam pam:server" \
+    -d "code_challenge=$CODE_CHALLENGE" \
+    -d "code_challenge_method=S256")
+echo "  Device response: $DEVICE_RESP"
+
+DEVICE_CODE=$(echo "$DEVICE_RESP" | jq -r '.device_code // empty')
+USER_CODE=$(echo "$DEVICE_RESP" | jq -r '.user_code // empty')
+
+if [ -z "$DEVICE_CODE" ] || [ -z "$USER_CODE" ]; then
+    echo "ERROR: Failed to get device code"
+    echo "Response: $DEVICE_RESP"
+    exit 1
+fi
+
+echo "Device code obtained, user code: $USER_CODE"
+
+# Step 4: Approve the device code as admin
+# Remove dashes from user_code for URL
+USER_CODE_CLEAN=$(echo "$USER_CODE" | tr -d '-')
+
+echo "Approving device code..."
+# First GET the device page to get the form token
+DEVICE_PAGE=$(curl -s -b "$COOKIE_FILE" "$PORTAL_URL/device?user_code=$USER_CODE_CLEAN")
+FORM_TOKEN=$(echo "$DEVICE_PAGE" | grep -oP 'name="token" value="\K[^"]+' | head -1)
+
+# POST approval
+APPROVE_RESP=$(curl -s -b "$COOKIE_FILE" -X POST "$PORTAL_URL/device" \
+    -d "user_code=$USER_CODE_CLEAN" \
+    -d "action=approve" \
+    -d "token=$FORM_TOKEN")
+
+if echo "$APPROVE_RESP" | grep -q "approved\|success\|authorized"; then
+    echo "Device code approved"
+else
+    # Check if approval worked by trying to get token
+    echo "Checking approval status..."
+fi
+
+# Step 5: Poll for access token
+echo "Polling for access token..."
+for i in {1..30}; do
+    TOKEN_RESP=$(curl -s -X POST "$PORTAL_URL/oauth2/token" \
+        -d "grant_type=urn:ietf:params:oauth:grant-type:device_code" \
+        -d "device_code=$DEVICE_CODE" \
+        -d "client_id=$CLIENT_ID" \
+        -d "client_secret=$CLIENT_SECRET" \
+        -d "code_verifier=$CODE_VERIFIER")
+
+    ACCESS_TOKEN=$(echo "$TOKEN_RESP" | jq -r '.access_token // empty')
+
+    if [ -n "$ACCESS_TOKEN" ]; then
+        echo "Access token obtained!"
+        # Extract additional token info
+        REFRESH_TOKEN=$(echo "$TOKEN_RESP" | jq -r '.refresh_token // empty')
+        EXPIRES_IN=$(echo "$TOKEN_RESP" | jq -r '.expires_in // 3600')
+        NOW=$(date +%s)
+        EXPIRES_AT=$((NOW + EXPIRES_IN))
+        # Save in JSON format with metadata
+        cat > "$TOKEN_FILE" << TOKENEOF
+{
+  "access_token": "$ACCESS_TOKEN",
+  "refresh_token": "${REFRESH_TOKEN:-}",
+  "expires_at": $EXPIRES_AT,
+  "enrolled_at": $NOW
+}
+TOKENEOF
+        chmod 600 "$TOKEN_FILE"
+        echo "Token saved in JSON format (expires at: $(date -d "@$EXPIRES_AT" 2>/dev/null || echo "$EXPIRES_AT"))"
+        break
+    fi
+
+    ERROR=$(echo "$TOKEN_RESP" | jq -r '.error // empty')
+    if [ "$ERROR" = "authorization_pending" ] || [ "$ERROR" = "slow_down" ]; then
+        sleep 2
+    elif [ -n "$ERROR" ]; then
+        echo "ERROR: Token request failed: $ERROR"
+        echo "Response: $TOKEN_RESP"
+        exit 1
+    fi
+done
+
+if [ ! -f "$TOKEN_FILE" ]; then
+    echo "ERROR: Failed to obtain access token after polling"
+    exit 1
+fi
+
+echo "Server enrollment complete"
+rm -f "$COOKIE_FILE"
+
+# Create PAM Open Bastion configuration
+mkdir -p /etc/open-bastion
+cat > /etc/open-bastion/openbastion.conf << EOF
+# Open Bastion PAM configuration for Backend (Token Auth Mode)
+
+portal_url = $PORTAL_URL
+server_group = $SERVER_GROUP
+
+# Client credentials
+client_id = $CLIENT_ID
+client_secret = $CLIENT_SECRET
+
+# Server token for authorization
+server_token_file = $TOKEN_FILE
+
+# HTTP settings
+timeout = 10
+verify_ssl = false
+
+# Cache settings
+cache_enabled = true
+cache_dir = /var/cache/open-bastion
+cache_ttl = 300
+
+# User creation
+create_user = true
+create_home = true
+default_shell = /bin/bash
+
+# Bastion JWT verification (require connection from authorized bastion)
+bastion_jwt_required = true
+bastion_jwt_issuer = $PORTAL_URL
+bastion_jwt_jwks_url = $PORTAL_URL/.well-known/jwks.json
+bastion_jwt_jwks_cache = /var/cache/open-bastion/jwks.json
+bastion_jwt_cache_ttl = 3600
+bastion_jwt_clock_skew = 60
+
+# Logging
+log_level = info
+EOF
+
+chmod 600 /etc/open-bastion/openbastion.conf
+
+# Create NSS Open Bastion configuration
+cat > /etc/open-bastion/nss_openbastion.conf << EOF
+# Open Bastion NSS configuration
+
+portal_url = $PORTAL_URL
+server_token_file = $TOKEN_FILE
+
+# Cache settings
+cache_ttl = 300
+
+# UID/GID range for dynamic users
+min_uid = 10000
+max_uid = 60000
+default_gid = 100
+
+# Defaults
+default_shell = /bin/bash
+default_home_base = /home
+EOF
+
+chmod 644 /etc/open-bastion/nss_openbastion.conf
+
+# Configure NSS to use Open Bastion for user/group resolution
+sed -i 's/^passwd:.*/passwd:         files openbastion/' /etc/nsswitch.conf
+sed -i 's/^group:.*/group:          files openbastion/' /etc/nsswitch.conf
+echo "NSS configured to use Open Bastion"
+
+# Start nscd for caching NSS lookups (runs as root, can read server token)
+if command -v nscd >/dev/null 2>&1; then
+    mkdir -p /var/run/nscd
+    nscd -i passwd 2>/dev/null || true
+    nscd 2>/dev/null &
+    echo "nscd started for NSS caching"
+fi
+
+# Configure PAM for token-based authentication
+# pam_openbastion.so in auth validates the LLNG token as password
+cat > /etc/pam.d/sshd << EOF
+# PAM configuration for SSH with Open Bastion (Token Auth Mode)
+# User enters their LLNG token as password
+
+# Authentication: LLNG token validation
+auth       sufficient   pam_openbastion.so
+auth       required     pam_deny.so
+
+# Authorization: LLNG checks user access to server group
+account    required     pam_openbastion.so
+
+# Session management
+session    required     pam_unix.so
+session    optional     pam_mkhomedir.so skel=/etc/skel umask=0022
+EOF
+
+# Ensure sshd_config.d is included
+if ! grep -q "Include /etc/ssh/sshd_config.d" /etc/ssh/sshd_config; then
+    echo "Include /etc/ssh/sshd_config.d/*.conf" >> /etc/ssh/sshd_config
+fi
+
+# NSS module resolves users dynamically from LLNG
+echo "Testing NSS module..."
+if getent passwd dwho >/dev/null 2>&1; then
+    echo "  NSS module working: $(getent passwd dwho)"
+else
+    echo "  ERROR: NSS module not resolving users from LLNG"
+    exit 1
+fi
+
+echo "=== Backend Configuration Complete (Token Auth Mode) ==="
+echo "SSH listening on port 22"
+echo "Users connect with their LLNG token as password"
+echo "Sudo available for authorized users (rtyler)"
+echo ""
+echo "Bastion JWT verification ENABLED"
+echo "Direct SSH connections without valid bastion JWT will be DENIED"
+
+# Execute the command (sshd)
+exec "$@"

--- a/docker-demo-token-svc/bastion/Dockerfile
+++ b/docker-demo-token-svc/bastion/Dockerfile
@@ -1,0 +1,103 @@
+# Open Bastion SSH Bastion - Token + Service Accounts
+#
+# This container provides:
+# - SSH password authentication using Open Bastion tokens (human users)
+# - SSH key authentication for service accounts declared in
+#   /etc/open-bastion/service-accounts.conf (ansible, backup, ...)
+# - Session recording for audit
+# - PAM authorization via Open Bastion
+
+FROM debian:13-slim
+
+# Install dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    openssh-server \
+    nscd \
+    sudo \
+    libcurl4-gnutls-dev \
+    libjson-c-dev \
+    libssl-dev \
+    libpam0g-dev \
+    curl \
+    jq \
+    openssl \
+    cmake \
+    gcc \
+    make \
+    bsdutils \
+    && rm -rf /var/lib/apt/lists/*
+
+# Create directories
+RUN mkdir -p /var/run/sshd \
+    /var/cache/open-bastion \
+    /var/lib/open-bastion/sessions \
+    /etc/open-bastion \
+    && chmod 700 /var/lib/open-bastion/sessions \
+    && chmod 750 /var/cache/open-bastion
+
+# Build PAM module from source (context is open-bastion/)
+COPY CMakeLists.txt /src/open-bastion/
+COPY src/ /src/open-bastion/src/
+COPY include/ /src/open-bastion/include/
+COPY nss/ /src/open-bastion/nss/
+COPY scripts/ /src/open-bastion/scripts/
+WORKDIR /src/open-bastion
+RUN mkdir -p build && cd build && \
+    cmake -DBUILD_TESTING=OFF .. && \
+    make -j$(nproc) && \
+    cp pam_openbastion.so /usr/lib/x86_64-linux-gnu/security/ && \
+    cp nss/libnss_openbastion.so.2 /lib/x86_64-linux-gnu/ && \
+    cp ../scripts/ob-session-recorder /usr/sbin/ && \
+    cp ../scripts/ob-ssh-proxy /usr/bin/ && \
+    cp ../scripts/ob-service-account-keys /usr/local/bin/ && \
+    chmod 755 /usr/sbin/ob-session-recorder && \
+    chmod 755 /usr/bin/ob-ssh-proxy && \
+    chown root:root /usr/local/bin/ob-service-account-keys && \
+    chmod 755 /usr/local/bin/ob-service-account-keys && \
+    ldconfig && \
+    cd / && rm -rf /src/open-bastion/build
+
+# Configure PAM for SSH (bastion mode with token authentication)
+RUN echo '# PAM configuration for SSH Bastion with Open Bastion\n\
+# Authentication via Open Bastion tokens (user pastes token as password)\n\
+auth       required     pam_openbastion.so\n\
+\n\
+# Authorization - check with Open Bastion\n\
+account    required     pam_openbastion.so\n\
+\n\
+# Session - standard Unix\n\
+session    required     pam_unix.so\n\
+session    optional     pam_openbastion.so\n\
+' > /etc/pam.d/sshd
+
+# Configure PAM for sudo (Open Bastion authorization)
+RUN echo '# PAM configuration for sudo with Open Bastion\n\
+auth       required     pam_openbastion.so service_type=sudo\n\
+account    required     pam_openbastion.so service_type=sudo\n\
+session    required     pam_unix.so\n\
+' > /etc/pam.d/sudo
+
+# Sudo requires PAM authentication (no NOPASSWD)
+RUN echo "ALL ALL=(ALL:ALL) ALL" >> /etc/sudoers
+
+# Session recorder configuration
+RUN echo '# Open Bastion Session Recorder Configuration\n\
+sessions_dir = /var/lib/open-bastion/sessions\n\
+format = script\n\
+max_duration = 28800\n\
+' > /etc/open-bastion/session-recorder.conf
+
+# Fix PAM loginuid for Docker
+RUN sed -i 's/session\s*required\s*pam_loginuid.so/session optional pam_loginuid.so/' /etc/pam.d/sshd 2>/dev/null || true
+
+# Generate SSH host keys
+RUN ssh-keygen -A
+
+# Startup script
+COPY docker-demo-token-svc/bastion/entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+EXPOSE 22
+
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["/usr/sbin/sshd", "-D", "-e"]

--- a/docker-demo-token-svc/bastion/entrypoint.sh
+++ b/docker-demo-token-svc/bastion/entrypoint.sh
@@ -326,9 +326,16 @@ session    required     pam_unix.so
 session    optional     pam_mkhomedir.so skel=/etc/skel umask=0022
 EOF
 
-# Fix session recording directory permissions
+# Session recording directory: match production permissions
+# (1770 root:ob-sessions). Only root and the recorder group may write
+# there — regular users cannot fill the volume or interfere with
+# recorder output.
+if ! getent group ob-sessions >/dev/null 2>&1; then
+    groupadd --system ob-sessions
+fi
 mkdir -p /var/lib/open-bastion/sessions
-chmod 1777 /var/lib/open-bastion/sessions
+chown root:ob-sessions /var/lib/open-bastion/sessions
+chmod 1770 /var/lib/open-bastion/sessions
 
 # Ensure sshd_config.d is included
 if ! grep -q "Include /etc/ssh/sshd_config.d" /etc/ssh/sshd_config; then

--- a/docker-demo-token-svc/bastion/entrypoint.sh
+++ b/docker-demo-token-svc/bastion/entrypoint.sh
@@ -1,0 +1,357 @@
+#!/bin/bash
+# LLNG Bastion Entrypoint - Token-based authentication
+# Uses LLNG tokens as SSH passwords (no SSH certificates)
+
+set -e
+
+PORTAL_URL="${LLNG_PORTAL_URL:-http://sso}"
+SERVER_GROUP="${LLNG_SERVER_GROUP:-bastion}"
+CLIENT_ID="${LLNG_CLIENT_ID:-pam-access}"
+CLIENT_SECRET="${LLNG_CLIENT_SECRET:-pamsecret}"
+ADMIN_USER="${LLNG_ADMIN_USER:-dwho}"
+ADMIN_PASSWORD="${LLNG_ADMIN_PASSWORD:-dwho}"
+TOKEN_FILE="/etc/open-bastion/server_token.json"
+
+echo "=== LLNG Bastion Starting (Token Auth Mode) ==="
+echo "Portal URL: $PORTAL_URL"
+echo "Server Group: $SERVER_GROUP"
+
+# Wait for SSO to be available
+echo "Waiting for SSO..."
+for i in {1..60}; do
+    if curl -sf "$PORTAL_URL/" >/dev/null 2>&1; then
+        echo "SSO is available"
+        break
+    fi
+    sleep 1
+done
+
+# Configure sshd for both password (human users) and pubkey (service
+# accounts) auth. AuthorizedKeysCommand yields a key only for usernames
+# declared in /etc/open-bastion/service-accounts.conf, so plain pubkey
+# auth is effectively restricted to those service accounts.
+cat > /etc/ssh/sshd_config.d/llng-bastion.conf << EOF
+# LemonLDAP::NG Bastion Configuration (Token Auth Mode + Service Accounts)
+
+# Enable public key authentication for service accounts. AuthorizedKeysFile
+# is "none" - sshd only resolves authorized keys via AuthorizedKeysCommand,
+# which is scoped to registered service accounts.
+PubkeyAuthentication yes
+AuthorizedKeysFile none
+AuthorizedKeysCommand /usr/local/bin/ob-service-account-keys %u
+AuthorizedKeysCommandUser nobody
+
+# Expose SSH auth details to PAM so pam_openbastion can re-verify the
+# public-key fingerprint from SSH_USER_AUTH against service-accounts.conf
+# in pam_sm_acct_mgmt (defense-in-depth).
+ExposeAuthInfo yes
+
+# Enable password authentication via PAM (LLNG token as password)
+PasswordAuthentication yes
+KbdInteractiveAuthentication yes
+
+# Allow agent forwarding for ProxyJump to backend
+AllowAgentForwarding yes
+AllowTcpForwarding yes
+
+# Use PAM for authentication AND authorization
+UsePAM yes
+
+# Security settings
+X11Forwarding no
+PermitRootLogin no
+EOF
+
+# Enroll server via Device Authorization Grant
+echo "=== Server Enrollment via Device Authorization ==="
+COOKIE_FILE="/tmp/admin_cookies"
+touch "$COOKIE_FILE"
+
+# Step 1: Get login token
+echo "Getting login token..."
+LOGIN_TOKEN=$(curl -s "$PORTAL_URL/" | grep -oP 'name="token" value="\K[^"]+' | head -1)
+echo "  Token: $LOGIN_TOKEN"
+
+# Step 2: Login as admin (don't follow redirect, cookie is set on 302 response)
+echo "Logging in as $ADMIN_USER..."
+LOGIN_RESP=$(curl -s -c "$COOKIE_FILE" \
+    -d "user=$ADMIN_USER" \
+    -d "password=$ADMIN_PASSWORD" \
+    -d "token=$LOGIN_TOKEN" \
+    "$PORTAL_URL/")
+
+# Verify login succeeded by checking cookie file
+if grep -q "lemonldap" "$COOKIE_FILE"; then
+    echo "Admin login successful"
+else
+    echo "ERROR: Failed to login as admin"
+    echo "Cookie file contents:"
+    cat "$COOKIE_FILE" || true
+    exit 1
+fi
+
+# Step 3: Initiate Device Authorization Grant with PKCE (RFC 7636)
+echo "Initiating Device Authorization Grant with PKCE..."
+
+# Generate PKCE code_verifier (32 bytes of random data, base64url encoded)
+CODE_VERIFIER=$(head -c 32 /dev/urandom | openssl base64 -e -A | tr '+/' '-_' | tr -d '=')
+# Generate code_challenge = BASE64URL(SHA256(code_verifier))
+CODE_CHALLENGE=$(echo -n "$CODE_VERIFIER" | openssl dgst -sha256 -binary | openssl base64 -e -A | tr '+/' '-_' | tr -d '=')
+echo "  PKCE enabled (code_challenge_method=S256)"
+
+DEVICE_RESP=$(curl -s -X POST "$PORTAL_URL/oauth2/device" \
+    -d "client_id=$CLIENT_ID" \
+    -d "client_secret=$CLIENT_SECRET" \
+    -d "scope=pam pam:server" \
+    -d "code_challenge=$CODE_CHALLENGE" \
+    -d "code_challenge_method=S256")
+echo "  Device response: $DEVICE_RESP"
+
+DEVICE_CODE=$(echo "$DEVICE_RESP" | jq -r '.device_code // empty')
+USER_CODE=$(echo "$DEVICE_RESP" | jq -r '.user_code // empty')
+
+if [ -z "$DEVICE_CODE" ] || [ -z "$USER_CODE" ]; then
+    echo "ERROR: Failed to get device code"
+    echo "Response: $DEVICE_RESP"
+    exit 1
+fi
+
+echo "Device code obtained, user code: $USER_CODE"
+
+# Step 4: Approve the device code as admin
+# Remove dashes from user_code for URL
+USER_CODE_CLEAN=$(echo "$USER_CODE" | tr -d '-')
+
+echo "Approving device code..."
+# First GET the device page to get the form token
+DEVICE_PAGE=$(curl -s -b "$COOKIE_FILE" "$PORTAL_URL/device?user_code=$USER_CODE_CLEAN")
+FORM_TOKEN=$(echo "$DEVICE_PAGE" | grep -oP 'name="token" value="\K[^"]+' | head -1)
+
+# POST approval
+APPROVE_RESP=$(curl -s -b "$COOKIE_FILE" -X POST "$PORTAL_URL/device" \
+    -d "user_code=$USER_CODE_CLEAN" \
+    -d "action=approve" \
+    -d "token=$FORM_TOKEN")
+
+if echo "$APPROVE_RESP" | grep -q "approved\|success\|authorized"; then
+    echo "Device code approved"
+else
+    # Check if approval worked by trying to get token
+    echo "Checking approval status..."
+fi
+
+# Step 5: Poll for access token (with PKCE code_verifier)
+echo "Polling for access token..."
+for i in {1..30}; do
+    TOKEN_RESP=$(curl -s -X POST "$PORTAL_URL/oauth2/token" \
+        -d "grant_type=urn:ietf:params:oauth:grant-type:device_code" \
+        -d "device_code=$DEVICE_CODE" \
+        -d "client_id=$CLIENT_ID" \
+        -d "client_secret=$CLIENT_SECRET" \
+        -d "code_verifier=$CODE_VERIFIER")
+
+    ACCESS_TOKEN=$(echo "$TOKEN_RESP" | jq -r '.access_token // empty')
+
+    if [ -n "$ACCESS_TOKEN" ]; then
+        echo "Access token obtained!"
+        # Extract additional token info
+        REFRESH_TOKEN=$(echo "$TOKEN_RESP" | jq -r '.refresh_token // empty')
+        EXPIRES_IN=$(echo "$TOKEN_RESP" | jq -r '.expires_in // 3600')
+        NOW=$(date +%s)
+        EXPIRES_AT=$((NOW + EXPIRES_IN))
+        # Save in JSON format with metadata
+        cat > "$TOKEN_FILE" << TOKENEOF
+{
+  "access_token": "$ACCESS_TOKEN",
+  "refresh_token": "${REFRESH_TOKEN:-}",
+  "expires_at": $EXPIRES_AT,
+  "enrolled_at": $NOW
+}
+TOKENEOF
+        chmod 600 "$TOKEN_FILE"
+        echo "Token saved in JSON format (expires at: $(date -d "@$EXPIRES_AT" 2>/dev/null || echo "$EXPIRES_AT"))"
+        break
+    fi
+
+    ERROR=$(echo "$TOKEN_RESP" | jq -r '.error // empty')
+    if [ "$ERROR" = "authorization_pending" ] || [ "$ERROR" = "slow_down" ]; then
+        sleep 2
+    elif [ -n "$ERROR" ]; then
+        echo "ERROR: Token request failed: $ERROR"
+        echo "Response: $TOKEN_RESP"
+        exit 1
+    fi
+done
+
+if [ ! -f "$TOKEN_FILE" ]; then
+    echo "ERROR: Failed to obtain access token after polling"
+    exit 1
+fi
+
+echo "Server enrollment complete"
+rm -f "$COOKIE_FILE"
+
+# Create PAM Open Bastion configuration
+mkdir -p /etc/open-bastion
+cat > /etc/open-bastion/openbastion.conf << EOF
+# Open Bastion PAM configuration for Bastion (Token Auth Mode)
+
+portal_url = $PORTAL_URL
+server_group = $SERVER_GROUP
+
+# Client credentials
+client_id = $CLIENT_ID
+client_secret = $CLIENT_SECRET
+
+# Server token for authorization
+server_token_file = $TOKEN_FILE
+
+# HTTP settings
+timeout = 10
+verify_ssl = false
+
+# Cache settings
+cache_enabled = true
+cache_dir = /var/cache/open-bastion
+cache_ttl = 300
+
+# Service accounts (ansible, backup, ...). Initially empty; the integration
+# test populates this file at runtime with a real fingerprint + matching
+# public key in /etc/open-bastion/service-accounts.d/.
+service_accounts_file = /etc/open-bastion/service-accounts.conf
+
+# Auto-create the local Unix account on first login. Required for service
+# accounts unknown to LLNG (pam_openbastion uses the uid/gid declared in
+# service-accounts.conf instead of NSS).
+create_user = true
+create_home = true
+default_shell = /bin/bash
+
+# Logging
+log_level = info
+EOF
+
+chmod 600 /etc/open-bastion/openbastion.conf
+
+# Root-owned, empty service-accounts.conf so pam_openbastion's permission
+# check (root:root, 0600) succeeds at module init even when no service
+# account is registered yet.
+if [ ! -f /etc/open-bastion/service-accounts.conf ]; then
+    : > /etc/open-bastion/service-accounts.conf
+    chown root:root /etc/open-bastion/service-accounts.conf
+    chmod 600 /etc/open-bastion/service-accounts.conf
+fi
+
+# Directory consumed by ob-service-account-keys (AuthorizedKeysCommand).
+# Traversable by the AuthorizedKeysCommandUser (nobody); .pub files are
+# root:root 0644.
+mkdir -p /etc/open-bastion/service-accounts.d
+chown root:root /etc/open-bastion/service-accounts.d
+chmod 755 /etc/open-bastion/service-accounts.d
+
+# Create NSS Open Bastion configuration
+cat > /etc/open-bastion/nss_openbastion.conf << EOF
+# Open Bastion NSS configuration
+
+portal_url = $PORTAL_URL
+server_token_file = $TOKEN_FILE
+
+# Cache settings
+cache_ttl = 300
+
+# UID/GID range for dynamic users
+min_uid = 10000
+max_uid = 60000
+default_gid = 100
+
+# Defaults
+default_shell = /bin/bash
+default_home_base = /home
+EOF
+
+chmod 644 /etc/open-bastion/nss_openbastion.conf
+
+# Create SSH proxy configuration for bastion-to-backend connections
+cat > /etc/open-bastion/ssh-proxy.conf << EOF
+# Open Bastion SSH Proxy configuration
+# Used by ob-ssh-proxy to request JWT for bastion-to-backend auth
+
+PORTAL_URL=$PORTAL_URL
+SERVER_TOKEN_FILE=$TOKEN_FILE
+SERVER_GROUP=$SERVER_GROUP
+TARGET_GROUP=backend
+TIMEOUT=10
+VERIFY_SSL=false
+SSH_OPTIONS="-o StrictHostKeyChecking=no"
+DEBUG=false
+EOF
+chmod 644 /etc/open-bastion/ssh-proxy.conf
+echo "SSH proxy configured for bastion-to-backend authentication"
+
+# Configure NSS to use Open Bastion for user/group resolution
+sed -i 's/^passwd:.*/passwd:         files openbastion/' /etc/nsswitch.conf
+sed -i 's/^group:.*/group:          files openbastion/' /etc/nsswitch.conf
+echo "NSS configured to use Open Bastion"
+
+# Start nscd for caching NSS lookups (runs as root, can read server token)
+if command -v nscd >/dev/null 2>&1; then
+    mkdir -p /var/run/nscd
+    nscd -i passwd 2>/dev/null || true
+    nscd 2>/dev/null &
+    echo "nscd started for NSS caching"
+fi
+
+# Configure PAM for token-based authentication + service accounts.
+# Human users: pam_openbastion validates the LLNG token (password auth).
+# Service accounts: sshd accepted the key via AuthorizedKeysCommand; for
+# pubkey auth sshd does NOT call pam_authenticate, so the marker and
+# gecos/shell/home data are populated in pam_sm_acct_mgmt. The session
+# phase materialises the local Unix account using the uid/gid declared
+# in service-accounts.conf (pam_openbastion.so create_user=true).
+cat > /etc/pam.d/sshd << EOF
+# PAM configuration for SSH with Open Bastion
+# (Token Auth Mode + Service Accounts)
+
+# Authentication: LLNG token validation (human users only — pubkey auth
+# skips this phase, see pam_sm_acct_mgmt for service-account handling).
+auth       sufficient   pam_openbastion.so
+auth       required     pam_deny.so
+
+# Authorization: LLNG / service-account check
+account    required     pam_openbastion.so
+
+# Session: auto-create the Unix account on first login
+session    required     pam_openbastion.so create_user=true
+session    required     pam_unix.so
+session    optional     pam_mkhomedir.so skel=/etc/skel umask=0022
+EOF
+
+# Fix session recording directory permissions
+mkdir -p /var/lib/open-bastion/sessions
+chmod 1777 /var/lib/open-bastion/sessions
+
+# Ensure sshd_config.d is included
+if ! grep -q "Include /etc/ssh/sshd_config.d" /etc/ssh/sshd_config; then
+    echo "Include /etc/ssh/sshd_config.d/*.conf" >> /etc/ssh/sshd_config
+fi
+
+# NSS module resolves users dynamically from LLNG
+echo "Testing NSS module..."
+if getent passwd dwho >/dev/null 2>&1; then
+    echo "  NSS module working: $(getent passwd dwho)"
+else
+    echo "  ERROR: NSS module not resolving users from LLNG"
+    exit 1
+fi
+
+echo "=== Bastion Configuration Complete (Token Auth Mode) ==="
+echo "SSH listening on port 22"
+echo "Users connect with: ssh -p 2222 <username>@localhost"
+echo "Password: Use your LLNG access token"
+echo ""
+echo "To connect to backend via bastion:"
+echo "  From bastion: ob-ssh-proxy backend"
+echo "  Or: ssh -o ProxyCommand='ob-ssh-proxy %h %p' backend"
+
+# Execute the command (sshd)
+exec "$@"

--- a/docker-demo-token-svc/docker-compose.yml
+++ b/docker-demo-token-svc/docker-compose.yml
@@ -1,0 +1,91 @@
+# Open Bastion Token-based Authentication Demo + Service Accounts
+#
+# Same as docker-demo-token (LLNG tokens used as SSH passwords for human
+# users) plus local service accounts (ansible, backup, ...) declared in
+# /etc/open-bastion/service-accounts.conf and authenticated via a plain
+# SSH key that is NOT signed by any SSH CA.
+#
+# Architecture:
+#   - sso:     LLNG Portal (PAM Access + Device Authorization, no SSH CA)
+#   - bastion: token-auth SSH bastion, also serves service-account keys
+#   - backend: token-auth SSH backend, also serves service-account keys
+#
+# Usage:
+#   docker compose up -d
+#   # Regular user (token as password):
+#   #   llng --llng-url http://localhost:80 --login dwho --password dwho llng_cookie
+#   #   ssh -p 2222 dwho@localhost
+#   # Service account (SSH key):
+#   #   docker exec ob-token-svc-bastion sh -c '...populate service-accounts.conf...'
+#   #   ssh -p 2222 -i ~/.ssh/ansible-ci ansible-ci@localhost
+
+services:
+  sso:
+    build:
+      context: ./sso
+      dockerfile: Dockerfile
+    image: ob-token-svc-sso
+    container_name: ob-token-svc-sso
+    ports:
+      - "80:8080"
+    volumes:
+      - ./lmConf-1.json:/var/lib/lemonldap-ng/conf/lmConf-1.json:ro
+    environment:
+      - SSODOMAIN=example.com
+      - PORTAL=http://localhost
+    healthcheck:
+      test: ["CMD", "curl", "-sf", "http://localhost:8080/"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+    networks:
+      ob-token-svc-net:
+        aliases:
+          - sso
+          - auth.example.com
+
+  bastion:
+    build:
+      context: ..
+      dockerfile: docker-demo-token-svc/bastion/Dockerfile
+    image: ob-token-svc-bastion
+    container_name: ob-token-svc-bastion
+    ports:
+      - "2222:22"
+    depends_on:
+      sso:
+        condition: service_healthy
+    environment:
+      - LLNG_PORTAL_URL=http://sso:8080
+      - LLNG_SERVER_GROUP=bastion
+      - LLNG_CLIENT_ID=pam-access
+      - LLNG_CLIENT_SECRET=pamsecret
+      - LLNG_ADMIN_USER=dwho
+      - LLNG_ADMIN_PASSWORD=dwho
+    networks:
+      - ob-token-svc-net
+
+  backend:
+    build:
+      context: ..
+      dockerfile: docker-demo-token-svc/backend/Dockerfile
+    image: ob-token-svc-backend
+    container_name: ob-token-svc-backend
+    expose:
+      - "22"
+    depends_on:
+      sso:
+        condition: service_healthy
+    environment:
+      - LLNG_PORTAL_URL=http://sso:8080
+      - LLNG_SERVER_GROUP=backend
+      - LLNG_CLIENT_ID=pam-access
+      - LLNG_CLIENT_SECRET=pamsecret
+      - LLNG_ADMIN_USER=dwho
+      - LLNG_ADMIN_PASSWORD=dwho
+    networks:
+      - ob-token-svc-net
+
+networks:
+  ob-token-svc-net:
+    driver: bridge

--- a/docker-demo-token-svc/lmConf-1.json
+++ b/docker-demo-token-svc/lmConf-1.json
@@ -1,0 +1,185 @@
+{
+  "cfgNum": "1",
+  "cfgAuthor": "docker-compose",
+  "cfgDate": 1734400000,
+  "cfgVersion": "2.20.0",
+
+  "authentication": "Demo",
+  "userDB": "Same",
+  "passwordDB": "Demo",
+  "registerDB": "Demo",
+
+  "portal": "http://localhost/",
+  "domain": "",
+  "cookieName": "lemonldap",
+  "securedCookie": 0,
+  "https": 0,
+  "timeout": 72000,
+  "whatToTrace": "uid",
+
+  "demoExportedVars": {
+    "cn": "cn",
+    "mail": "mail",
+    "uid": "uid"
+  },
+
+  "globalStorage": "Apache::Session::File",
+  "globalStorageOptions": {
+    "Directory": "/var/lib/lemonldap-ng/sessions",
+    "LockDirectory": "/var/lib/lemonldap-ng/sessions/lock",
+    "generateModule": "Lemonldap::NG::Common::Apache::Session::Generate::SHA256"
+  },
+
+  "localSessionStorage": "Cache::FileCache",
+  "localSessionStorageOptions": {
+    "cache_root": "/tmp",
+    "namespace": "lemonldap-ng-sessions",
+    "default_expires_in": 600
+  },
+
+  "locationRules": {
+    "auth.example.com": {
+      "^/device": "$uid eq 'dwho'",
+      "default": "accept"
+    },
+    "localhost": {
+      "^/device": "$uid eq 'dwho'",
+      "default": "accept"
+    },
+    "sso": {
+      "^/device": "$uid eq 'dwho'",
+      "default": "accept"
+    }
+  },
+
+  "portalSkin": "bootstrap",
+  "loginHistoryEnabled": 0,
+
+  "issuerDBOpenIDConnectActivation": 1,
+  "oidcServiceMetaDataAuthorizeURI": "authorize",
+  "oidcServiceMetaDataTokenURI": "token",
+  "oidcServiceMetaDataUserInfoURI": "userinfo",
+  "oidcServiceMetaDataJWKSURI": "jwks",
+  "oidcServiceMetaDataEndSessionURI": "logout",
+  "oidcServiceMetaDataIntrospectionURI": "introspect",
+  "oidcServiceMetaDataRegistrationURI": "register",
+  "oidcServiceMetaDataCheckSessionURI": "check_session",
+  "oidcServiceMetaDataRevokeURI": "revoke",
+  "oidcServiceAllowHybridFlow": 1,
+  "oidcServiceAllowImplicitFlow": 1,
+  "oidcServiceAllowAuthorizationCodeFlow": 1,
+
+  "oidcServicePrivateKeySig": "-----BEGIN RSA PRIVATE KEY-----\nMIIEowIBAAKCAQEAs2jsmIoFuWzMkilJaA8//5/T30cnuzX9GImXUrFR2k9EKTMt\nGMHCdKlWOl3BV+BTAU9TLz7Jzd/iJ5GJ6B8TrH1PHFmHpy8/qE/S5OhinIpIi7eb\nABqnoVcwDdCa8ugzq8k8SWxhRNXfVIlwz4NH1caJ8lmiERFj7IvNKqEhzAk0pyDr\n8hubveTC39xREujKlsqutpPAFPJ3f2ybVsdykX5rx0h5SslG3jVWYhZ/SOb2aIzO\nr0RMjhQmsYRwbpt3anjlBZ98aOzg7GAkbO8093X5VVk9vaPRg0zxJQ0Do0YLyzkR\nisSAIFb0tdKuDnjRGK6y/N2j6At2HjkxntbtGQIDAQABAoIBADYq6LxJd977LWy3\n0HT9nboFPIf+SM2qSEc/S5Po+6ipJBA4ZlZCMf7dHa6znet1TDpqA9iQ4YcqIHMH\n6xZNQ7hhgSAzG9TrXBHqP+djDlrrGWotvjuy0IfS9ixFnnLWjrtAH9afRWLuG+a/\nNHNC1M6DiiTE0TzL/lpt/zzut3CNmWzH+t19X6UsxUg95AzooEeewEYkv25eumWD\nmfQZfCtSlIw1sp/QwxeJa/6LJw7KcPZ1wXUm1BN0b9eiKt9Cmni1MS7elgpZlgGt\nxtfGTZtNLQ7bgDiM8MHzUfPBhbceNSIx2BeCuOCs/7eaqgpyYHBbAbuBQex2H61l\nLcc3Tz0CgYEA4Kx/avpCPxnvsJ+nHVQm5d/WERuDxk4vH1DNuCYBvXTdVCGADf6a\nF5No1JcTH3nPTyPWazOyGdT9LcsEJicLyD8vCM6hBFstG4XjqcAuqG/9DRsElpHQ\nyi1zc5DNP7Vxmiz9wII0Mjy0abYKtxnXh9YK4a9g6wrcTpvShhIcIb8CgYEAzGzG\nlorVCfX9jXULIznnR/uuP5aSnTEsn0xJeqTlbW0RFWLdj8aIL1peirh1X89HroB9\nGeTNqEJXD+3CVL2cx+BRggMDUmEz4hR59meZCDGUyT5fex4LIsceb/ESUl2jo6Sw\nHXwWbN67rQ55N4oiOcOppsGxzOHkl5HdExKidycCgYEAr5Qev2tz+fw65LzfzHvH\nKj4S/KuT/5V6He731cFd+sEpdmX3vPgLVAFPG1Q1DZQT/rTzDDQKK0XX1cGiLG63\nNnaqOye/jbfzOF8Z277kt51NFMDYhRLPKDD82IOA4xjY/rPKWndmcxwdob8yAIWh\nefY76sMz6ntCT+xWSZA9i+ECgYBWMZM2TIlxLsBfEbfFfZewOUWKWEGvd9l5vV/K\nD5cRIYivfMUw5yPq2267jPUolayCvniBH4E7beVpuPVUZ7KgcEvNxtlytbt7muil\n5Z6X3tf+VodJ0Swe2NhTmNEB26uwxzLe68BE3VFCsbSYn2y48HAq+MawPZr18bHG\nZfgMxwKBgHHRg6HYqF5Pegzk1746uH2G+OoCovk5ylGGYzcH2ghWTK4agCHfBcDt\nEYqYAev/l82wi+OZ5O8U+qjFUpT1CVeUJdDs0o5u19v0UJjunU1cwh9jsxBZAWLy\nPAGd6SWf4S3uQCTw6dLeMna25YIlPh5qPA6I/pAahe8e3nSu2ckl\n-----END RSA PRIVATE KEY-----",
+  "oidcServicePublicKeySig": "-----BEGIN CERTIFICATE-----\nMIIC/zCCAeegAwIBAgIUYFySF9bmkPZK1u+wdkwTSS9bxnMwDQYJKoZIhvcNAQEL\nBQAwDzENMAsGA1UEAwwEVGVzdDAeFw0yMjExMjkxNDI2MTFaFw00MjAxMjgxNDI2\nMTFaMA8xDTALBgNVBAMMBFRlc3QwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEK\nAoIBAQCzaOyYigW5bMySKUloDz//n9PfRye7Nf0YiZdSsVHaT0QpMy0YwcJ0qVY6\nXcFX4FMBT1MvPsnN3+InkYnoHxOsfU8cWYenLz+oT9Lk6GKcikiLt5sAGqehVzAN\n0Jry6DOryTxJbGFE1d9UiXDPg0fVxonyWaIREWPsi80qoSHMCTSnIOvyG5u95MLf\n3FES6MqWyq62k8AU8nd/bJtWx3KRfmvHSHlKyUbeNVZiFn9I5vZojM6vREyOFCax\nhHBum3dqeOUFn3xo7ODsYCRs7zT3dflVWT29o9GDTPElDQOjRgvLORGKxIAgVvS1\n0q4OeNEYrrL83aPoC3YeOTGe1u0ZAgMBAAGjUzBRMB0GA1UdDgQWBBS/LX4E0Ipq\nh/4wcxNIXvoksj4vizAfBgNVHSMEGDAWgBS/LX4E0Ipqh/4wcxNIXvoksj4vizAP\nBgNVHRMBAf8EBTADAQH/MA0GCSqGSIb3DQEBCwUAA4IBAQAZk2m++tQ/FkZedpoA\nBlbRjvWjQ8u6qH5zaqS5oxnNX/JfJEFOsqL2n37g/0wuu6HhSYh2vD+zc4KfVMrj\nv6wzzmspJaZnACQLlEoB+ZKC1P+a8R95BK8iL1Dp1Iy0SC8CR6ZvQDEHNGWm8SAC\nK/cm2ee4wv4obg336SjXZ+Wid8lmdKDpJ7/XjiK2NQuvDLw6Jt7QpItKqwajEcJ/\nBOYQi7AAYtRBfi0v99nm3L2XF2ijTsIHDGhQqliFTXYwKO6ErCevEpDfDF28txqT\nR333fBH0ADco70lNPVTfOtpfdTjKvJ3N9SmU9V0BbhtegzMeung3QBmtMxApt8++\nLcJp\n-----END CERTIFICATE-----",
+
+  "oidcServiceDeviceAuthorizationExpiration": 600,
+  "oidcServiceDeviceAuthorizationPollingInterval": 5,
+  "oidcServiceDeviceAuthorizationUserCodeLength": 8,
+
+  "oidcRPMetaDataExportedVars": {
+    "pam-access": {
+      "email": "mail",
+      "name": "cn",
+      "groups": "groups",
+      "uid": "uid"
+    },
+    "ssh-cert": {
+      "email": "mail",
+      "name": "cn",
+      "uid": "uid"
+    }
+  },
+
+  "oidcRPMetaDataOptions": {
+    "pam-access": {
+      "oidcRPMetaDataOptionsDisplayName": "PAM Access",
+      "oidcRPMetaDataOptionsClientID": "pam-access",
+      "oidcRPMetaDataOptionsClientSecret": "pamsecret",
+      "oidcRPMetaDataOptionsClientAuthenticationMethod": "client_secret_jwt",
+      "oidcRPMetaDataOptionsAccessTokenExpiration": 86400,
+      "oidcRPMetaDataOptionsRefreshToken": 1,
+      "oidcRPMetaDataOptionsAllowDeviceAuthorization": 1,
+      "oidcRPMetaDataOptionsRequirePKCE": 1
+    },
+    "ssh-cert": {
+      "oidcRPMetaDataOptionsDisplayName": "SSH Certificate",
+      "oidcRPMetaDataOptionsClientID": "ssh-cert",
+      "oidcRPMetaDataOptionsClientSecret": "",
+      "oidcRPMetaDataOptionsPublic": 1,
+      "oidcRPMetaDataOptionsAccessTokenExpiration": 300,
+      "oidcRPMetaDataOptionsAllowDeviceAuthorization": 1
+    }
+  },
+
+  "oidcRPMetaDataScopeRules": {
+    "pam-access": {
+      "pam": "1",
+      "pam:server": "1"
+    },
+    "ssh-cert": {
+      "openid": "1",
+      "ssh_cert": "1"
+    }
+  },
+
+  "oidcOPMetaDataOptions": {},
+  "oidcOPMetaDataJSON": {},
+  "oidcOPMetaDataJWKS": {},
+
+  "customPlugins": "::Plugins::OIDCDeviceAuthorization ::Plugins::OIDCDeviceOrganization",
+
+  "portalDisplayPamAccess": 1,
+  "portalDisplaySshCa": 1,
+  "pamAccessActivation": 1,
+  "pamAccessTokenDuration": 600,
+  "pamAccessMaxDuration": 3600,
+  "pamAccessRp": "pam-access",
+  "pamAccessHeartbeatInterval": 300,
+
+  "pamAccessExportedVars": {
+    "uid": "uid",
+    "cn": "cn",
+    "mail": "mail",
+    "gecos": "cn"
+  },
+
+  "pamAccessSshRules": {
+    "default": "1",
+    "bastion": "$uid eq 'dwho' or $uid eq 'rtyler' or $uid eq 'msmith'",
+    "backend": "$uid eq 'dwho' or $uid eq 'rtyler' or $uid eq 'msmith'",
+    "backend-new": "$uid eq 'dwho' or $uid eq 'rtyler' or $uid eq 'msmith'"
+  },
+
+  "pamAccessSudoRules": {
+    "default": "0",
+    "bastion": "0",
+    "backend": "$uid eq 'rtyler'",
+    "backend-new": "$uid eq 'rtyler'"
+  },
+
+  "pamAccessOfflineEnabled": "1",
+  "pamAccessOfflineTtl": 86400,
+
+  "sshCaActivation": 0,
+  "sshCaKeyType": "ed25519",
+  "sshCaKeyRef": "ssh-ca",
+  "sshCaCertDefaultValidity": 60,
+  "sshCaCertMaxValidity": 480,
+  "sshCaPrincipalSources": "$uid",
+  "sshCaSerialPath": "/var/lib/lemonldap-ng/ssh/serial",
+  "sshCaKrlPath": "/var/lib/lemonldap-ng/ssh/revoked_keys",
+
+  "keys": {
+    "ssh-ca": {
+      "keyPrivate": "-----BEGIN PRIVATE KEY-----\nMC4CAQAwBQYDK2VwBCIEIEZyz2Nqnufxbdjr0Pz1h3XRUKtPhj4KU/10cvzNl7tK\n-----END PRIVATE KEY-----",
+      "keyPublic": "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAE5IbzuAljtMFsLCwim6WfiNLy0IWUn6qd7HiP9/tqsc=\n-----END PUBLIC KEY-----",
+      "keyComment": "LLNG SSH CA for Docker Demo"
+    }
+  },
+
+  "macros": {
+    "groups": "'users'"
+  },
+
+  "groups": {}
+}

--- a/docker-demo-token-svc/sso/Dockerfile
+++ b/docker-demo-token-svc/sso/Dockerfile
@@ -1,0 +1,11 @@
+# LemonLDAP::NG SSO with pre-initialized server tokens
+#
+# This extends the standard LLNG portal image to pre-create
+# server tokens at startup for bastion and backend.
+
+FROM yadd/lemonldap-ng-portal:latest-non-root
+
+# Copy token initialization script to run during container init
+COPY --chmod=755 init-tokens.sh /etc/cont-init.d/10-init-tokens
+
+# Keep original entrypoint and command

--- a/docker-demo-token-svc/sso/init-tokens.sh
+++ b/docker-demo-token-svc/sso/init-tokens.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+# LemonLDAP::NG init script
+# Pre-creates server tokens for bastion and backend at startup
+
+echo "=== Initializing LLNG server tokens ==="
+
+# Session storage directories
+SESSIONS_DIR="/var/lib/lemonldap-ng/sessions"
+LOCK_DIR="${SESSIONS_DIR}/lock"
+SSH_DIR="/var/lib/lemonldap-ng/ssh"
+
+# Pre-defined server tokens (must match docker-compose.yml LLNG_SERVER_TOKEN values)
+SERVER_TOKEN="5f3284b425bbd083e1c47dc737acbffb0f04ecdbecd942486f2e13220b03abfa"
+
+# Ensure directories exist with correct ownership
+mkdir -p "$SESSIONS_DIR" "$LOCK_DIR" "$SSH_DIR"
+
+# Remove any existing session file with this ID (might have wrong format)
+rm -f "$SESSIONS_DIR/$SERVER_TOKEN"
+
+chown -R www-data:www-data /var/lib/lemonldap-ng
+
+echo "Pre-creating server token..."
+
+# Create server token session using LLNG's Session module directly
+# This ensures the correct serialization format (JSON, not Storable)
+perl -e '
+    use strict;
+    use warnings;
+    use Lemonldap::NG::Common::Session;
+
+    my $sessions_dir = $ARGV[0];
+    my $lock_dir = $ARGV[1];
+    my $target_id = $ARGV[2];
+    my $now = time();
+    my $expires = $now + 31536000;  # 1 year
+
+    # Create session with LLNG Session module (which handles JSON serialization)
+    my $session = Lemonldap::NG::Common::Session->new({
+        storageModule => "Apache::Session::File",
+        storageModuleOptions => {
+            Directory => $sessions_dir,
+            LockDirectory => $lock_dir,
+        },
+        id => $target_id,
+        force => 1,  # Force creation with specific ID
+        kind => "OIDCI",
+        info => {
+            _session_kind   => "OIDCI",
+            _utime          => $now,
+            grant_type      => "device_code",
+            scope           => "pam pam:server",
+            client_id       => "pam-access",
+            _type           => "access_token",
+            rp              => "pam-access",
+            _pamServer      => 1,
+            _pamServerGroup => "bastion",
+            _pamHostname    => "bastion-server",
+            _pamEnrolledAt  => $now,
+            _pamLastSeen    => $now,
+            _pamStatus      => "active",
+            expires_at      => $expires,
+        },
+    });
+
+    if ($session->error) {
+        die "Error creating session: " . $session->error . "\n";
+    }
+
+    print "Created server token with ID: " . $session->id . "\n";
+' "$SESSIONS_DIR" "$LOCK_DIR" "$SERVER_TOKEN"
+
+chown -R www-data:www-data "$SESSIONS_DIR"
+echo "Server tokens created"

--- a/nss/libnss_openbastion.c
+++ b/nss/libnss_openbastion.c
@@ -46,6 +46,14 @@
 #define DEFAULT_SHELL "/bin/bash"
 #define DEFAULT_HOME_BASE "/home"
 #define DEFAULT_MIN_UID 10000
+
+/*
+ * Default path to the Open Bastion service-accounts configuration. Can be
+ * overridden in nss_openbastion.conf with `service_accounts_file = …`
+ * (same key name pam_openbastion uses) so both modules keep a consistent
+ * view of which file is authoritative.
+ */
+#define DEFAULT_SERVICE_ACCOUNTS_CONF_FILE "/etc/open-bastion/service-accounts.conf"
 #define DEFAULT_MAX_UID 60000
 
 /* Reserved UID for 'nobody' user - must never be assigned */
@@ -67,6 +75,7 @@ typedef struct {
     uid_t min_uid;
     uid_t max_uid;
     gid_t default_gid;
+    char *service_accounts_file;  /* Local service accounts config */
 } nss_llng_config_t;
 
 /* Cache entry */
@@ -514,6 +523,10 @@ static int load_config(nss_llng_config_t *config)
                 config->default_gid = default_gid;
             }
         }
+        else if (strcmp(key, "service_accounts_file") == 0) {
+            free(config->service_accounts_file);
+            config->service_accounts_file = strdup(value);
+        }
     }
 
     fclose(f);
@@ -529,6 +542,9 @@ static int load_config(nss_llng_config_t *config)
     }
     if (!config->default_home_base) {
         config->default_home_base = strdup(DEFAULT_HOME_BASE);
+    }
+    if (!config->service_accounts_file) {
+        config->service_accounts_file = strdup(DEFAULT_SERVICE_ACCOUNTS_CONF_FILE);
     }
 
     return (config->portal_url && config->server_token) ? 0 : -1;
@@ -854,16 +870,6 @@ static size_t write_callback(void *contents, size_t size, size_t nmemb, void *us
     return realsize;
 }
 
-/*
- * Path to the Open Bastion service-accounts configuration. The file is
- * 0600 root:root, so this lookup only succeeds when libnss_openbastion
- * runs inside a root-owned process (e.g. sshd during pre-auth user
- * validation). Unprivileged callers silently fall through to the LLNG
- * query, which is the behaviour we want: service accounts are a host-
- * local concept, there is no reason for normal users to resolve them.
- */
-#define SERVICE_ACCOUNTS_CONF_FILE "/etc/open-bastion/service-accounts.conf"
-
 /* Minimal in-place trim used by the .conf parser below. */
 static char *sa_trim(char *s)
 {
@@ -909,12 +915,26 @@ static int query_service_account(const char *username, struct passwd *pw,
         if (!islower(c) && !isdigit(c) && c != '_' && c != '-') return -1;
     }
 
-    int fd = open(SERVICE_ACCOUNTS_CONF_FILE, O_RDONLY | O_NOFOLLOW | O_CLOEXEC);
+    const char *conf_path = g_config.service_accounts_file
+                            ? g_config.service_accounts_file
+                            : DEFAULT_SERVICE_ACCOUNTS_CONF_FILE;
+
+    int fd = open(conf_path, O_RDONLY | O_NOFOLLOW | O_CLOEXEC);
     if (fd < 0) return -1;
 
-    /* Ownership guard: must be root-owned regular file. */
+    /*
+     * Strict guard: must be a regular root:root file with exact 0600
+     * permissions. Anything more permissive is refused — unprivileged
+     * callers must NOT be able to pull service-account data out of this
+     * file via a misconfigured mode, and pam_openbastion applies the
+     * same contract on its side.
+     */
     struct stat st;
-    if (fstat(fd, &st) != 0 || !S_ISREG(st.st_mode) || st.st_uid != 0) {
+    if (fstat(fd, &st) != 0 ||
+        !S_ISREG(st.st_mode) ||
+        st.st_uid != 0 ||
+        st.st_gid != 0 ||
+        (st.st_mode & 0777) != (S_IRUSR | S_IWUSR)) {
         close(fd);
         return -1;
     }
@@ -1340,10 +1360,16 @@ NSS_VISIBLE enum nss_status _nss_openbastion_getpwnam_r(const char *name,
      * deliberately unknown to LLNG and exist only on this host. We only
      * get an answer when the calling process can read the 0600 config
      * file (typically sshd during pre-auth getpwnam()).
+     *
+     * Deliberately skip file_cache_save() here: the shared file cache
+     * lives under /var/cache/nss_llng with 0755 dir and 0644 entries,
+     * so persisting service-account metadata there would expose it to
+     * unprivileged users on the host (including the uid → name reverse
+     * lookup). Keeping it in the per-process in-memory cache only is
+     * sufficient for the one-shot sshd pre-auth getpwnam() path.
      */
     if (query_service_account(name, result, buffer, buflen) == 0) {
         cache_add(name, result, 1);
-        file_cache_save(result);
         g_in_nss_lookup = 0;
         return NSS_STATUS_SUCCESS;
     }

--- a/nss/libnss_openbastion.c
+++ b/nss/libnss_openbastion.c
@@ -854,6 +854,178 @@ static size_t write_callback(void *contents, size_t size, size_t nmemb, void *us
     return realsize;
 }
 
+/*
+ * Path to the Open Bastion service-accounts configuration. The file is
+ * 0600 root:root, so this lookup only succeeds when libnss_openbastion
+ * runs inside a root-owned process (e.g. sshd during pre-auth user
+ * validation). Unprivileged callers silently fall through to the LLNG
+ * query, which is the behaviour we want: service accounts are a host-
+ * local concept, there is no reason for normal users to resolve them.
+ */
+#define SERVICE_ACCOUNTS_CONF_FILE "/etc/open-bastion/service-accounts.conf"
+
+/* Minimal in-place trim used by the .conf parser below. */
+static char *sa_trim(char *s)
+{
+    if (!s) return s;
+    while (*s && isspace((unsigned char)*s)) s++;
+    char *end = s + strlen(s);
+    while (end > s && isspace((unsigned char)end[-1])) end--;
+    *end = '\0';
+    return s;
+}
+
+/*
+ * Service-account NSS lookup.
+ *
+ * Resolves a local service account (ansible, backup, deploy, ...) out of
+ * /etc/open-bastion/service-accounts.conf without contacting LLNG. This
+ * is what unblocks sshd's pre-auth getpwnam() check for usernames that
+ * only ever live in the bastion's own config (they are deliberately
+ * unknown to the LLNG directory).
+ *
+ * Returns 0 on success, -1 on any failure (file unreadable, user not
+ * found, uid/gid missing or out of range, buffer too small, etc.).
+ *
+ * Only looks at the [uid] and [gid] numeric fields plus gecos/shell/home
+ * strings. Authentication material (key_fingerprint, sudo_*, ...) is not
+ * our business here: pam_openbastion still owns auth and authorization.
+ */
+static int query_service_account(const char *username, struct passwd *pw,
+                                  char *buffer, size_t buflen)
+{
+    if (!username || !*username || !pw || !buffer) return -1;
+
+    /* Length cap (matches MAX_SERVICE_ACCOUNT_NAME in service_account.h). */
+    size_t ulen = strlen(username);
+    if (ulen == 0 || ulen > 32) return -1;
+
+    /* First char must be [a-z_]; remaining [a-z0-9_-]. Matches
+     * validate_username() in service_account.c and the SSHD-side
+     * ob-service-account-keys helper. */
+    if (!(islower((unsigned char)username[0]) || username[0] == '_')) return -1;
+    for (size_t i = 1; i < ulen; i++) {
+        unsigned char c = (unsigned char)username[i];
+        if (!islower(c) && !isdigit(c) && c != '_' && c != '-') return -1;
+    }
+
+    int fd = open(SERVICE_ACCOUNTS_CONF_FILE, O_RDONLY | O_NOFOLLOW | O_CLOEXEC);
+    if (fd < 0) return -1;
+
+    /* Ownership guard: must be root-owned regular file. */
+    struct stat st;
+    if (fstat(fd, &st) != 0 || !S_ISREG(st.st_mode) || st.st_uid != 0) {
+        close(fd);
+        return -1;
+    }
+
+    FILE *f = fdopen(fd, "r");
+    if (!f) {
+        close(fd);
+        return -1;
+    }
+
+    char line[1024];
+    int in_target_section = 0;
+    int found = 0;
+    uid_t uid = 0;
+    gid_t gid = 0;
+    int have_uid = 0, have_gid = 0;
+    char gecos[256] = "";
+    char shell[128] = "";
+    char home[256] = "";
+
+    while (fgets(line, sizeof(line), f)) {
+        char *t = sa_trim(line);
+        if (*t == '\0' || *t == '#' || *t == ';') continue;
+
+        if (*t == '[') {
+            char *end = strchr(t, ']');
+            if (!end) continue;
+            *end = '\0';
+            char *name = sa_trim(t + 1);
+            if (in_target_section && found) break;  /* already captured */
+            in_target_section = (strcmp(name, username) == 0);
+            if (in_target_section) found = 1;
+            continue;
+        }
+
+        if (!in_target_section) continue;
+
+        char *eq = strchr(t, '=');
+        if (!eq) continue;
+        *eq = '\0';
+        char *key = sa_trim(t);
+        char *val = sa_trim(eq + 1);
+
+        if (strcmp(key, "uid") == 0) {
+            char *ep;
+            errno = 0;
+            unsigned long v = strtoul(val, &ep, 10);
+            if (errno == 0 && ep != val && *ep == '\0' && v > 0 && v <= 65534) {
+                uid = (uid_t)v;
+                have_uid = 1;
+            }
+        } else if (strcmp(key, "gid") == 0) {
+            char *ep;
+            errno = 0;
+            unsigned long v = strtoul(val, &ep, 10);
+            if (errno == 0 && ep != val && *ep == '\0' && v > 0 && v <= 65534) {
+                gid = (gid_t)v;
+                have_gid = 1;
+            }
+        } else if (strcmp(key, "gecos") == 0 || strcmp(key, "description") == 0) {
+            strncpy(gecos, val, sizeof(gecos) - 1);
+            gecos[sizeof(gecos) - 1] = '\0';
+        } else if (strcmp(key, "shell") == 0) {
+            strncpy(shell, val, sizeof(shell) - 1);
+            shell[sizeof(shell) - 1] = '\0';
+        } else if (strcmp(key, "home") == 0 || strcmp(key, "home_dir") == 0) {
+            strncpy(home, val, sizeof(home) - 1);
+            home[sizeof(home) - 1] = '\0';
+        }
+    }
+    fclose(f);
+
+    if (!found || !have_uid || !have_gid) return -1;
+
+    /* Fill in sensible defaults when optional fields are unset. */
+    const char *shell_to_use = (*shell) ? shell : DEFAULT_SHELL;
+    char home_default[320];
+    const char *home_to_use;
+    if (*home) {
+        home_to_use = home;
+    } else {
+        snprintf(home_default, sizeof(home_default), "%s/%s",
+                 DEFAULT_HOME_BASE, username);
+        home_to_use = home_default;
+    }
+
+    /* Populate the passwd struct using the caller-provided buffer. */
+    char *p = buffer;
+    size_t remaining = buflen;
+
+    pw->pw_name = p;
+    if (safe_strcpy(&p, &remaining, username) != 0) return -1;
+
+    pw->pw_passwd = p;
+    if (safe_strcpy(&p, &remaining, "x") != 0) return -1;
+
+    pw->pw_uid = uid;
+    pw->pw_gid = gid;
+
+    pw->pw_gecos = p;
+    if (safe_strcpy(&p, &remaining, gecos) != 0) return -1;
+
+    pw->pw_dir = p;
+    if (safe_strcpy(&p, &remaining, home_to_use) != 0) return -1;
+
+    pw->pw_shell = p;
+    if (safe_strcpy(&p, &remaining, shell_to_use) != 0) return -1;
+
+    return 0;
+}
+
 /* Query LLNG server for user info */
 static int query_llng_userinfo(const char *username, struct passwd *pw,
                                 char *buffer, size_t buflen)
@@ -1162,6 +1334,19 @@ NSS_VISIBLE enum nss_status _nss_openbastion_getpwnam_r(const char *name,
         return NSS_STATUS_TRYAGAIN;
     }
     pthread_mutex_unlock(&g_cache.lock);
+
+    /*
+     * Try the local service-accounts.conf first: these users are
+     * deliberately unknown to LLNG and exist only on this host. We only
+     * get an answer when the calling process can read the 0600 config
+     * file (typically sshd during pre-auth getpwnam()).
+     */
+    if (query_service_account(name, result, buffer, buflen) == 0) {
+        cache_add(name, result, 1);
+        file_cache_save(result);
+        g_in_nss_lookup = 0;
+        return NSS_STATUS_SUCCESS;
+    }
 
     /* Query LLNG server */
     if (query_llng_userinfo(name, result, buffer, buflen) == 0) {

--- a/scripts/ob-service-account-keys
+++ b/scripts/ob-service-account-keys
@@ -1,0 +1,60 @@
+#!/bin/bash
+# ob-service-account-keys - AuthorizedKeysCommand helper for Open Bastion
+#
+# Invoked by sshd (AuthorizedKeysCommand) as an unprivileged user. Given a
+# username, print the authorized SSH public key(s) if the account is a
+# registered service account in /etc/open-bastion/service-accounts.conf.
+#
+# This lets Mode E bastions (AuthorizedKeysFile none) accept service-account
+# keys at the SSH protocol layer without exposing a writable authorized_keys
+# file. pam_openbastion still re-validates the SHA256 fingerprint against
+# service-accounts.conf in pam_sm_authenticate.
+#
+# Layout:
+#   /etc/open-bastion/service-accounts.conf       - [name] sections (root:root 0600)
+#   /etc/open-bastion/service-accounts.d/NAME.pub - one authorized key per service
+#                                                   account (root:root 0644)
+#
+# This script is invoked by sshd as AuthorizedKeysCommandUser (typically
+# "nobody"), which CANNOT read the 0600-protected service-accounts.conf.
+# The mere presence of NAME.pub is therefore treated as the SSH-layer
+# gatekeeper here. The authoritative check (username IS a configured
+# service account AND the SHA256 fingerprint matches) is re-done inside
+# pam_openbastion in pam_sm_authenticate, which runs as root and can read
+# service-accounts.conf. If an orphan .pub ever made it to the directory,
+# sshd would accept the key but PAM would still reject the session.
+#
+# Exit status is always 0: sshd only rejects on non-zero, and we always want
+# sshd to continue with its normal code path even when we produce no output
+# (so a non-service-account user just falls through to the cert path).
+
+set -u
+
+KEYS_DIR="${OB_SERVICE_ACCOUNTS_KEYS_DIR:-/etc/open-bastion/service-accounts.d}"
+
+USER="${1:-}"
+[ -n "$USER" ] || exit 0
+
+# Strict username validation: lowercase letters, digits, underscore, hyphen.
+# First character must be a letter or underscore (matches validate_username()
+# in service_account.c). Reject anything else so shell metacharacters or
+# path-traversal attempts cannot reach the file system.
+case "$USER" in
+    [a-z_]*) : ;;
+    *) exit 0 ;;
+esac
+case "$USER" in
+    *[!a-z0-9_-]*) exit 0 ;;
+esac
+
+KEY_FILE="$KEYS_DIR/${USER}.pub"
+[ -f "$KEY_FILE" ] || exit 0
+
+# Defense-in-depth: the key file must be root-owned. sshd itself also
+# rejects an AuthorizedKeysCommand output if the command binary is not
+# root-owned, but the data file is our own responsibility.
+owner=$(stat -c '%u' "$KEY_FILE" 2>/dev/null || echo "")
+[ "$owner" = "0" ] || exit 0
+
+cat "$KEY_FILE"
+exit 0

--- a/src/pam_openbastion.c
+++ b/src/pam_openbastion.c
@@ -2361,51 +2361,67 @@ PAM_VISIBLE PAM_EXTERN int pam_sm_authenticate(pam_handle_t *pamh,
 
             return PAM_AUTH_ERR;
         }
-        OB_LOG_DEBUG(pamh, "User %s is a service account, validating SSH key fingerprint", user);
-
         /*
-         * Security: Validate SSH key fingerprint.
-         * Extract the fingerprint from SSH_USER_AUTH and compare with configured value.
-         * This requires ExposeAuthInfo=yes in sshd_config.
+         * Sudo context: there is no SSH_USER_AUTH because sudo is not an
+         * SSH service. When sudo_nopasswd is configured the admin has
+         * declared that a valid existing Unix session is sufficient, so
+         * skip the fingerprint check here. pam_sm_acct_mgmt will still
+         * enforce sudo_allowed below.
          */
-        char *ssh_fingerprint = extract_ssh_key_fingerprint(pamh);
-        if (!ssh_fingerprint) {
-            OB_LOG_ERR(pamh, "Service account %s: cannot extract SSH key fingerprint "
-                    "(is ExposeAuthInfo enabled in sshd_config?)", user);
+        bool skip_fp_check =
+            (strcmp(service, "sudo") == 0) && sa->sudo_nopasswd;
 
-            if (audit_initialized) {
-                audit_event.event_type = AUDIT_AUTH_FAILURE;
-                audit_event.result_code = PAM_AUTH_ERR;
-                audit_event.reason = "Service account: no SSH fingerprint available";
-                audit_event_set_end_time(&audit_event);
-                audit_log_event(data->audit, &audit_event);
+        if (skip_fp_check) {
+            OB_LOG_INFO(pamh,
+                        "Service account %s: sudo with sudo_nopasswd, "
+                        "skipping SSH fingerprint check", user);
+        } else {
+            OB_LOG_DEBUG(pamh, "User %s is a service account, validating SSH key fingerprint", user);
+
+            /*
+             * Security: Validate SSH key fingerprint.
+             * Extract the fingerprint from SSH_USER_AUTH and compare with configured value.
+             * This requires ExposeAuthInfo=yes in sshd_config.
+             */
+            char *ssh_fingerprint = extract_ssh_key_fingerprint(pamh);
+            if (!ssh_fingerprint) {
+                OB_LOG_ERR(pamh, "Service account %s: cannot extract SSH key fingerprint "
+                        "(is ExposeAuthInfo enabled in sshd_config?)", user);
+
+                if (audit_initialized) {
+                    audit_event.event_type = AUDIT_AUTH_FAILURE;
+                    audit_event.result_code = PAM_AUTH_ERR;
+                    audit_event.reason = "Service account: no SSH fingerprint available";
+                    audit_event_set_end_time(&audit_event);
+                    audit_log_event(data->audit, &audit_event);
+                }
+
+                return PAM_AUTH_ERR;
             }
 
-            return PAM_AUTH_ERR;
-        }
+            /* Validate fingerprint against configured value */
+            int fp_result = service_accounts_validate_key(&data->service_accounts, user, ssh_fingerprint);
+            if (fp_result != 0) {
+                OB_LOG_ERR(pamh, "Service account %s: SSH key fingerprint mismatch "
+                        "(got %s, expected %s)", user, ssh_fingerprint,
+                        sa->key_fingerprint ? sa->key_fingerprint : "(none)");
+                free(ssh_fingerprint);
 
-        /* Validate fingerprint against configured value */
-        int fp_result = service_accounts_validate_key(&data->service_accounts, user, ssh_fingerprint);
-        if (fp_result != 0) {
-            OB_LOG_ERR(pamh, "Service account %s: SSH key fingerprint mismatch "
-                    "(got %s, expected %s)", user, ssh_fingerprint,
-                    sa->key_fingerprint ? sa->key_fingerprint : "(none)");
+                if (audit_initialized) {
+                    audit_event.event_type = AUDIT_AUTH_FAILURE;
+                    audit_event.result_code = PAM_AUTH_ERR;
+                    audit_event.reason = "Service account: SSH key fingerprint mismatch";
+                    audit_event_set_end_time(&audit_event);
+                    audit_log_event(data->audit, &audit_event);
+                }
+
+                return PAM_AUTH_ERR;
+            }
+
+            OB_LOG_INFO(pamh, "Service account %s authenticated with fingerprint %s",
+                    user, ssh_fingerprint);
             free(ssh_fingerprint);
-
-            if (audit_initialized) {
-                audit_event.event_type = AUDIT_AUTH_FAILURE;
-                audit_event.result_code = PAM_AUTH_ERR;
-                audit_event.reason = "Service account: SSH key fingerprint mismatch";
-                audit_event_set_end_time(&audit_event);
-                audit_log_event(data->audit, &audit_event);
-            }
-
-            return PAM_AUTH_ERR;
         }
-
-        OB_LOG_INFO(pamh, "Service account %s authenticated with fingerprint %s",
-                user, ssh_fingerprint);
-        free(ssh_fingerprint);
 
         /* Store service account attributes for pam_sm_open_session (user creation) */
         if (sa->gecos) {
@@ -2434,7 +2450,9 @@ PAM_VISIBLE PAM_EXTERN int pam_sm_authenticate(pam_handle_t *pamh,
         if (audit_initialized) {
             audit_event.event_type = AUDIT_AUTH_SUCCESS;
             audit_event.result_code = PAM_SUCCESS;
-            audit_event.reason = "Service account (SSH key validated)";
+            audit_event.reason = skip_fp_check
+                ? "Service account (sudo_nopasswd, fingerprint check skipped)"
+                : "Service account (SSH key validated)";
             audit_event_set_end_time(&audit_event);
             audit_log_event(data->audit, &audit_event);
         }
@@ -3099,6 +3117,64 @@ PAM_VISIBLE PAM_EXTERN int pam_sm_acct_mgmt(pam_handle_t *pamh,
         }
 
         /*
+         * Mark as service account for pam_sm_open_session and propagate the
+         * user attributes from service-accounts.conf. For SSH pubkey auth
+         * sshd does NOT invoke pam_authenticate, so this is the only place
+         * where we can stash this information for the session phase.
+         */
+        pam_set_data(pamh, "ob_service_account", (void *)1, NULL);
+        if (sa->gecos) {
+            char *gecos_copy = strdup(sa->gecos);
+            if (gecos_copy) {
+                pam_set_data(pamh, "ob_gecos", gecos_copy, cleanup_string);
+            }
+        }
+        if (sa->shell) {
+            char *shell_copy = strdup(sa->shell);
+            if (shell_copy) {
+                pam_set_data(pamh, "ob_shell", shell_copy, cleanup_string);
+            }
+        }
+        if (sa->home) {
+            char *home_copy = strdup(sa->home);
+            if (home_copy) {
+                pam_set_data(pamh, "ob_home", home_copy, cleanup_string);
+            }
+        }
+
+        /*
+         * Defense-in-depth fingerprint check for SSH sessions. sshd's
+         * AuthorizedKeysCommand already ensured the presented key matches
+         * what we published for this service account, but we re-verify
+         * the SHA256 fingerprint from SSH_USER_AUTH (ExposeAuthInfo yes)
+         * against the canonical value in service-accounts.conf. We do NOT
+         * fail closed when SSH_USER_AUTH is absent: the PAM `sudo` service
+         * never has it, and some OpenSSH builds omit it for non-cert keys.
+         */
+        if (strcmp(service, "sshd") == 0 || strcmp(service, "ssh") == 0) {
+            char *ssh_fp = extract_ssh_key_fingerprint(pamh);
+            if (ssh_fp) {
+                int fp_result = service_accounts_validate_key(
+                    &data->service_accounts, user, ssh_fp);
+                if (fp_result != 0) {
+                    OB_LOG_ERR(pamh,
+                               "Service account %s: fingerprint mismatch in account phase "
+                               "(got %s)", user, ssh_fp);
+                    free(ssh_fp);
+                    if (audit_initialized) {
+                        audit_event.event_type = AUDIT_AUTHZ_DENIED;
+                        audit_event.result_code = PAM_PERM_DENIED;
+                        audit_event.reason = "Service account fingerprint mismatch";
+                        audit_event_set_end_time(&audit_event);
+                        audit_log_event(data->audit, &audit_event);
+                    }
+                    return PAM_PERM_DENIED;
+                }
+                free(ssh_fp);
+            }
+        }
+
+        /*
          * Handle sudo authorization for service accounts.
          * Check if the service account has sudo_allowed permission.
          */
@@ -3564,7 +3640,9 @@ static int create_unix_user(pam_handle_t *pamh,
                             const pam_openbastion_config_t *config,
                             const char *gecos,
                             const char *shell,
-                            const char *home)
+                            const char *home,
+                            uid_t forced_uid,
+                            gid_t forced_gid)
 {
     uid_t uid = 0;
     gid_t gid = 0;
@@ -3583,20 +3661,64 @@ static int create_unix_user(pam_handle_t *pamh,
         return -1;
     }
 
-    /* Get UID/GID from NSS (libnss_openbastion) */
-    struct passwd *nss_pw = getpwnam(user);
-    if (nss_pw) {
-        uid = nss_pw->pw_uid;
-        gid = nss_pw->pw_gid;
-    } else {
-        OB_LOG_ERR(pamh, "Cannot get user info from NSS for %s", user);
-        return -1;
-    }
+    if (forced_uid != 0) {
+        /*
+         * Service-account path: the account only exists in
+         * service-accounts.conf, not in LLNG, so NSS cannot resolve it.
+         * Use the uid/gid explicitly configured by the admin and auto-create
+         * the matching primary group on the fly.
+         */
+        uid = forced_uid;
+        gid = (forced_gid != 0) ? forced_gid : forced_uid;
 
-    /* Verify that the primary group exists */
-    if (!group_exists_locally(gid)) {
-        OB_LOG_ERR(pamh, "Primary group %lu does not exist for user %s", (unsigned long)gid, user);
-        return -1;
+        if (!group_exists_locally(gid)) {
+            OB_LOG_INFO(pamh, "Creating primary group %s (gid=%lu) for service account",
+                        user, (unsigned long)gid);
+            pid_t pid = fork();
+            if (pid < 0) {
+                OB_LOG_ERR(pamh, "Cannot fork for groupadd: %s", strerror(errno));
+                return -1;
+            }
+            if (pid == 0) {
+                char gid_str[16];
+                snprintf(gid_str, sizeof(gid_str), "%lu", (unsigned long)gid);
+                int null_fd = open("/dev/null", O_WRONLY);
+                if (null_fd >= 0) {
+                    dup2(null_fd, STDOUT_FILENO);
+                    dup2(null_fd, STDERR_FILENO);
+                    close(null_fd);
+                }
+                execl("/usr/sbin/groupadd", "groupadd", "-g", gid_str, user, NULL);
+                _exit(127);
+            }
+            int status;
+            if (waitpid(pid, &status, 0) < 0) {
+                OB_LOG_ERR(pamh, "Cannot wait for groupadd: %s", strerror(errno));
+                return -1;
+            }
+            if (!group_exists_locally(gid)) {
+                OB_LOG_ERR(pamh, "Failed to create primary group %s (gid=%lu)",
+                           user, (unsigned long)gid);
+                return -1;
+            }
+        }
+    } else {
+        /* Get UID/GID from NSS (libnss_openbastion) */
+        struct passwd *nss_pw = getpwnam(user);
+        if (nss_pw) {
+            uid = nss_pw->pw_uid;
+            gid = nss_pw->pw_gid;
+        } else {
+            OB_LOG_ERR(pamh, "Cannot get user info from NSS for %s", user);
+            return -1;
+        }
+
+        /* Verify that the primary group exists */
+        if (!group_exists_locally(gid)) {
+            OB_LOG_ERR(pamh, "Primary group %lu does not exist for user %s",
+                       (unsigned long)gid, user);
+            return -1;
+        }
     }
 
     /* Determine and validate home directory */
@@ -3941,10 +4063,29 @@ PAM_VISIBLE PAM_EXTERN int pam_sm_open_session(pam_handle_t *pamh,
         shell = (const char *)ob_shell;
         home = (const char *)ob_home;
 
+        /*
+         * If the user is a service account (only in service-accounts.conf,
+         * unknown to LLNG), NSS cannot resolve it. Use the explicit uid/gid
+         * from the service-account configuration.
+         */
+        uid_t forced_uid = 0;
+        gid_t forced_gid = 0;
+        const void *ob_sa_marker = NULL;
+        if (pam_get_data(pamh, "ob_service_account", &ob_sa_marker) == PAM_SUCCESS &&
+            ob_sa_marker != NULL) {
+            const service_account_t *sa =
+                service_accounts_find(&data->service_accounts, user);
+            if (sa) {
+                forced_uid = (uid_t)sa->uid;
+                forced_gid = (gid_t)sa->gid;
+            }
+        }
+
         /* Create the user */
         OB_LOG_INFO(pamh, "User %s does not exist, creating account", user);
 
-        if (create_unix_user(pamh, user, &data->config, gecos, shell, home) != 0) {
+        if (create_unix_user(pamh, user, &data->config, gecos, shell, home,
+                             forced_uid, forced_gid) != 0) {
             OB_LOG_ERR(pamh, "Failed to create Unix user: %s", user);
             return PAM_SESSION_ERR;
         }

--- a/tests/test_integration_maxsec.sh
+++ b/tests/test_integration_maxsec.sh
@@ -64,6 +64,7 @@ PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
 DOCKER_DIR="$PROJECT_DIR/docker-demo-maxsec"
 COOKIE_FILE="/tmp/llng-test-cookies"
 TEST_KEY="/tmp/test_integration_key"
+SVC_KEY="/tmp/test_integration_svc_key"
 
 # Test configuration
 PORTAL_URL="http://localhost:80"
@@ -71,6 +72,13 @@ TEST_USER="dwho"
 TEST_PASSWORD="dwho"
 CLIENT_ID="pam-access"
 CLIENT_SECRET="pamsecret"
+
+# Service account used for the SSH-key-only scenario. Intentionally a user
+# unknown to LLNG: only service-accounts.conf + the matching .pub key on
+# the bastion grant access.
+SVC_ACCOUNT="ansible-ci"
+SVC_UID=5000
+SVC_GID=5000
 
 log() {
     echo -e "${GREEN}[TEST]${NC} $*"
@@ -105,7 +113,8 @@ fail() {
 
 cleanup() {
     log "Cleaning up..."
-    rm -f "$COOKIE_FILE" "${TEST_KEY}" "${TEST_KEY}.pub" "${TEST_KEY}-cert.pub" 2>/dev/null || true
+    rm -f "$COOKIE_FILE" "${TEST_KEY}" "${TEST_KEY}.pub" "${TEST_KEY}-cert.pub" \
+          "${SVC_KEY}" "${SVC_KEY}.pub" 2>/dev/null || true
 
     if [[ $KEEP_CONTAINERS -eq 0 ]]; then
         log "Stopping containers..."
@@ -866,6 +875,285 @@ test_password_auth_disabled() {
 }
 
 # =============================================================================
+# Service-account test cases
+# =============================================================================
+#
+# Scenario: an ansible-style service account is registered ONLY locally on
+# the bastion (service-accounts.conf + .pub). LLNG does NOT know this user.
+# We then verify:
+#   1. SSH with the plain (non-SSO-signed) key is accepted thanks to
+#      AuthorizedKeysCommand + service-accounts.conf fingerprint matching.
+#   2. pam_openbastion materialises the local Unix account in /etc/passwd
+#      on first login using the uid/gid from service-accounts.conf
+#      (service-account NSS resolution is impossible).
+#   3. `sudo -n` from that session works without a password (sudo_nopasswd
+#      path in pam_openbastion auth) and yields uid 0.
+
+svc_provision_on_bastion() {
+    local pubkey
+    pubkey=$(cat "${SVC_KEY}.pub")
+
+    # service-accounts.conf: must be root:root 0600 (pam_openbastion enforces this).
+    # NOTE: use `docker exec -i sh -c` and a heredoc so special chars in the key
+    # don't break the shell; pubkey comes from our own file so it's trusted.
+    docker exec -i ob-maxsec-bastion sh -c "cat > /etc/open-bastion/service-accounts.conf" <<EOF
+[${SVC_ACCOUNT}]
+key_fingerprint = $(ssh-keygen -l -E sha256 -f "${SVC_KEY}.pub" | awk '{print $2}')
+sudo_allowed = true
+sudo_nopasswd = true
+gecos = CI service account
+shell = /bin/bash
+home = /home/${SVC_ACCOUNT}
+uid = ${SVC_UID}
+gid = ${SVC_GID}
+EOF
+    docker exec ob-maxsec-bastion chown root:root /etc/open-bastion/service-accounts.conf
+    docker exec ob-maxsec-bastion chmod 600 /etc/open-bastion/service-accounts.conf
+
+    # Public key file consumed by ob-service-account-keys (AuthorizedKeysCommand).
+    docker exec -i ob-maxsec-bastion sh -c \
+        "cat > /etc/open-bastion/service-accounts.d/${SVC_ACCOUNT}.pub" <<< "$pubkey"
+    docker exec ob-maxsec-bastion chown root:root \
+        "/etc/open-bastion/service-accounts.d/${SVC_ACCOUNT}.pub"
+    docker exec ob-maxsec-bastion chmod 644 \
+        "/etc/open-bastion/service-accounts.d/${SVC_ACCOUNT}.pub"
+
+    # sudoers NOPASSWD rule. sudo(8) decides whether to prompt for a
+    # password from sudoers BEFORE it invokes the PAM stack, so
+    # pam_openbastion's service-account sudo_nopasswd logic is necessary
+    # but not sufficient: we also need an explicit NOPASSWD entry here.
+    #
+    # The maxsec image appends `%open-bastion-sudo ALL=(ALL:ALL) ALL` to
+    # /etc/sudoers AFTER the `@includedir /etc/sudoers.d` directive.
+    # sudoers is "last-match-wins", so any rule dropped into
+    # /etc/sudoers.d is overwritten by the group rule. We therefore
+    # append our NOPASSWD rule directly at the very end of
+    # /etc/sudoers so it has the final say for this specific user.
+    #
+    # visudo -c validates the result; if it fails we abort to avoid
+    # leaving a broken sudoers on a production-lookalike host.
+    docker exec ob-maxsec-bastion sh -c "
+        set -e
+        grep -qE '^${SVC_ACCOUNT}[[:space:]]+ALL=.*NOPASSWD' /etc/sudoers || \
+            printf '%s\n' '${SVC_ACCOUNT} ALL=(ALL:ALL) NOPASSWD: ALL' >> /etc/sudoers
+        visudo -c >/dev/null
+    "
+}
+
+test_service_account_provision() {
+    TESTS_RUN=$((TESTS_RUN + 1))
+    log "Provisioning service account ${SVC_ACCOUNT} on the bastion..."
+
+    # Fresh key: plain ed25519, NOT signed by the LLNG SSH CA.
+    rm -f "${SVC_KEY}" "${SVC_KEY}.pub"
+    if ! ssh-keygen -t ed25519 -f "${SVC_KEY}" -N "" -q; then
+        fail "Failed to generate service account SSH key"
+        return 1
+    fi
+
+    if ! svc_provision_on_bastion; then
+        fail "Failed to provision service account on bastion"
+        return 1
+    fi
+
+    # Sanity-check: the local Unix account MUST NOT exist yet (whole point
+    # of this test is the on-login auto-creation).
+    if docker exec ob-maxsec-bastion getent -s files passwd "${SVC_ACCOUNT}" >/dev/null 2>&1; then
+        fail "Service account ${SVC_ACCOUNT} already exists locally before first login"
+        return 1
+    fi
+
+    # The AuthorizedKeysCommand must now return our public key for this user.
+    local cmd_output
+    cmd_output=$(docker exec ob-maxsec-bastion \
+        /usr/local/bin/ob-service-account-keys "${SVC_ACCOUNT}" 2>/dev/null || true)
+    if [[ -z "$cmd_output" ]]; then
+        fail "ob-service-account-keys returned no key for ${SVC_ACCOUNT}"
+        return 1
+    fi
+    if ! grep -q "ssh-ed25519" <<< "$cmd_output"; then
+        fail "ob-service-account-keys output is not an ed25519 key" "$cmd_output"
+        return 1
+    fi
+
+    pass "Service account ${SVC_ACCOUNT} provisioned (key + conf installed)"
+    return 0
+}
+
+test_service_account_ssh_login() {
+    TESTS_RUN=$((TESTS_RUN + 1))
+    log "Testing SSH login as service account ${SVC_ACCOUNT} (plain key)..."
+
+    if [[ ! -f "${SVC_KEY}" ]]; then
+        fail "Service account key missing; provisioning step must run first"
+        return 1
+    fi
+
+    local output rc=0
+    output=$(ssh -i "${SVC_KEY}" \
+                 -o IdentitiesOnly=yes \
+                 -o StrictHostKeyChecking=no \
+                 -o UserKnownHostsFile=/dev/null \
+                 -o BatchMode=yes \
+                 -o ConnectTimeout=10 \
+                 -p 2222 \
+                 "${SVC_ACCOUNT}@localhost" \
+                 "whoami && id -u && id -g" 2>&1) || rc=$?
+    log_verbose "SSH(svc) rc=$rc output: $output"
+
+    if [[ $rc -ne 0 ]]; then
+        fail "SSH login as ${SVC_ACCOUNT} failed" "$output"
+        return 1
+    fi
+
+    if ! grep -qx "${SVC_ACCOUNT}" <<< "$output"; then
+        fail "SSH session did not report ${SVC_ACCOUNT} as whoami" "$output"
+        return 1
+    fi
+    if ! grep -qx "${SVC_UID}" <<< "$output"; then
+        fail "SSH session reported wrong uid (expected ${SVC_UID})" "$output"
+        return 1
+    fi
+    if ! grep -qx "${SVC_GID}" <<< "$output"; then
+        fail "SSH session reported wrong gid (expected ${SVC_GID})" "$output"
+        return 1
+    fi
+
+    pass "Service account ${SVC_ACCOUNT} logged in with uid=${SVC_UID}, gid=${SVC_GID}"
+    return 0
+}
+
+test_service_account_local_user_created() {
+    TESTS_RUN=$((TESTS_RUN + 1))
+    log "Checking that the local Unix account was materialised by pam_openbastion..."
+
+    # Look in /etc/passwd directly: libnss_openbastion could otherwise mask
+    # the question "does a local account exist?".
+    local passwd_entry
+    passwd_entry=$(docker exec ob-maxsec-bastion \
+        grep -E "^${SVC_ACCOUNT}:" /etc/passwd 2>&1) || true
+    log_verbose "passwd entry: $passwd_entry"
+
+    if [[ -z "$passwd_entry" ]]; then
+        fail "No /etc/passwd entry for ${SVC_ACCOUNT} after first SSH login"
+        return 1
+    fi
+
+    # Format: name:x:uid:gid:gecos:home:shell
+    local entry_uid entry_gid entry_home entry_shell
+    entry_uid=$(cut -d: -f3 <<< "$passwd_entry")
+    entry_gid=$(cut -d: -f4 <<< "$passwd_entry")
+    entry_home=$(cut -d: -f6 <<< "$passwd_entry")
+    entry_shell=$(cut -d: -f7 <<< "$passwd_entry")
+
+    if [[ "$entry_uid" != "${SVC_UID}" ]]; then
+        fail "/etc/passwd uid for ${SVC_ACCOUNT} is $entry_uid, expected ${SVC_UID}" "$passwd_entry"
+        return 1
+    fi
+    if [[ "$entry_gid" != "${SVC_GID}" ]]; then
+        fail "/etc/passwd gid for ${SVC_ACCOUNT} is $entry_gid, expected ${SVC_GID}" "$passwd_entry"
+        return 1
+    fi
+    if [[ "$entry_home" != "/home/${SVC_ACCOUNT}" ]]; then
+        fail "Home directory for ${SVC_ACCOUNT} is $entry_home, expected /home/${SVC_ACCOUNT}" "$passwd_entry"
+        return 1
+    fi
+    if [[ "$entry_shell" != "/bin/bash" ]]; then
+        fail "Login shell for ${SVC_ACCOUNT} is $entry_shell, expected /bin/bash" "$passwd_entry"
+        return 1
+    fi
+
+    # Primary group must also have been materialised.
+    local group_entry
+    group_entry=$(docker exec ob-maxsec-bastion \
+        awk -F: -v gid="${SVC_GID}" '$3 == gid {print; exit}' /etc/group 2>&1) || true
+    if [[ -z "$group_entry" ]]; then
+        fail "No /etc/group entry for gid ${SVC_GID} after first login"
+        return 1
+    fi
+
+    pass "Local account ${SVC_ACCOUNT} created in /etc/passwd + matching /etc/group entry"
+    return 0
+}
+
+test_service_account_sudo() {
+    TESTS_RUN=$((TESTS_RUN + 1))
+    log "Testing sudo from service account session (sudo_nopasswd path)..."
+
+    if [[ ! -f "${SVC_KEY}" ]]; then
+        fail "Service account key missing; earlier step must have run"
+        return 1
+    fi
+
+    # -n: non-interactive. If anything prompts for a password this fails,
+    # which is exactly what we want to assert about sudo_nopasswd.
+    local output rc=0
+    output=$(ssh -i "${SVC_KEY}" \
+                 -o IdentitiesOnly=yes \
+                 -o StrictHostKeyChecking=no \
+                 -o UserKnownHostsFile=/dev/null \
+                 -o BatchMode=yes \
+                 -o ConnectTimeout=10 \
+                 -p 2222 \
+                 "${SVC_ACCOUNT}@localhost" \
+                 "sudo -n id -u && sudo -n id -un" 2>&1) || rc=$?
+    log_verbose "SSH(svc+sudo) rc=$rc output: $output"
+
+    if [[ $rc -ne 0 ]]; then
+        fail "sudo -n as ${SVC_ACCOUNT} failed" "$output"
+        return 1
+    fi
+
+    # Expect "0" and "root" on separate lines.
+    if ! grep -qx "0" <<< "$output"; then
+        fail "sudo did not yield uid 0" "$output"
+        return 1
+    fi
+    if ! grep -qx "root" <<< "$output"; then
+        fail "sudo did not yield root username" "$output"
+        return 1
+    fi
+
+    pass "sudo -n from ${SVC_ACCOUNT} runs as root (nopasswd path)"
+    return 0
+}
+
+test_service_account_bad_key_rejected() {
+    TESTS_RUN=$((TESTS_RUN + 1))
+    log "Testing that a different ed25519 key is rejected for ${SVC_ACCOUNT}..."
+
+    local bad_key="/tmp/test_integration_svc_bad"
+    rm -f "$bad_key" "${bad_key}.pub"
+    ssh-keygen -t ed25519 -f "$bad_key" -N "" -q
+
+    local output rc
+    output=$(ssh -i "$bad_key" \
+                 -o IdentitiesOnly=yes \
+                 -o StrictHostKeyChecking=no \
+                 -o UserKnownHostsFile=/dev/null \
+                 -o BatchMode=yes \
+                 -o ConnectTimeout=10 \
+                 -p 2222 \
+                 "${SVC_ACCOUNT}@localhost" \
+                 "echo SHOULD_NEVER_PRINT" 2>&1) || true
+    rc=$?
+    rm -f "$bad_key" "${bad_key}.pub"
+    log_verbose "SSH(bad key) rc=$rc output: $output"
+
+    if grep -q "SHOULD_NEVER_PRINT" <<< "$output"; then
+        fail "An unrelated key was accepted for ${SVC_ACCOUNT}" "$output"
+        return 1
+    fi
+    if ! grep -qE "Permission denied|Connection closed|Authentication failed" <<< "$output"; then
+        fail "SSH with wrong key did not fail with a permission denial" "$output"
+        return 1
+    fi
+
+    pass "A non-registered SSH key is rejected for ${SVC_ACCOUNT}"
+    return 0
+}
+
+# =============================================================================
 # Main
 # =============================================================================
 
@@ -916,7 +1204,18 @@ main() {
     test_password_auth_disabled
 
     echo ""
-    echo "=== Phase 7: Cert revocation via fingerprint binding ==="
+    echo "=== Phase 7: Service-account SSH key + sudo ==="
+    # Must run before the revocation phase (which invalidates the cert used
+    # earlier) but has no ordering dependency with Phase 6: the service
+    # account uses a distinct username unknown to LLNG.
+    test_service_account_provision
+    test_service_account_ssh_login
+    test_service_account_local_user_created
+    test_service_account_sudo
+    test_service_account_bad_key_rejected
+
+    echo ""
+    echo "=== Phase 8: Cert revocation via fingerprint binding ==="
     # MUST run last: /ssh/myrevoke invalidates the test cert and would
     # break any subsequent test that relies on a valid certificate.
     test_pam_authorize_rejects_revoked_cert

--- a/tests/test_integration_maxsec.sh
+++ b/tests/test_integration_maxsec.sh
@@ -1126,7 +1126,7 @@ test_service_account_bad_key_rejected() {
     rm -f "$bad_key" "${bad_key}.pub"
     ssh-keygen -t ed25519 -f "$bad_key" -N "" -q
 
-    local output rc
+    local output rc=0
     output=$(ssh -i "$bad_key" \
                  -o IdentitiesOnly=yes \
                  -o StrictHostKeyChecking=no \
@@ -1135,8 +1135,7 @@ test_service_account_bad_key_rejected() {
                  -o ConnectTimeout=10 \
                  -p 2222 \
                  "${SVC_ACCOUNT}@localhost" \
-                 "echo SHOULD_NEVER_PRINT" 2>&1) || true
-    rc=$?
+                 "echo SHOULD_NEVER_PRINT" 2>&1) || rc=$?
     rm -f "$bad_key" "${bad_key}.pub"
     log_verbose "SSH(bad key) rc=$rc output: $output"
 

--- a/tests/test_integration_token_svc.sh
+++ b/tests/test_integration_token_svc.sh
@@ -1,0 +1,452 @@
+#!/bin/bash
+#
+# test_integration_token_svc.sh
+#
+# Integration test for docker-demo-token-svc: the Token authentication
+# demo (LLNG tokens as SSH passwords) augmented with local service
+# accounts (ansible, backup, ...) that authenticate via a plain SSH
+# key listed in /etc/open-bastion/service-accounts.conf and are NOT
+# signed by any SSH CA.
+#
+# Scope:
+#   - bring up the docker-demo-token-svc stack
+#   - verify a human user can still get an LLNG access token
+#   - provision a service account on the bastion at runtime
+#   - SSH as that service account with its plain key
+#   - check that the local Unix account was created on first login
+#   - check that sudo -n works (sudo_nopasswd path)
+#   - check that a non-registered key is refused
+#
+# Usage:
+#   ./tests/test_integration_token_svc.sh [--keep] [--verbose]
+#
+
+set -e
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+KEEP_CONTAINERS=0
+VERBOSE=0
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --keep) KEEP_CONTAINERS=1; shift ;;
+        --verbose|-v) VERBOSE=1; shift ;;
+        *) echo "Unknown option: $1"; exit 1 ;;
+    esac
+done
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+DOCKER_DIR="$PROJECT_DIR/docker-demo-token-svc"
+COOKIE_FILE="/tmp/llng-token-svc-cookies"
+SVC_KEY="/tmp/test_token_svc_key"
+
+PORTAL_URL="http://localhost:80"
+TEST_USER="dwho"
+TEST_PASSWORD="dwho"
+
+# Service account used for the SSH-key-only scenario. Unknown to LLNG.
+SVC_ACCOUNT="ansible-ci"
+SVC_UID=5000
+SVC_GID=5000
+
+log()      { echo -e "${GREEN}[TEST]${NC} $*"; }
+log_warn() { echo -e "${YELLOW}[WARN]${NC} $*"; }
+log_error(){ echo -e "${RED}[ERROR]${NC} $*"; }
+log_verbose(){ [[ $VERBOSE -eq 1 ]] && echo -e "[DEBUG] $*" || true; }
+pass() { TESTS_PASSED=$((TESTS_PASSED + 1)); echo -e "${GREEN}[PASS]${NC} $1"; }
+fail() {
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}[FAIL]${NC} $1"
+    [[ -n "$2" ]] && echo "       Details: $2"
+}
+
+cleanup() {
+    log "Cleaning up..."
+    rm -f "$COOKIE_FILE" "${SVC_KEY}" "${SVC_KEY}.pub" 2>/dev/null || true
+    if [[ $KEEP_CONTAINERS -eq 0 ]]; then
+        log "Stopping containers..."
+        cd "$DOCKER_DIR" && docker compose down --volumes --remove-orphans 2>/dev/null || true
+    else
+        log_warn "Keeping containers running (--keep specified)"
+    fi
+}
+trap cleanup EXIT
+
+check_requirements() {
+    log "Checking requirements..."
+    local missing=0
+    for cmd in docker jq curl ssh-keygen; do
+        if ! command -v "$cmd" &>/dev/null; then
+            log_error "$cmd not found"
+            missing=1
+        fi
+    done
+    if ! docker compose version &>/dev/null; then
+        log_error "docker compose not found"
+        missing=1
+    fi
+    [[ $missing -eq 1 ]] && exit 1
+    log "All requirements satisfied"
+}
+
+start_containers() {
+    log "Building and starting docker-demo-token-svc..."
+    cd "$DOCKER_DIR"
+
+    # Stop any conflicting compose projects sharing the :80 and :2222
+    # bindings before we start our own.
+    for d in docker-demo-token docker-demo-token-svc docker-demo-cert docker-demo-maxsec; do
+        if [ -d "$PROJECT_DIR/$d" ]; then
+            (cd "$PROJECT_DIR/$d" && docker compose down --volumes --remove-orphans 2>/dev/null) || true
+        fi
+    done
+    cd "$DOCKER_DIR"
+
+    if [[ $VERBOSE -eq 1 ]]; then
+        docker compose build
+    else
+        docker compose build --quiet
+    fi
+    docker compose up -d
+
+    log "Waiting for SSO to be healthy..."
+    local waited=0
+    while [[ $waited -lt 120 ]]; do
+        if curl -sf "$PORTAL_URL/" >/dev/null 2>&1; then
+            log "SSO is healthy after ${waited}s"
+            return 0
+        fi
+        sleep 2
+        ((waited+=2))
+    done
+    log_error "SSO did not become healthy within 120s"
+    docker compose logs sso
+    return 1
+}
+
+wait_for_bastion() {
+    log "Waiting for bastion enrollment..."
+    local waited=0
+    while [[ $waited -lt 60 ]]; do
+        if docker exec ob-token-svc-bastion test -f /etc/open-bastion/server_token.json 2>/dev/null; then
+            log "Bastion enrolled after ${waited}s"
+            return 0
+        fi
+        sleep 2
+        ((waited+=2))
+    done
+    log_error "Bastion did not enroll within 60s"
+    docker logs ob-token-svc-bastion
+    return 1
+}
+
+# ---------------------------------------------------------------------
+# Sanity tests (token path still works)
+# ---------------------------------------------------------------------
+
+test_llng_authentication() {
+    TESTS_RUN=$((TESTS_RUN + 1))
+    log "Testing LLNG authentication via llng CLI..."
+
+    rm -f "$COOKIE_FILE"
+    local output
+    output=$(llng --llng-url "$PORTAL_URL" \
+                  --login "$TEST_USER" \
+                  --password "$TEST_PASSWORD" \
+                  --cookie-jar "$COOKIE_FILE" \
+                  llng_cookie 2>&1) || true
+    log_verbose "llng output: $output"
+
+    if [[ -f "$COOKIE_FILE" ]] && grep -q "lemonldap" "$COOKIE_FILE"; then
+        pass "LLNG authentication successful (human user path)"
+    else
+        fail "LLNG authentication failed" "$output"
+    fi
+}
+
+test_bastion_service_accounts_file_present() {
+    TESTS_RUN=$((TESTS_RUN + 1))
+    log "Checking that bastion has a blank service-accounts.conf + dir..."
+
+    local perms
+    perms=$(docker exec ob-token-svc-bastion stat -c '%u %a' /etc/open-bastion/service-accounts.conf 2>/dev/null || echo "missing")
+    log_verbose "service-accounts.conf perms: $perms"
+    if [[ "$perms" != "0 600" ]]; then
+        fail "service-accounts.conf must be 0600 root:root, got: $perms"
+        return 1
+    fi
+
+    local dir_perms
+    dir_perms=$(docker exec ob-token-svc-bastion stat -c '%u %a' /etc/open-bastion/service-accounts.d 2>/dev/null || echo "missing")
+    log_verbose "service-accounts.d perms: $dir_perms"
+    if [[ "$dir_perms" != "0 755" ]]; then
+        fail "service-accounts.d must be 0755 root:root, got: $dir_perms"
+        return 1
+    fi
+
+    pass "service-accounts config scaffold in place"
+}
+
+# ---------------------------------------------------------------------
+# Service account tests
+# ---------------------------------------------------------------------
+
+svc_provision_on_bastion() {
+    local pubkey
+    pubkey=$(cat "${SVC_KEY}.pub")
+    local fp
+    fp=$(ssh-keygen -l -E sha256 -f "${SVC_KEY}.pub" | awk '{print $2}')
+
+    docker exec -i ob-token-svc-bastion sh -c "cat > /etc/open-bastion/service-accounts.conf" <<EOF
+[${SVC_ACCOUNT}]
+key_fingerprint = ${fp}
+sudo_allowed = true
+sudo_nopasswd = true
+gecos = CI service account
+shell = /bin/bash
+home = /home/${SVC_ACCOUNT}
+uid = ${SVC_UID}
+gid = ${SVC_GID}
+EOF
+    docker exec ob-token-svc-bastion chown root:root /etc/open-bastion/service-accounts.conf
+    docker exec ob-token-svc-bastion chmod 600 /etc/open-bastion/service-accounts.conf
+
+    docker exec -i ob-token-svc-bastion sh -c \
+        "cat > /etc/open-bastion/service-accounts.d/${SVC_ACCOUNT}.pub" <<< "$pubkey"
+    docker exec ob-token-svc-bastion chown root:root \
+        "/etc/open-bastion/service-accounts.d/${SVC_ACCOUNT}.pub"
+    docker exec ob-token-svc-bastion chmod 644 \
+        "/etc/open-bastion/service-accounts.d/${SVC_ACCOUNT}.pub"
+
+    # Drop a user-specific NOPASSWD rule at the end of /etc/sudoers so it
+    # wins over the demo image's default "ALL ALL=(ALL:ALL) ALL"
+    # (sudoers is last-match-wins).
+    docker exec ob-token-svc-bastion sh -c "
+        set -e
+        grep -qE '^${SVC_ACCOUNT}[[:space:]]+ALL=.*NOPASSWD' /etc/sudoers || \
+            printf '%s\n' '${SVC_ACCOUNT} ALL=(ALL:ALL) NOPASSWD: ALL' >> /etc/sudoers
+        visudo -c >/dev/null
+    "
+}
+
+test_service_account_provision() {
+    TESTS_RUN=$((TESTS_RUN + 1))
+    log "Provisioning service account ${SVC_ACCOUNT}..."
+
+    rm -f "${SVC_KEY}" "${SVC_KEY}.pub"
+    if ! ssh-keygen -t ed25519 -f "${SVC_KEY}" -N "" -q; then
+        fail "Failed to generate service account SSH key"
+        return 1
+    fi
+    if ! svc_provision_on_bastion; then
+        fail "Failed to provision service account on bastion"
+        return 1
+    fi
+
+    # User must not exist locally yet.
+    if docker exec ob-token-svc-bastion grep -q "^${SVC_ACCOUNT}:" /etc/passwd 2>/dev/null; then
+        fail "Service account already exists locally before first login"
+        return 1
+    fi
+
+    local helper_out
+    helper_out=$(docker exec ob-token-svc-bastion \
+        /usr/local/bin/ob-service-account-keys "${SVC_ACCOUNT}" 2>/dev/null || true)
+    if ! grep -q "ssh-ed25519" <<< "$helper_out"; then
+        fail "ob-service-account-keys returned no ed25519 key" "$helper_out"
+        return 1
+    fi
+
+    pass "Service account ${SVC_ACCOUNT} provisioned (key + conf + sudoers)"
+}
+
+test_service_account_ssh_login() {
+    TESTS_RUN=$((TESTS_RUN + 1))
+    log "Testing SSH login as ${SVC_ACCOUNT} (plain key, no SSO)..."
+
+    if [[ ! -f "${SVC_KEY}" ]]; then
+        fail "Service account key missing; provisioning step must run first"
+        return 1
+    fi
+
+    local output rc=0
+    output=$(ssh -i "${SVC_KEY}" \
+                 -o IdentitiesOnly=yes \
+                 -o StrictHostKeyChecking=no \
+                 -o UserKnownHostsFile=/dev/null \
+                 -o BatchMode=yes \
+                 -o ConnectTimeout=10 \
+                 -p 2222 \
+                 "${SVC_ACCOUNT}@localhost" \
+                 "whoami && id -u && id -g" 2>&1) || rc=$?
+    log_verbose "SSH(svc) rc=$rc output: $output"
+
+    if [[ $rc -ne 0 ]]; then
+        fail "SSH login as ${SVC_ACCOUNT} failed" "$output"
+        return 1
+    fi
+    if ! grep -qx "${SVC_ACCOUNT}" <<< "$output"; then
+        fail "whoami did not report ${SVC_ACCOUNT}" "$output"
+        return 1
+    fi
+    if ! grep -qx "${SVC_UID}" <<< "$output"; then
+        fail "Wrong uid (expected ${SVC_UID})" "$output"
+        return 1
+    fi
+    if ! grep -qx "${SVC_GID}" <<< "$output"; then
+        fail "Wrong gid (expected ${SVC_GID})" "$output"
+        return 1
+    fi
+
+    pass "Service account ${SVC_ACCOUNT} logged in with uid=${SVC_UID}, gid=${SVC_GID}"
+}
+
+test_service_account_local_user_created() {
+    TESTS_RUN=$((TESTS_RUN + 1))
+    log "Checking local Unix account was materialised..."
+
+    local entry
+    entry=$(docker exec ob-token-svc-bastion grep -E "^${SVC_ACCOUNT}:" /etc/passwd 2>&1) || true
+    log_verbose "passwd: $entry"
+    if [[ -z "$entry" ]]; then
+        fail "No /etc/passwd entry for ${SVC_ACCOUNT}"
+        return 1
+    fi
+
+    local u g h s
+    u=$(cut -d: -f3 <<< "$entry")
+    g=$(cut -d: -f4 <<< "$entry")
+    h=$(cut -d: -f6 <<< "$entry")
+    s=$(cut -d: -f7 <<< "$entry")
+
+    [[ "$u" == "${SVC_UID}" ]] || { fail "uid=$u (expected ${SVC_UID})" "$entry"; return 1; }
+    [[ "$g" == "${SVC_GID}" ]] || { fail "gid=$g (expected ${SVC_GID})" "$entry"; return 1; }
+    [[ "$h" == "/home/${SVC_ACCOUNT}" ]] || { fail "home=$h" "$entry"; return 1; }
+    [[ "$s" == "/bin/bash" ]] || { fail "shell=$s" "$entry"; return 1; }
+
+    local group_entry
+    group_entry=$(docker exec ob-token-svc-bastion \
+        awk -F: -v gid="${SVC_GID}" '$3 == gid {print; exit}' /etc/group 2>&1)
+    if [[ -z "$group_entry" ]]; then
+        fail "No /etc/group entry for gid ${SVC_GID}"
+        return 1
+    fi
+
+    pass "/etc/passwd + /etc/group entries materialised by pam_openbastion"
+}
+
+test_service_account_sudo() {
+    TESTS_RUN=$((TESTS_RUN + 1))
+    log "Testing sudo -n from service account session..."
+
+    local output rc=0
+    output=$(ssh -i "${SVC_KEY}" \
+                 -o IdentitiesOnly=yes \
+                 -o StrictHostKeyChecking=no \
+                 -o UserKnownHostsFile=/dev/null \
+                 -o BatchMode=yes \
+                 -o ConnectTimeout=10 \
+                 -p 2222 \
+                 "${SVC_ACCOUNT}@localhost" \
+                 "sudo -n id -u && sudo -n id -un" 2>&1) || rc=$?
+    log_verbose "SSH(svc+sudo) rc=$rc output: $output"
+
+    if [[ $rc -ne 0 ]]; then
+        fail "sudo -n as ${SVC_ACCOUNT} failed" "$output"
+        return 1
+    fi
+    grep -qx "0" <<< "$output"    || { fail "sudo uid != 0" "$output"; return 1; }
+    grep -qx "root" <<< "$output" || { fail "sudo user != root" "$output"; return 1; }
+
+    pass "sudo -n from ${SVC_ACCOUNT} yields uid 0"
+}
+
+test_service_account_bad_key_rejected() {
+    TESTS_RUN=$((TESTS_RUN + 1))
+    log "Testing that a different ed25519 key is rejected..."
+
+    local bad_key="/tmp/test_token_svc_bad"
+    rm -f "$bad_key" "${bad_key}.pub"
+    ssh-keygen -t ed25519 -f "$bad_key" -N "" -q
+
+    local output rc=0
+    output=$(ssh -i "$bad_key" \
+                 -o IdentitiesOnly=yes \
+                 -o StrictHostKeyChecking=no \
+                 -o UserKnownHostsFile=/dev/null \
+                 -o BatchMode=yes \
+                 -o PreferredAuthentications=publickey \
+                 -o ConnectTimeout=10 \
+                 -p 2222 \
+                 "${SVC_ACCOUNT}@localhost" \
+                 "echo SHOULD_NEVER_PRINT" 2>&1) || rc=$?
+    rm -f "$bad_key" "${bad_key}.pub"
+    log_verbose "SSH(bad key) rc=$rc output: $output"
+
+    if grep -q "SHOULD_NEVER_PRINT" <<< "$output"; then
+        fail "An unrelated key was accepted for ${SVC_ACCOUNT}" "$output"
+        return 1
+    fi
+    if ! grep -qE "Permission denied|Connection closed|Authentication failed" <<< "$output"; then
+        fail "SSH with wrong key did not fail as expected" "$output"
+        return 1
+    fi
+
+    pass "A non-registered SSH key is rejected for ${SVC_ACCOUNT}"
+}
+
+# ---------------------------------------------------------------------
+
+main() {
+    echo "=========================================================="
+    echo "  Open Bastion Integration Tests - Token + Service Accounts"
+    echo "=========================================================="
+    echo ""
+    check_requirements
+
+    echo ""
+    echo "=== Phase 1: Setup ==="
+    start_containers
+    wait_for_bastion
+
+    echo ""
+    echo "=== Phase 2: Sanity ==="
+    test_llng_authentication
+    test_bastion_service_accounts_file_present
+
+    echo ""
+    echo "=== Phase 3: Service account SSH key + sudo ==="
+    test_service_account_provision
+    test_service_account_ssh_login
+    test_service_account_local_user_created
+    test_service_account_sudo
+    test_service_account_bad_key_rejected
+
+    echo ""
+    echo "=========================================================="
+    echo "  Test Results"
+    echo "=========================================================="
+    echo "  Tests run:    $TESTS_RUN"
+    echo -e "  ${GREEN}Passed:       $TESTS_PASSED${NC}"
+    if [[ $TESTS_FAILED -gt 0 ]]; then
+        echo -e "  ${RED}Failed:       $TESTS_FAILED${NC}"
+        echo ""
+        echo -e "${RED}Some tests failed!${NC}"
+        exit 1
+    else
+        echo "  Failed:       $TESTS_FAILED"
+        echo ""
+        echo -e "${GREEN}All tests passed!${NC}"
+    fi
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

End-to-end support for service accounts in Mode E: a user declared only in `service-accounts.conf` on the bastion can now SSH in with a plain (non-SSO-signed) key, have its local Unix account materialised on first login, and run `sudo` without password when `sudo_nopasswd = true` is set.

Touches the three layers where it was broken:

- **PAM module** (`src/pam_openbastion.c`)
  - `create_unix_user()` accepts `forced_uid`/`forced_gid` and auto-creates the primary group when the account is unknown to NSS.
  - `pam_sm_open_session()` fetches the service-account struct and passes uid/gid through.
  - `pam_sm_acct_mgmt()` now sets the `ob_service_account` marker + gecos/shell/home PAM data, because sshd with `UsePAM yes` + pubkey auth **does not call `pam_authenticate`** — only `account` and `session` phases run. Also does a defense-in-depth re-check of the SSH key fingerprint from `SSH_USER_AUTH`.
  - `pam_sm_authenticate()` service-account path: short-circuits the SSH fingerprint extraction when `service == "sudo"` and `sudo_nopasswd` is true (no `SSH_USER_AUTH` in a sudo context).

- **NSS module** (`nss/libnss_openbastion.c`)
  - New `query_service_account()` resolves service accounts locally from `service-accounts.conf` before falling back to the LLNG HTTP query. Unblocks sshd's pre-auth `getpwnam()` check, which otherwise logs `Invalid user <name>` and closes the connection before PAM ever sees it. Since `service-accounts.conf` is `0600 root:root`, unprivileged callers silently fall through.

- **Mode E SSH layer** (`docker-demo-maxsec/bastion/*`, `scripts/ob-service-account-keys`)
  - New `AuthorizedKeysCommand` helper that returns the authorised public key for registered service accounts, allowing sshd to accept the plain key at the SSH layer without weakening the "`AuthorizedKeysFile none`" Mode E guarantee. Runs as `nobody`; reads only the `.pub` file under `/etc/open-bastion/service-accounts.d/`.
  - bastion `entrypoint.sh`: wire up `AuthorizedKeysCommand`, add `service_accounts_file` + `create_user = true` to `openbastion.conf`, create empty `service-accounts.conf` with correct perms, add `pam_openbastion.so` to the session phase with `create_user=true`.

## Test plan

All 24 integration tests pass locally (`tests/test_integration_maxsec.sh`), including the new Phase 7 (service-account SSH + sudo):

- [x] `test_service_account_provision`: generate ed25519 key, write `service-accounts.conf` + `.pub`, add `NOPASSWD` to `/etc/sudoers` (last-match-wins to override `%open-bastion-sudo`), verify `ob-service-account-keys` returns the key.
- [x] `test_service_account_ssh_login`: SSH with plain key, check uid/gid match `service-accounts.conf`.
- [x] `test_service_account_local_user_created`: `/etc/passwd` + `/etc/group` entries materialised.
- [x] `test_service_account_sudo`: `sudo -n id` yields uid 0.
- [x] `test_service_account_bad_key_rejected`: unrelated ed25519 key refused with `Permission denied`.
- [x] All previous maxsec tests (unsigned key rejected, KRL, cert revocation via `/ssh/myrevoke`, etc.) still pass.
- [x] 22/22 C unit tests still pass.