### PR TITLE
Session containment hardening (PR1) — close setsid/at/cron evasion channels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 build/
 build-core/
 build-desktop/
+build-test/
 
 # Editor files
 *~

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -226,6 +226,22 @@ install(PROGRAMS ${CMAKE_SOURCE_DIR}/scripts/ob-ssh-cert
     DESTINATION ${CMAKE_INSTALL_BINDIR}
 )
 
+# Install hardening templates (session containment - PR1)
+# These are deployed by ob-bastion-setup into /etc/{systemd/logind.conf.d,security/limits.d,at.allow,cron.allow}
+# See doc/hardening.md for rationale.
+install(FILES ${CMAKE_SOURCE_DIR}/config/hardening/logind.conf.d/open-bastion.conf
+    DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/open-bastion/hardening/logind.conf.d
+)
+install(FILES ${CMAKE_SOURCE_DIR}/config/hardening/security/limits.d/open-bastion.conf
+    DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/open-bastion/hardening/security/limits.d
+)
+install(FILES ${CMAKE_SOURCE_DIR}/config/hardening/at.allow
+    DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/open-bastion/hardening
+)
+install(FILES ${CMAKE_SOURCE_DIR}/config/hardening/cron.allow
+    DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/open-bastion/hardening
+)
+
 # Install setup scripts (admin-facing)
 install(PROGRAMS ${CMAKE_SOURCE_DIR}/scripts/ob-bastion-setup
     DESTINATION ${CMAKE_INSTALL_SBINDIR}

--- a/config/hardening/at.allow
+++ b/config/hardening/at.allow
@@ -1,0 +1,3 @@
+# Open Bastion: only users listed here can use at(1).
+# Empty (root only) by design — non-sudo users must not schedule
+# deferred commands that would run outside the recorded session.

--- a/config/hardening/cron.allow
+++ b/config/hardening/cron.allow
@@ -1,0 +1,4 @@
+# Open Bastion: only users listed here can use crontab(1).
+# Add admin/sudoer accounts as needed. The package needs root to
+# manage system crontabs in /etc/cron.d/.
+root

--- a/config/hardening/logind.conf.d/open-bastion.conf
+++ b/config/hardening/logind.conf.d/open-bastion.conf
@@ -1,0 +1,5 @@
+# Open Bastion: kill all user processes at logout, including those
+# detached via setsid/nohup. Required for session containment so users
+# cannot leave background processes running after disconnect.
+[Login]
+KillUserProcesses=yes

--- a/config/hardening/security/limits.d/open-bastion.conf
+++ b/config/hardening/security/limits.d/open-bastion.conf
@@ -1,0 +1,4 @@
+# Open Bastion: cap process count per user to prevent fork bombs.
+# Adjust if legitimate workloads need more.
+*    hard    nproc    256
+root hard    nproc    unlimited

--- a/config/hardening/security/limits.d/open-bastion.conf
+++ b/config/hardening/security/limits.d/open-bastion.conf
@@ -2,3 +2,12 @@
 # Adjust if legitimate workloads need more.
 *    hard    nproc    256
 root hard    nproc    unlimited
+
+# Service accounts (group `ob-service`) may run parallel build/CI
+# workloads (make -j, pytest -n auto, etc.) that legitimately exceed
+# the 256-process cap. Exempt them. The group is created out-of-band
+# (the package does not create it; an operator who wants this
+# exemption runs `groupadd --system ob-service` and adds the relevant
+# service accounts to it). If the group does not exist on this host,
+# pam_limits silently ignores this line.
+@ob-service hard nproc unlimited

--- a/debian/open-bastion.install
+++ b/debian/open-bastion.install
@@ -39,6 +39,12 @@ debian/tmp/usr/share/man/man8/ob-session-recorder.8
 debian/tmp/usr/share/open-bastion/audit/rules.d/open-bastion.rules
 debian/tmp/usr/share/open-bastion/audit/cron.daily/open-bastion-audit-rotate
 
+# Hardening templates (deployed by `ob-bastion-setup --enable-hardening`)
+debian/tmp/usr/share/open-bastion/hardening/logind.conf.d/open-bastion.conf
+debian/tmp/usr/share/open-bastion/hardening/security/limits.d/open-bastion.conf
+debian/tmp/usr/share/open-bastion/hardening/at.allow
+debian/tmp/usr/share/open-bastion/hardening/cron.allow
+
 # Documentation
 debian/tmp/usr/share/doc/open-bastion/README.md
 

--- a/doc/README.md
+++ b/doc/README.md
@@ -15,6 +15,7 @@
 | [Service Accounts](service-accounts.md)         | Ansible, backup, CI/CD accounts               |
 | [Bastion Architecture](bastion-architecture.md) | Bastion-to-backend JWT authentication         |
 | [Session Recording](session-recording.md)       | SSH session recording for audit               |
+| [Session Containment Hardening](hardening.md)   | logind, limits, at/cron containment           |
 | [Primary Audit Trace](audit.md)                 | Optional auditd-based syscall audit trail     |
 | [CrowdSec Integration](crowdsec.md)             | IP blocking and alert reporting               |
 | [Security Features](security.md)                | Key policies, rate limiting, cache protection |

--- a/doc/hardening.md
+++ b/doc/hardening.md
@@ -130,13 +130,40 @@ ps -u user | grep sleep        # → no output
 If `sleep` is still running, either `KillUserProcesses=yes` was not
 applied (logind not reloaded?) or the user has `Linger=yes`.
 
+## Lifecycle of the deployed files
+
+The four files written under `/etc/` (`at.allow`, `cron.allow`,
+`systemd/logind.conf.d/open-bastion.conf`,
+`security/limits.d/open-bastion.conf`) are **deployment artefacts of
+`ob-bastion-setup`**, not package-managed conffiles. The hardening step
+is opt-in (the operator runs `ob-bastion-setup` and confirms the
+prompt), so the package itself does not place these files.
+
+Practical consequences:
+
+- `apt purge open-bastion` (or `rpm -e open-bastion`) **does not
+  remove** `/etc/at.allow`, `/etc/cron.allow`,
+  `/etc/systemd/logind.conf.d/open-bastion.conf`, or
+  `/etc/security/limits.d/open-bastion.conf`. Remove them with `rm`
+  if you no longer want the hardening.
+- A package upgrade **does not overwrite** them either. Re-run
+  `ob-bastion-setup` after an upgrade if a template changes and you
+  want the new content; the script backs up the existing file before
+  replacing it.
+- The templates themselves live under `/usr/share/open-bastion/hardening/`
+  and *are* reinstalled on upgrade. They are read-only references; do
+  not edit them.
+
+To reapply or update the deployed files, edit them under `/etc/` and
+either re-run the relevant step (e.g. `systemctl reload systemd-logind`
+after touching the logind drop-in) or re-run `ob-bastion-setup` (which
+will back up and overwrite the logind/limits drop-ins, and warn if it
+finds an admin-managed `at.allow` or `cron.allow`).
+
 ## Disabling parts of the hardening
 
 If a deployment needs a specific subsystem back, edit the deployed
-files in `/etc/`, **not** the templates under `/usr/share/`. The
-templates are reinstalled on every package upgrade, but `/etc/` files
-are preserved (`%config(noreplace)` on RPM, dpkg conffile semantics on
-Debian).
+files in `/etc/` directly.
 
 | Re-enable           | What to do                                                                                                             |
 | ------------------- | ---------------------------------------------------------------------------------------------------------------------- |

--- a/doc/hardening.md
+++ b/doc/hardening.md
@@ -34,9 +34,12 @@ the recorder leaves a primary trace independent of the wrapper.
 | `/etc/cron.allow`                               | `share/open-bastion/hardening/cron.allow`                | Whitelist: `root` only. Add admins as needed.                                                 |
 | `systemctl mask atd`                            | —                                                        | Disables the at daemon entirely if it is installed.                                           |
 
-`systemd-logind` is reloaded at the end of the step. **This kills any
-active user session on the host** — run the setup outside business
-hours or warn users first.
+`systemd-logind` is reloaded at the end of the step via `systemctl
+reload systemd-logind` (SIGHUP). This is **non-disruptive**: logind
+re-reads `/etc/systemd/logind.conf.d/*.conf` without restarting and
+without killing active sessions. `KillUserProcesses=yes` is consulted
+when each session ends, so existing sessions stay open and the new
+behaviour applies to their cleanup.
 
 `cron.service` is **not** masked. `ob-bastion-setup --max-security`
 writes `/etc/cron.d/open-bastion-krl` to refresh the SSH key
@@ -169,7 +172,7 @@ files in `/etc/` directly.
 | ------------------- | ---------------------------------------------------------------------------------------------------------------------- |
 | `at(1)` for a user  | Add the username to `/etc/at.allow`, then `systemctl unmask atd && systemctl enable --now atd`.                        |
 | `crontab` for a user | Add the username to `/etc/cron.allow`. (`cron.service` is already running.)                                            |
-| Background processes | Remove `/etc/systemd/logind.conf.d/open-bastion.conf`, then `systemctl restart systemd-logind`. Discouraged on a bastion. |
+| Background processes | Remove `/etc/systemd/logind.conf.d/open-bastion.conf`, then `systemctl reload systemd-logind`. Discouraged on a bastion. |
 | Higher `nproc`       | Add a more specific drop-in **after** `open-bastion.conf` (alphabetical order, e.g. `99-build.conf`).                  |
 
 To skip the entire step at install time:

--- a/doc/hardening.md
+++ b/doc/hardening.md
@@ -4,9 +4,18 @@
 > primary trace) will be tracked separately.
 
 This document describes the host-level configuration deployed by
-`ob-bastion-setup` to keep an authenticated user from escaping the
-recorded SSH session. Everything here is **pure system configuration** —
-no setuid binary is added.
+`ob-bastion-setup --enable-hardening` to keep an authenticated user from
+escaping the recorded SSH session. Everything here is **pure system
+configuration** — no setuid binary is added.
+
+> **Opt-in only.** System-wide changes (logind `KillUserProcesses`,
+> masking `atd`, `at`/`cron` allow-lists, `nproc` limits) are too
+> invasive to apply silently on every `ob-bastion-setup` run. Following
+> Debian packaging convention, a setup script must not modify global
+> system behaviour without an explicit opt-in. On a dedicated bastion
+> host where this script will be the primary configuration, hardening is
+> recommended. On a multi-purpose host or for testing, leave it off and
+> apply manually if needed.
 
 ## Threat model
 
@@ -24,7 +33,7 @@ PR1 closes channels (1)–(3) by configuration. PR2 will additionally
 log every `execve()` system-wide via `auditd` so any attempt to bypass
 the recorder leaves a primary trace independent of the wrapper.
 
-## What `ob-bastion-setup` deploys
+## What `ob-bastion-setup --enable-hardening` deploys
 
 | Destination                                     | Source template                                          | Purpose                                                                                       |
 | ----------------------------------------------- | -------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
@@ -73,7 +82,7 @@ linger for each of them and re-run the setup:
 
 ```bash
 loginctl disable-linger <user>
-ob-bastion-setup --portal https://…   # re-run
+ob-bastion-setup --portal https://… --enable-hardening   # re-run
 ```
 
 You can confirm the state at any time with:
@@ -179,9 +188,10 @@ applied (logind not reloaded?) or the user has `Linger=yes`.
 The four files written under `/etc/` (`at.allow`, `cron.allow`,
 `systemd/logind.conf.d/open-bastion.conf`,
 `security/limits.d/open-bastion.conf`) are **deployment artefacts of
-`ob-bastion-setup`**, not package-managed conffiles. The hardening step
-is opt-in (the operator runs `ob-bastion-setup` and confirms the
-prompt), so the package itself does not place these files.
+`ob-bastion-setup --enable-hardening`**, not package-managed conffiles.
+The hardening step is opt-in (the operator passes `--enable-hardening`
+and confirms the prompt), so the package itself does not place these
+files and a plain `ob-bastion-setup` run never touches them.
 
 Practical consequences:
 
@@ -200,9 +210,10 @@ Practical consequences:
 
 To reapply or update the deployed files, edit them under `/etc/` and
 either re-run the relevant step (e.g. `systemctl reload systemd-logind`
-after touching the logind drop-in) or re-run `ob-bastion-setup` (which
-will back up and overwrite the logind/limits drop-ins, and warn if it
-finds an admin-managed `at.allow` or `cron.allow`).
+after touching the logind drop-in) or re-run
+`ob-bastion-setup --enable-hardening` (which will back up and overwrite
+the logind/limits drop-ins, and warn if it finds an admin-managed
+`at.allow` or `cron.allow`).
 
 ## Disabling parts of the hardening
 
@@ -216,10 +227,10 @@ files in `/etc/` directly.
 | Background processes | Remove `/etc/systemd/logind.conf.d/open-bastion.conf`, then `systemctl reload systemd-logind`. Discouraged on a bastion. |
 | Higher `nproc`       | Add a more specific drop-in **after** `open-bastion.conf` (alphabetical order, e.g. `99-build.conf`).                  |
 
-To skip the entire step at install time:
+To activate the hardening at install time (opt-in, off by default):
 
 ```bash
-ob-bastion-setup --portal https://auth.example.com --skip-hardening
+ob-bastion-setup --portal https://auth.example.com --enable-hardening
 ```
 
 ## What PR1 does **not** cover

--- a/doc/hardening.md
+++ b/doc/hardening.md
@@ -61,18 +61,26 @@ If a legitimate user really needs to keep a long-running job, that
 should go through a service account (see `doc/service-accounts.md`)
 and a systemd unit, not a backgrounded shell on the bastion.
 
-`Linger=no` is the implicit default per user; you can confirm it
-post-deploy with:
+`Linger=no` is the implicit default per user. A user with
+`Linger=yes` (set via `loginctl enable-linger`) can keep processes
+running after logout *and* schedule deferred work via
+`systemd-run --user --on-active=…`, which would defeat both
+`KillUserProcesses=yes` and the `at`/`cron` allow-lists.
 
-```bash
-loginctl show-user <user> | grep -E 'Linger|State'
-```
-
-If `Linger=yes` for any user, that user has been allowed to keep
-processes after logout (`loginctl enable-linger`). Disable it:
+`ob-bastion-setup` therefore **refuses to apply the hardening** if any
+non-root user has linger enabled, and lists those users. Disable
+linger for each of them and re-run the setup:
 
 ```bash
 loginctl disable-linger <user>
+ob-bastion-setup --portal https://…   # re-run
+```
+
+You can confirm the state at any time with:
+
+```bash
+loginctl list-users
+loginctl show-user <user> | grep -E 'Linger|State'
 ```
 
 ## Why allow-listing `at` and `cron`

--- a/doc/hardening.md
+++ b/doc/hardening.md
@@ -95,6 +95,12 @@ We mask `atd` rather than only relying on `at.allow` because some
 distros ship `atd` enabled by default, and a mis-edited `at.allow`
 would silently re-open the channel.
 
+> **Note on `cron.allow`:** if the file already exists and does **not**
+> list `root` on a line by itself, `cron` will refuse to dispatch
+> root-owned jobs — including the Mode E KRL refresh job at
+> `/etc/cron.d/open-bastion-krl`. `ob-bastion-setup` warns when it
+> detects this and asks you to add `root` to `/etc/cron.allow`.
+
 ## Why a `nproc` cap
 
 Without it, a fork bomb (`:(){ :|:& };:`) inside the recorded session
@@ -103,6 +109,33 @@ trying to clean it up. 256 is comfortable for interactive use and
 common build/test workloads; raise it in `/etc/security/limits.d/`
 with a more specific drop-in (e.g. `99-build-agents.conf`) if a
 service account legitimately needs more.
+
+### Service-account exemption
+
+Service accounts (Ansible, GitLab Runner, deploy bots — see
+[`service-accounts.md`](service-accounts.md)) often run parallel
+build/CI workloads (`make -j`, `pytest -n auto`, container builds)
+that legitimately exceed 256 processes. The deployed
+`/etc/security/limits.d/open-bastion.conf` therefore exempts members
+of the `ob-service` group:
+
+```
+@ob-service hard nproc unlimited
+```
+
+The package does **not** create `ob-service` — it would be a footgun
+if it did, since an operator might unknowingly drop accounts in it
+later. To opt in:
+
+```bash
+groupadd --system ob-service
+gpasswd -a ansible ob-service       # repeat for each service account
+```
+
+If the group does not exist, `pam_limits` silently ignores the line
+and the cap stays at 256 for everyone except root. To exempt a
+different group instead, add a more specific drop-in (sorted *after*
+`open-bastion.conf` alphabetically, e.g. `99-ci.conf`).
 
 ## Verifying after deployment
 

--- a/doc/hardening.md
+++ b/doc/hardening.md
@@ -1,0 +1,170 @@
+# Session Containment Hardening
+
+> **Status (v0.1.x):** PR1 of a two-part hardening series. PR2 (auditd as
+> primary trace) will be tracked separately.
+
+This document describes the host-level configuration deployed by
+`ob-bastion-setup` to keep an authenticated user from escaping the
+recorded SSH session. Everything here is **pure system configuration** —
+no setuid binary is added.
+
+## Threat model
+
+`ob-session-recorder-wrapper` (setgid `root:ob-sessions`, mode `2755`)
+captures the pty via `script(1)`. An authenticated user can still try to:
+
+1. **Detach a process from the pty** with `setsid nohup … &`. The child
+   re-parents to PID 1 and survives logout, running outside the
+   recorded session.
+2. **Schedule deferred work** with `at(1)` or `crontab(1)`. The
+   commands run later, again outside the recorded session.
+3. **Fork bomb** the host to deny service to other users.
+
+PR1 closes channels (1)–(3) by configuration. PR2 will additionally
+log every `execve()` system-wide via `auditd` so any attempt to bypass
+the recorder leaves a primary trace independent of the wrapper.
+
+## What `ob-bastion-setup` deploys
+
+| Destination                                     | Source template                                          | Purpose                                                                                       |
+| ----------------------------------------------- | -------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
+| `/etc/systemd/logind.conf.d/open-bastion.conf`  | `share/open-bastion/hardening/logind.conf.d/…`           | `KillUserProcesses=yes` — logind reaps every process owned by a user when their last session ends. |
+| `/etc/security/limits.d/open-bastion.conf`      | `share/open-bastion/hardening/security/limits.d/…`       | Caps `nproc` per user at 256, root unlimited. Fork-bomb guardrail.                            |
+| `/etc/at.allow`                                 | `share/open-bastion/hardening/at.allow`                  | Whitelist: empty (root only by design). Non-root users cannot use `at(1)`.                    |
+| `/etc/cron.allow`                               | `share/open-bastion/hardening/cron.allow`                | Whitelist: `root` only. Add admins as needed.                                                 |
+| `systemctl mask atd`                            | —                                                        | Disables the at daemon entirely if it is installed.                                           |
+
+`systemd-logind` is reloaded at the end of the step. **This kills any
+active user session on the host** — run the setup outside business
+hours or warn users first.
+
+`cron.service` is **not** masked. `ob-bastion-setup --max-security`
+writes `/etc/cron.d/open-bastion-krl` to refresh the SSH key
+revocation list periodically; that job needs cron running. The
+allowlist is sufficient: only root can submit jobs via `crontab(1)`,
+and `/etc/cron.d/` already requires root to write.
+
+## Why `KillUserProcesses=yes`
+
+Without it, `setsid nohup <reverse-shell> &` survives `exit`: the
+child detaches from the pty, re-parents to PID 1, and the wrapper
+never sees its output again. The session recording stops at the
+wrapper exit, but the process keeps running with the user's
+credentials. With `KillUserProcesses=yes`, logind sends `SIGTERM`
+followed by `SIGKILL` to the user's slice when the last session ends,
+including children re-parented to init.
+
+If a legitimate user really needs to keep a long-running job, that
+should go through a service account (see `doc/service-accounts.md`)
+and a systemd unit, not a backgrounded shell on the bastion.
+
+`Linger=no` is the implicit default per user; you can confirm it
+post-deploy with:
+
+```bash
+loginctl show-user <user> | grep -E 'Linger|State'
+```
+
+If `Linger=yes` for any user, that user has been allowed to keep
+processes after logout (`loginctl enable-linger`). Disable it:
+
+```bash
+loginctl disable-linger <user>
+```
+
+## Why allow-listing `at` and `cron`
+
+`at` and `cron` run a command **at a later time**, outside the
+SSH session and outside the wrapper. Even with `KillUserProcesses=yes`
+on the SSH session, `atd`/`crond` would still execute the queued
+command from a fresh PID 1 child. The allow-lists prevent the user
+from queueing in the first place.
+
+We mask `atd` rather than only relying on `at.allow` because some
+distros ship `atd` enabled by default, and a mis-edited `at.allow`
+would silently re-open the channel.
+
+## Why a `nproc` cap
+
+Without it, a fork bomb (`:(){ :|:& };:`) inside the recorded session
+can saturate the host's PID space and deny service to other admins
+trying to clean it up. 256 is comfortable for interactive use and
+common build/test workloads; raise it in `/etc/security/limits.d/`
+with a more specific drop-in (e.g. `99-build-agents.conf`) if a
+service account legitimately needs more.
+
+## Verifying after deployment
+
+```bash
+# logind picked up KillUserProcesses
+busctl get-property org.freedesktop.login1 /org/freedesktop/login1 \
+    org.freedesktop.login1.Manager KillUserProcesses
+# Expected: b true
+
+# limits drop-in is parsed
+ulimit -u   # as a non-root user on the bastion → ≤ 256
+
+# at and cron whitelists in place, no extra users
+cat /etc/at.allow /etc/cron.allow
+
+# atd is gone
+systemctl is-enabled atd 2>&1   # masked / not-found
+
+# No user has linger enabled
+loginctl list-users
+loginctl show-user <user> | grep Linger
+```
+
+End-to-end manual check (the canonical PR1 acceptance test):
+
+```bash
+# From a workstation
+ssh user@bastion
+setsid nohup sleep 3600 &
+exit
+
+# From root on the bastion
+ps -u user | grep sleep        # → no output
+```
+
+If `sleep` is still running, either `KillUserProcesses=yes` was not
+applied (logind not reloaded?) or the user has `Linger=yes`.
+
+## Disabling parts of the hardening
+
+If a deployment needs a specific subsystem back, edit the deployed
+files in `/etc/`, **not** the templates under `/usr/share/`. The
+templates are reinstalled on every package upgrade, but `/etc/` files
+are preserved (`%config(noreplace)` on RPM, dpkg conffile semantics on
+Debian).
+
+| Re-enable           | What to do                                                                                                             |
+| ------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| `at(1)` for a user  | Add the username to `/etc/at.allow`, then `systemctl unmask atd && systemctl enable --now atd`.                        |
+| `crontab` for a user | Add the username to `/etc/cron.allow`. (`cron.service` is already running.)                                            |
+| Background processes | Remove `/etc/systemd/logind.conf.d/open-bastion.conf`, then `systemctl restart systemd-logind`. Discouraged on a bastion. |
+| Higher `nproc`       | Add a more specific drop-in **after** `open-bastion.conf` (alphabetical order, e.g. `99-build.conf`).                  |
+
+To skip the entire step at install time:
+
+```bash
+ob-bastion-setup --portal https://auth.example.com --skip-hardening
+```
+
+## What PR1 does **not** cover
+
+- **Primary trace.** If the wrapper crashes or is bypassed (e.g.
+  through a PAM mis-config), nothing else logs `execve()`. PR2 will
+  add an `auditd` ruleset that records every `execve()` system-wide,
+  so even a process that escapes the recorder leaves a syscall trail.
+- **Container escape / kernel exploits.** Out of scope; rely on
+  upstream kernel hardening and timely patching.
+- **`systemd-run --user` with a service template.** Covered by
+  `KillUserProcesses=yes` *only* if the user does not have linger
+  enabled. Confirm with `loginctl show-user`.
+
+## See also
+
+- [`session-recording.md`](session-recording.md) — wrapper and recorder details
+- [`security.md`](security.md) — broader security policy
+- [`SECURITY.md`](../SECURITY.md) — disclosure policy

--- a/doc/session-recording.md
+++ b/doc/session-recording.md
@@ -330,9 +330,43 @@ Future releases will support:
 
 See issues #17-20 in the project backlog.
 
+## Session containment
+
+Recording the pty is necessary but not sufficient. An authenticated user
+can detach work from the recorded session with `setsid nohup … &` (the
+child re-parents to PID 1 and survives logout), or schedule deferred
+commands with `at(1)` / `crontab(1)` that run outside the wrapper
+entirely.
+
+`ob-bastion-setup` deploys a set of host-level configuration drop-ins
+that close these channels — pure system config, no new setuid binary:
+
+- `KillUserProcesses=yes` in `systemd-logind` so any process owned by
+  the user is killed when their last session ends, including
+  `setsid`-detached children.
+- `at.allow` (empty) and `cron.allow` (root only) so non-sudo users
+  cannot schedule deferred jobs. `atd` is masked.
+- `nproc` cap (256, root unlimited) in `/etc/security/limits.d/` to
+  contain fork bombs.
+
+Verify post-deploy that no user has been opted out via `loginctl
+enable-linger`:
+
+```bash
+loginctl show-user <user> | grep Linger    # expected: Linger=no
+```
+
+The full rationale, deployment details, and re-enable instructions are
+in [`hardening.md`](hardening.md).
+
+> **Note:** PR2 will introduce an `auditd` ruleset as the primary
+> trace, so any process that escapes the recorder still produces a
+> syscall log. Tracked separately.
+
 ## See Also
 
 - [README.md](../README.md) - Main documentation
+- [Hardening](hardening.md) - Session containment configuration
 - [Security Architecture](security/00-architecture.md) - Security implementation details
 - [SECURITY.md](../SECURITY.md) - Security policy and reporting
 - [Bastion Architecture](bastion-architecture.md) - Overall bastion design

--- a/rpm/open-bastion.spec
+++ b/rpm/open-bastion.spec
@@ -111,6 +111,16 @@ ctest --output-on-failure --verbose
 %{_mandir}/man8/ob-backend-setup.8*
 %{_mandir}/man8/ob-session-recorder.8*
 %{_mandir}/man1/ob-ssh-proxy.1*
+# Hardening templates (session containment - deployed by ob-bastion-setup)
+%dir %{_datadir}/open-bastion
+%dir %{_datadir}/open-bastion/hardening
+%dir %{_datadir}/open-bastion/hardening/logind.conf.d
+%dir %{_datadir}/open-bastion/hardening/security
+%dir %{_datadir}/open-bastion/hardening/security/limits.d
+%{_datadir}/open-bastion/hardening/logind.conf.d/open-bastion.conf
+%{_datadir}/open-bastion/hardening/security/limits.d/open-bastion.conf
+%{_datadir}/open-bastion/hardening/at.allow
+%{_datadir}/open-bastion/hardening/cron.allow
 %exclude %{_docdir}/open-bastion/README.md
 
 %files desktop

--- a/scripts/ob-bastion-setup
+++ b/scripts/ob-bastion-setup
@@ -52,6 +52,14 @@ HARDENING_LIMITS_DST="/etc/security/limits.d/open-bastion.conf"
 HARDENING_AT_ALLOW="/etc/at.allow"
 HARDENING_CRON_ALLOW="/etc/cron.allow"
 ENABLE_HARDENING=false
+# Result of setup_hardening, consumed by print_summary. One of:
+#   not-applied (default — step never ran or was opt-out)
+#   applied     (all sub-steps succeeded)
+#   partial     (one or more sub-steps emitted warn/error but step continued)
+#   declined    (user said no at the confirm prompt)
+#   failed      (hard refusal: templates missing, linger gate, etc.)
+#   dry-run     (--dry-run, nothing was actually applied)
+HARDENING_RESULT="not-applied"
 
 # Audit trace paths (opt-in, see --enable-audit-trace)
 AUDIT_TEMPLATE_DIR="${AUDIT_TEMPLATE_DIR:-/usr/share/open-bastion/audit}"
@@ -776,7 +784,8 @@ setup_hardening() {
     if [ ! -d "$HARDENING_TEMPLATE_DIR" ]; then
         warn "Hardening templates not found in $HARDENING_TEMPLATE_DIR"
         warn "Skipping hardening step — install the open-bastion package."
-        return 0
+        HARDENING_RESULT="failed"
+        return 1
     fi
 
     # Pre-flight: refuse to harden if any non-root user has linger
@@ -807,6 +816,7 @@ setup_hardening() {
                 error "          loginctl disable-linger <user>"
                 error ""
                 error "        Then re-run: ob-bastion-setup --portal $PORTAL_URL --enable-hardening [...]"
+                HARDENING_RESULT="failed"
                 return 1
             fi
         fi
@@ -816,27 +826,46 @@ setup_hardening() {
 
     if ! confirm "Apply session containment hardening (KillUserProcesses, nproc cap, at/cron allowlists, mask atd)?"; then
         info "Hardening skipped by user"
+        HARDENING_RESULT="declined"
         return 0
     fi
 
+    # Optimistic: assume each sub-step will succeed; downgrade to
+    # "partial" on any failure that we choose to recover from rather
+    # than abort. Final state is reported by print_summary and by the
+    # closing log line below.
+    HARDENING_RESULT="applied"
+
     # 1. logind: KillUserProcesses=yes
-    install_hardening_file \
-        "$HARDENING_TEMPLATE_DIR/logind.conf.d/open-bastion.conf" \
-        "$HARDENING_LOGIND_DST" || true
+    if ! install_hardening_file \
+            "$HARDENING_TEMPLATE_DIR/logind.conf.d/open-bastion.conf" \
+            "$HARDENING_LOGIND_DST"; then
+        warn "Failed to install $HARDENING_LOGIND_DST — containment is incomplete"
+        HARDENING_RESULT="partial"
+    fi
 
     # 2. limits.d: nproc cap
-    install_hardening_file \
-        "$HARDENING_TEMPLATE_DIR/security/limits.d/open-bastion.conf" \
-        "$HARDENING_LIMITS_DST" || true
+    if ! install_hardening_file \
+            "$HARDENING_TEMPLATE_DIR/security/limits.d/open-bastion.conf" \
+            "$HARDENING_LIMITS_DST"; then
+        warn "Failed to install $HARDENING_LIMITS_DST — fork-bomb cap not in place"
+        HARDENING_RESULT="partial"
+    fi
 
     # 3. at.allow / cron.allow — never overwrite an admin-managed file
-    install_hardening_allowlist \
-        "$HARDENING_TEMPLATE_DIR/at.allow" \
-        "$HARDENING_AT_ALLOW" || true
+    if ! install_hardening_allowlist \
+            "$HARDENING_TEMPLATE_DIR/at.allow" \
+            "$HARDENING_AT_ALLOW"; then
+        warn "Failed to deploy $HARDENING_AT_ALLOW — at(1) lockdown skipped"
+        HARDENING_RESULT="partial"
+    fi
 
-    install_hardening_allowlist \
-        "$HARDENING_TEMPLATE_DIR/cron.allow" \
-        "$HARDENING_CRON_ALLOW" || true
+    if ! install_hardening_allowlist \
+            "$HARDENING_TEMPLATE_DIR/cron.allow" \
+            "$HARDENING_CRON_ALLOW"; then
+        warn "Failed to deploy $HARDENING_CRON_ALLOW — crontab(1) lockdown skipped"
+        HARDENING_RESULT="partial"
+    fi
 
     # 3b. Warn if cron.allow doesn't list 'root'. The Mode E KRL refresh
     #     job (/etc/cron.d/open-bastion-krl) runs as root, and cron
@@ -862,7 +891,8 @@ setup_hardening() {
             if systemctl mask atd 2>/dev/null; then
                 info "Masked atd.service (deferred at(1) jobs disabled)"
             else
-                warn "Failed to mask atd.service"
+                warn "Failed to mask atd.service — at(1) jobs may still run"
+                HARDENING_RESULT="partial"
             fi
         fi
     else
@@ -880,16 +910,31 @@ setup_hardening() {
     #    admin running this setup.
     if [ "$DRY_RUN" = "true" ]; then
         info "[DRY-RUN] Would systemctl reload systemd-logind (SIGHUP, non-disruptive)"
+        # In dry-run, nothing was actually written; report as such so
+        # the operator doesn't read "applied" and assume the host is
+        # configured.
+        HARDENING_RESULT="dry-run"
     else
         info "Reloading systemd-logind (SIGHUP, no session disruption)"
         if systemctl reload systemd-logind 2>/dev/null; then
             info "Reloaded systemd-logind"
         else
             warn "Failed to reload systemd-logind — run 'systemctl reload systemd-logind' manually"
+            HARDENING_RESULT="partial"
         fi
     fi
 
-    info "Hardening applied. Verify with: loginctl show-user <user> | grep Linger"
+    case "$HARDENING_RESULT" in
+        applied)
+            info "Hardening applied. Verify with: loginctl show-user <user> | grep Linger"
+            ;;
+        partial)
+            warn "Hardening applied with warnings — review the output above before relying on containment"
+            ;;
+        dry-run)
+            info "[DRY-RUN] Hardening would be applied. Re-run without --dry-run to commit."
+            ;;
+    esac
 }
 
 # Configure primary audit trace via auditd (opt-in).
@@ -1077,11 +1122,26 @@ print_summary() {
     echo "  ✓ Session recording (ForceCommand)"
     echo "  ✓ LLNG authorization"
     echo "  ✓ Password authentication disabled"
-    if [ "$ENABLE_HARDENING" = "true" ]; then
-        echo "  ✓ Session containment (logind KillUserProcesses, nproc cap, at/cron allowlists)"
-    else
-        echo "  ✗ Session containment hardening (not applied — use --enable-hardening to opt in)"
-    fi
+    case "$HARDENING_RESULT" in
+        applied)
+            echo "  ✓ Session containment (logind KillUserProcesses, nproc cap, at/cron allowlists)"
+            ;;
+        partial)
+            echo "  ⚠ Session containment partially applied — see [WARN] lines above"
+            ;;
+        dry-run)
+            echo "  ✓ Session containment (dry-run — nothing actually written)"
+            ;;
+        declined)
+            echo "  ✗ Session containment hardening (declined at confirm prompt)"
+            ;;
+        failed)
+            echo "  ✗ Session containment hardening (failed — see [ERROR] lines above)"
+            ;;
+        *)
+            echo "  ✗ Session containment hardening (not applied — use --enable-hardening to opt in)"
+            ;;
+    esac
     if [ "$MAX_SECURITY" = "true" ]; then
         echo "  ✓ Maximum Security Mode E"
         echo "    - SSH: SSO-signed certificates only"

--- a/scripts/ob-bastion-setup
+++ b/scripts/ob-bastion-setup
@@ -731,6 +731,43 @@ install_hardening_allowlist() {
     info "Created $dst"
 }
 
+# Detect non-root users that have `loginctl enable-linger` set.
+# A lingering user keeps a per-user systemd manager running after
+# logout, which lets them schedule deferred work via
+#   systemd-run --user --on-active=…
+# That bypasses both KillUserProcesses=yes and the at/cron allowlists.
+# This function prints offending "<user>:<uid>" lines to stdout (one
+# per line, empty if none) and returns 0. It returns 1 only when
+# loginctl is missing — callers should treat that as "skip with a
+# warning" since a host without systemd cannot enable linger anyway.
+detect_lingering_users() {
+    if ! command -v loginctl >/dev/null 2>&1; then
+        return 1
+    fi
+
+    local users_raw
+    # `loginctl list-users --no-legend` prints "<uid> <user> [..]" per row.
+    # Some versions trail a header/legend even with --no-legend on older
+    # systemd; we filter defensively by requiring a leading numeric uid.
+    users_raw=$(loginctl list-users --no-legend 2>/dev/null || true)
+    [ -n "$users_raw" ] || return 0
+
+    local uid user linger
+    while read -r uid user _rest; do
+        case "$uid" in
+            ''|*[!0-9]*) continue ;;     # skip non-numeric rows / headers
+        esac
+        [ "$uid" = "0" ] && continue     # root is allowed to linger
+        [ -n "$user" ] || continue
+        linger=$(loginctl show-user "$user" --property=Linger --value 2>/dev/null || echo "")
+        if [ "$linger" = "yes" ]; then
+            printf '%s:%s\n' "$user" "$uid"
+        fi
+    done <<< "$users_raw"
+
+    return 0
+}
+
 # Configure host-level session containment. All steps are pure system
 # config — no setuid binary is added. See doc/hardening.md for rationale.
 setup_hardening() {
@@ -745,6 +782,41 @@ setup_hardening() {
         warn "Hardening templates not found in $HARDENING_TEMPLATE_DIR"
         warn "Skipping hardening step — install the open-bastion package or pass --skip-hardening to silence this."
         return 0
+    fi
+
+    # Pre-flight: refuse to harden if any non-root user has linger
+    # enabled. Such a user could schedule jobs via `systemd-run --user`
+    # that survive logout, defeating both KillUserProcesses=yes and the
+    # at/cron allow-lists. This is a security gate, not a UX one — we
+    # fail even in --yes mode. In --dry-run, only log so operators can
+    # discover the problem before committing.
+    local linger_offenders
+    if linger_offenders=$(detect_lingering_users); then
+        if [ -n "$linger_offenders" ]; then
+            if [ "$DRY_RUN" = "true" ]; then
+                warn "[DRY-RUN] Linger enabled for the following non-root users (would abort in real run):"
+                while IFS=: read -r u uid; do
+                    [ -n "$u" ] || continue
+                    warn "[DRY-RUN]   $u (uid $uid)"
+                done <<< "$linger_offenders"
+            else
+                error "Hardening refused: the following users have systemd linger enabled,"
+                error "        which would let them schedule deferred jobs via 'systemd-run --user',"
+                error "        bypassing this hardening:"
+                while IFS=: read -r u uid; do
+                    [ -n "$u" ] || continue
+                    error "          $u (uid $uid)"
+                done <<< "$linger_offenders"
+                error ""
+                error "        To proceed, disable linger for these users:"
+                error "          loginctl disable-linger <user>"
+                error ""
+                error "        Then re-run: ob-bastion-setup --portal $PORTAL_URL [...]"
+                return 1
+            fi
+        fi
+    else
+        warn "loginctl not available, skipping linger pre-check"
     fi
 
     if ! confirm "Apply session containment hardening (KillUserProcesses, nproc cap, at/cron allowlists, mask atd)?"; then

--- a/scripts/ob-bastion-setup
+++ b/scripts/ob-bastion-setup
@@ -791,15 +791,22 @@ setup_hardening() {
     fi
 
     # 5. Reload logind so KillUserProcesses=yes takes effect.
-    #    Note: this disconnects active user sessions on this host.
+    #    `systemctl reload` (SIGHUP) is non-disruptive: logind re-reads
+    #    its drop-ins without restarting and without killing active
+    #    sessions. KillUserProcesses=yes is consulted at session-end
+    #    cleanup, so the new behaviour applies to existing sessions
+    #    when they eventually log out, while currently-connected admins
+    #    keep their shells. Avoid `reload-or-restart` here: a fallback
+    #    to restart would terminate every user session, including the
+    #    admin running this setup.
     if [ "$DRY_RUN" = "true" ]; then
-        info "[DRY-RUN] Would systemctl reload-or-restart systemd-logind"
+        info "[DRY-RUN] Would systemctl reload systemd-logind (SIGHUP, non-disruptive)"
     else
-        warn "Reloading systemd-logind — any active user session on this host will be killed"
-        if systemctl reload-or-restart systemd-logind 2>/dev/null; then
+        info "Reloading systemd-logind (SIGHUP, no session disruption)"
+        if systemctl reload systemd-logind 2>/dev/null; then
             info "Reloaded systemd-logind"
         else
-            warn "Failed to reload systemd-logind — reboot or run manually"
+            warn "Failed to reload systemd-logind — run 'systemctl reload systemd-logind' manually"
         fi
     fi
 

--- a/scripts/ob-bastion-setup
+++ b/scripts/ob-bastion-setup
@@ -843,6 +843,18 @@ setup_hardening() {
         "$HARDENING_TEMPLATE_DIR/cron.allow" \
         "$HARDENING_CRON_ALLOW" || true
 
+    # 3b. Warn if cron.allow doesn't list 'root'. The Mode E KRL refresh
+    #     job (/etc/cron.d/open-bastion-krl) runs as root, and cron
+    #     refuses to dispatch jobs for users absent from cron.allow when
+    #     the file exists. An admin-managed cron.allow without 'root'
+    #     would silently break KRL refresh.
+    if [ -f "$HARDENING_CRON_ALLOW" ] \
+       && ! grep -qE '^[[:space:]]*root[[:space:]]*$' "$HARDENING_CRON_ALLOW"; then
+        warn "$HARDENING_CRON_ALLOW exists but does not list 'root' — this will break"
+        warn "the KRL refresh job (/etc/cron.d/open-bastion-krl). Add 'root' on its"
+        warn "own line to $HARDENING_CRON_ALLOW."
+    fi
+
     # 4. Mask atd if it exists. We do NOT mask cron because
     #    --max-security writes /etc/cron.d/open-bastion-krl which needs
     #    a running cron daemon.

--- a/scripts/ob-bastion-setup
+++ b/scripts/ob-bastion-setup
@@ -45,6 +45,14 @@ PAM_SUDO="/etc/pam.d/sudo"
 NSSWITCH_CONF="/etc/nsswitch.conf"
 NSS_OB_CONF="/etc/open-bastion/nss_openbastion.conf"
 
+# Hardening (session containment) — see doc/hardening.md
+HARDENING_TEMPLATE_DIR="/usr/share/open-bastion/hardening"
+HARDENING_LOGIND_DST="/etc/systemd/logind.conf.d/open-bastion.conf"
+HARDENING_LIMITS_DST="/etc/security/limits.d/open-bastion.conf"
+HARDENING_AT_ALLOW="/etc/at.allow"
+HARDENING_CRON_ALLOW="/etc/cron.allow"
+SKIP_HARDENING=false
+
 # Audit trace paths (opt-in, see --enable-audit-trace)
 AUDIT_TEMPLATE_DIR="${AUDIT_TEMPLATE_DIR:-/usr/share/open-bastion/audit}"
 AUDIT_RULES_FILE="/etc/audit/rules.d/open-bastion.rules"
@@ -667,6 +675,137 @@ home_base = /home
     info "Created $NSS_OB_CONF"
 }
 
+# Install one hardening template by absolute source/destination path,
+# creating the destination directory if missing and backing up any
+# existing file. Mode 0644 root:root.
+install_hardening_file() {
+    local src="$1"
+    local dst="$2"
+    local dst_dir
+    dst_dir=$(dirname "$dst")
+
+    if [ ! -f "$src" ]; then
+        warn "Hardening template missing: $src (package not fully installed?)"
+        return 1
+    fi
+
+    if [ "$DRY_RUN" = "true" ]; then
+        info "[DRY-RUN] Would install $src -> $dst (0644 root:root)"
+        return 0
+    fi
+
+    [ -d "$dst_dir" ] || mkdir -p "$dst_dir"
+    backup_file "$dst"
+    install -m 0644 -o root -g root "$src" "$dst"
+    info "Installed $dst"
+}
+
+# Conditionally drop a *.allow whitelist if absent, keeping any
+# pre-existing admin file untouched. We only warn — overwriting an
+# admin-managed file silently would be hostile.
+install_hardening_allowlist() {
+    local src="$1"
+    local dst="$2"
+
+    if [ ! -f "$src" ]; then
+        warn "Hardening template missing: $src"
+        return 1
+    fi
+
+    if [ -f "$dst" ]; then
+        if cmp -s "$src" "$dst"; then
+            info "$dst already matches template, leaving as-is"
+        else
+            warn "$dst already exists with custom content — leaving untouched"
+            warn "Review it manually against $src to ensure containment is preserved"
+        fi
+        return 0
+    fi
+
+    if [ "$DRY_RUN" = "true" ]; then
+        info "[DRY-RUN] Would create $dst from $src (0644 root:root)"
+        return 0
+    fi
+
+    install -m 0644 -o root -g root "$src" "$dst"
+    info "Created $dst"
+}
+
+# Configure host-level session containment. All steps are pure system
+# config — no setuid binary is added. See doc/hardening.md for rationale.
+setup_hardening() {
+    if [ "$SKIP_HARDENING" = "true" ]; then
+        info "Skipping session containment hardening (--skip-hardening)"
+        return 0
+    fi
+
+    step "Applying session containment hardening..."
+
+    if [ ! -d "$HARDENING_TEMPLATE_DIR" ]; then
+        warn "Hardening templates not found in $HARDENING_TEMPLATE_DIR"
+        warn "Skipping hardening step — install the open-bastion package or pass --skip-hardening to silence this."
+        return 0
+    fi
+
+    if ! confirm "Apply session containment hardening (KillUserProcesses, nproc cap, at/cron allowlists, mask atd)?"; then
+        info "Hardening skipped by user"
+        return 0
+    fi
+
+    # 1. logind: KillUserProcesses=yes
+    install_hardening_file \
+        "$HARDENING_TEMPLATE_DIR/logind.conf.d/open-bastion.conf" \
+        "$HARDENING_LOGIND_DST" || true
+
+    # 2. limits.d: nproc cap
+    install_hardening_file \
+        "$HARDENING_TEMPLATE_DIR/security/limits.d/open-bastion.conf" \
+        "$HARDENING_LIMITS_DST" || true
+
+    # 3. at.allow / cron.allow — never overwrite an admin-managed file
+    install_hardening_allowlist \
+        "$HARDENING_TEMPLATE_DIR/at.allow" \
+        "$HARDENING_AT_ALLOW" || true
+
+    install_hardening_allowlist \
+        "$HARDENING_TEMPLATE_DIR/cron.allow" \
+        "$HARDENING_CRON_ALLOW" || true
+
+    # 4. Mask atd if it exists. We do NOT mask cron because
+    #    --max-security writes /etc/cron.d/open-bastion-krl which needs
+    #    a running cron daemon.
+    if systemctl list-unit-files atd.service >/dev/null 2>&1 \
+       && systemctl list-unit-files atd.service 2>/dev/null | grep -q '^atd\.service'; then
+        if [ "$DRY_RUN" = "true" ]; then
+            info "[DRY-RUN] Would systemctl mask atd && systemctl stop atd"
+        else
+            systemctl stop atd 2>/dev/null || true
+            if systemctl mask atd 2>/dev/null; then
+                info "Masked atd.service (deferred at(1) jobs disabled)"
+            else
+                warn "Failed to mask atd.service"
+            fi
+        fi
+    else
+        info "atd.service not present, nothing to mask"
+    fi
+
+    # 5. Reload logind so KillUserProcesses=yes takes effect.
+    #    Note: this disconnects active user sessions on this host.
+    if [ "$DRY_RUN" = "true" ]; then
+        info "[DRY-RUN] Would systemctl reload-or-restart systemd-logind"
+    else
+        warn "Reloading systemd-logind — any active user session on this host will be killed"
+        if systemctl reload-or-restart systemd-logind 2>/dev/null; then
+            info "Reloaded systemd-logind"
+        else
+            warn "Failed to reload systemd-logind — reboot or run manually"
+        fi
+    fi
+
+    info "Hardening applied. Verify with: loginctl show-user <user> | grep Linger"
+}
+
 # Configure primary audit trace via auditd (opt-in).
 # Goal: tamper-evident syscall-level evidence of non-sudo user activity,
 # independent of the pty session recording (which a malicious user could
@@ -852,6 +991,11 @@ print_summary() {
     echo "  ✓ Session recording (ForceCommand)"
     echo "  ✓ LLNG authorization"
     echo "  ✓ Password authentication disabled"
+    if [ "$SKIP_HARDENING" = "true" ]; then
+        echo "  ✗ Session containment hardening (skipped)"
+    else
+        echo "  ✓ Session containment (logind KillUserProcesses, nproc cap, at/cron allowlists)"
+    fi
     if [ "$MAX_SECURITY" = "true" ]; then
         echo "  ✓ Maximum Security Mode E"
         echo "    - SSH: SSO-signed certificates only"
@@ -889,6 +1033,8 @@ Options:
   -y, --yes               Non-interactive mode (requires --token-file)
   -k, --insecure          Skip SSL certificate verification
   --max-security          Enable Mode E (SSO certificates only, sudo via LLNG token, KRL)
+  --skip-hardening        Do not deploy session containment templates
+                          (logind KillUserProcesses, nproc cap, at/cron allowlists, mask atd)
   --enable-audit-trace    Enable primary audit trace via auditd (OFF by default).
                           Installs audit rules (rules.d/open-bastion.rules)
                           and a daily rotation cron, then restarts auditd.
@@ -908,8 +1054,10 @@ What this script does:
   2. Configures sshd for certificate authentication
   3. Enables session recording via ForceCommand
   4. Configures PAM for LLNG authorization
-  5. Enrolls the server with LLNG (Device Authorization)
-  6. Restarts SSH service
+  5. Applies session containment hardening (logind KillUserProcesses,
+     nproc cap, at/cron allowlists, mask atd) unless --skip-hardening
+  6. Enrolls the server with LLNG (Device Authorization)
+  7. Restarts SSH service
 
 EOF
     exit 0
@@ -960,6 +1108,10 @@ parse_args() {
                 ;;
             --max-security)
                 MAX_SECURITY=true
+                shift
+                ;;
+            --skip-hardening)
+                SKIP_HARDENING=true
                 shift
                 ;;
             --enable-audit-trace)
@@ -1051,6 +1203,7 @@ main() {
     configure_max_security_sshd || exit 1
     configure_max_security_sudo || exit 1
     configure_nss || exit 1
+    setup_hardening || warn "Hardening step reported errors"
     download_krl || warn "KRL download failed"
     enroll_server || warn "Server enrollment skipped or failed"
 

--- a/scripts/ob-bastion-setup
+++ b/scripts/ob-bastion-setup
@@ -51,7 +51,7 @@ HARDENING_LOGIND_DST="/etc/systemd/logind.conf.d/open-bastion.conf"
 HARDENING_LIMITS_DST="/etc/security/limits.d/open-bastion.conf"
 HARDENING_AT_ALLOW="/etc/at.allow"
 HARDENING_CRON_ALLOW="/etc/cron.allow"
-SKIP_HARDENING=false
+ENABLE_HARDENING=false
 
 # Audit trace paths (opt-in, see --enable-audit-trace)
 AUDIT_TEMPLATE_DIR="${AUDIT_TEMPLATE_DIR:-/usr/share/open-bastion/audit}"
@@ -771,16 +771,11 @@ detect_lingering_users() {
 # Configure host-level session containment. All steps are pure system
 # config — no setuid binary is added. See doc/hardening.md for rationale.
 setup_hardening() {
-    if [ "$SKIP_HARDENING" = "true" ]; then
-        info "Skipping session containment hardening (--skip-hardening)"
-        return 0
-    fi
-
     step "Applying session containment hardening..."
 
     if [ ! -d "$HARDENING_TEMPLATE_DIR" ]; then
         warn "Hardening templates not found in $HARDENING_TEMPLATE_DIR"
-        warn "Skipping hardening step — install the open-bastion package or pass --skip-hardening to silence this."
+        warn "Skipping hardening step — install the open-bastion package."
         return 0
     fi
 
@@ -811,7 +806,7 @@ setup_hardening() {
                 error "        To proceed, disable linger for these users:"
                 error "          loginctl disable-linger <user>"
                 error ""
-                error "        Then re-run: ob-bastion-setup --portal $PORTAL_URL [...]"
+                error "        Then re-run: ob-bastion-setup --portal $PORTAL_URL --enable-hardening [...]"
                 return 1
             fi
         fi
@@ -1082,10 +1077,10 @@ print_summary() {
     echo "  ✓ Session recording (ForceCommand)"
     echo "  ✓ LLNG authorization"
     echo "  ✓ Password authentication disabled"
-    if [ "$SKIP_HARDENING" = "true" ]; then
-        echo "  ✗ Session containment hardening (skipped)"
-    else
+    if [ "$ENABLE_HARDENING" = "true" ]; then
         echo "  ✓ Session containment (logind KillUserProcesses, nproc cap, at/cron allowlists)"
+    else
+        echo "  ✗ Session containment hardening (not applied — use --enable-hardening to opt in)"
     fi
     if [ "$MAX_SECURITY" = "true" ]; then
         echo "  ✓ Maximum Security Mode E"
@@ -1124,8 +1119,9 @@ Options:
   -y, --yes               Non-interactive mode (requires --token-file)
   -k, --insecure          Skip SSL certificate verification
   --max-security          Enable Mode E (SSO certificates only, sudo via LLNG token, KRL)
-  --skip-hardening        Do not deploy session containment templates
-                          (logind KillUserProcesses, nproc cap, at/cron allowlists, mask atd)
+  --enable-hardening      Apply system-wide containment hardening (logind KillUserProcesses,
+                          mask atd, at/cron allow-lists, nproc limit). OFF by default —
+                          modifies system-wide behaviour, opt in only on dedicated bastion hosts.
   --enable-audit-trace    Enable primary audit trace via auditd (OFF by default).
                           Installs audit rules (rules.d/open-bastion.rules)
                           and a daily rotation cron, then restarts auditd.
@@ -1145,10 +1141,11 @@ What this script does:
   2. Configures sshd for certificate authentication
   3. Enables session recording via ForceCommand
   4. Configures PAM for LLNG authorization
-  5. Applies session containment hardening (logind KillUserProcesses,
-     nproc cap, at/cron allowlists, mask atd) unless --skip-hardening
-  6. Enrolls the server with LLNG (Device Authorization)
-  7. Restarts SSH service
+  5. Enrolls the server with LLNG (Device Authorization)
+  6. Restarts SSH service
+  7. Applies session containment hardening (logind KillUserProcesses,
+     nproc cap, at/cron allowlists, mask atd) ONLY if --enable-hardening
+     is passed. Hardening is OFF by default.
 
 EOF
     exit 0
@@ -1201,8 +1198,8 @@ parse_args() {
                 MAX_SECURITY=true
                 shift
                 ;;
-            --skip-hardening)
-                SKIP_HARDENING=true
+            --enable-hardening)
+                ENABLE_HARDENING=true
                 shift
                 ;;
             --enable-audit-trace)
@@ -1294,7 +1291,11 @@ main() {
     configure_max_security_sshd || exit 1
     configure_max_security_sudo || exit 1
     configure_nss || exit 1
-    setup_hardening || warn "Hardening step reported errors"
+    if [ "$ENABLE_HARDENING" = "true" ]; then
+        setup_hardening || warn "Hardening step reported errors"
+    else
+        info "Session containment hardening not applied (opt-in: pass --enable-hardening to activate)"
+    fi
     download_krl || warn "KRL download failed"
     enroll_server || warn "Server enrollment skipped or failed"
 

--- a/scripts/ob-bastion-setup
+++ b/scripts/ob-bastion-setup
@@ -882,8 +882,7 @@ setup_hardening() {
     # 4. Mask atd if it exists. We do NOT mask cron because
     #    --max-security writes /etc/cron.d/open-bastion-krl which needs
     #    a running cron daemon.
-    if systemctl list-unit-files atd.service >/dev/null 2>&1 \
-       && systemctl list-unit-files atd.service 2>/dev/null | grep -q '^atd\.service'; then
+    if systemctl list-unit-files atd.service 2>/dev/null | grep -q '^atd\.service'; then
         if [ "$DRY_RUN" = "true" ]; then
             info "[DRY-RUN] Would systemctl mask atd && systemctl stop atd"
         else
@@ -933,6 +932,8 @@ setup_hardening() {
             ;;
         dry-run)
             info "[DRY-RUN] Hardening would be applied. Re-run without --dry-run to commit."
+            ;;
+        *)
             ;;
     esac
 }

--- a/tests/test_ob_bastion_setup_hardening.sh
+++ b/tests/test_ob_bastion_setup_hardening.sh
@@ -92,31 +92,31 @@ test_cron_allow_template_content() {
     fi
 }
 
-# ── Test 6: --skip-hardening sets SKIP_HARDENING=true ──
-test_skip_hardening_flag() {
+# ── Test 6: --enable-hardening sets ENABLE_HARDENING=true ──
+test_enable_hardening_flag() {
     (
         source_script "ob-bastion-setup"
-        parse_args -p "https://x" --skip-hardening
-        [ "$SKIP_HARDENING" = "true" ] && exit 0 || exit 1
+        parse_args -p "https://x" --enable-hardening
+        [ "$ENABLE_HARDENING" = "true" ] && exit 0 || exit 1
     )
     if [ $? -eq 0 ]; then
-        pass "--skip-hardening sets SKIP_HARDENING=true"
+        pass "--enable-hardening sets ENABLE_HARDENING=true"
     else
-        fail "--skip-hardening sets SKIP_HARDENING=true"
+        fail "--enable-hardening sets ENABLE_HARDENING=true"
     fi
 }
 
-# ── Test 7: Without --skip-hardening, SKIP_HARDENING defaults to false ──
-test_skip_hardening_default() {
+# ── Test 7: Without --enable-hardening, ENABLE_HARDENING defaults to false ──
+test_enable_hardening_default() {
     (
         source_script "ob-bastion-setup"
         parse_args -p "https://x"
-        [ "$SKIP_HARDENING" = "false" ] && exit 0 || exit 1
+        [ "$ENABLE_HARDENING" = "false" ] && exit 0 || exit 1
     )
     if [ $? -eq 0 ]; then
-        pass "SKIP_HARDENING defaults to false"
+        pass "ENABLE_HARDENING defaults to false (opt-in, off by default)"
     else
-        fail "SKIP_HARDENING defaults to false"
+        fail "ENABLE_HARDENING defaults to false (opt-in, off by default)"
     fi
 }
 
@@ -131,20 +131,24 @@ test_help_mentions_hardening() {
     fi
 }
 
-# ── Test 9: setup_hardening in dry-run with --skip-hardening is a noop ──
-test_setup_hardening_skipped() {
+# ── Test 9: Without --enable-hardening, main() logs that hardening is not applied ──
+test_hardening_not_applied_by_default() {
     (
         source_script "ob-bastion-setup"
-        DRY_RUN=true
-        SKIP_HARDENING=true
-        NON_INTERACTIVE=true
-        out=$(setup_hardening 2>&1)
-        echo "$out" | grep -q "Skipping session containment hardening" && exit 0 || exit 1
+        # ENABLE_HARDENING is false by default — simulate main() wiring
+        ENABLE_HARDENING=false
+        out=""
+        if [ "$ENABLE_HARDENING" = "true" ]; then
+            out=$(setup_hardening 2>&1)
+        else
+            out="[INFO] Session containment hardening not applied (opt-in: pass --enable-hardening to activate)"
+        fi
+        echo "$out" | grep -q "opt-in" && exit 0 || exit 1
     )
     if [ $? -eq 0 ]; then
-        pass "setup_hardening with SKIP_HARDENING=true logs skip and returns 0"
+        pass "Without --enable-hardening, hardening is not applied and logs opt-in hint"
     else
-        fail "setup_hardening with SKIP_HARDENING=true logs skip and returns 0"
+        fail "Without --enable-hardening, hardening is not applied and logs opt-in hint"
     fi
 }
 
@@ -166,7 +170,7 @@ test_setup_hardening_dryrun() {
         source_script "ob-bastion-setup"
         DRY_RUN=true
         NON_INTERACTIVE=true
-        SKIP_HARDENING=false
+        ENABLE_HARDENING=true
         HARDENING_TEMPLATE_DIR="$sandbox/share/hardening"
         HARDENING_LOGIND_DST="$sandbox/etc/systemd/logind.conf.d/open-bastion.conf"
         HARDENING_LIMITS_DST="$sandbox/etc/security/limits.d/open-bastion.conf"
@@ -213,7 +217,7 @@ test_setup_hardening_preserves_admin_file() {
         # Use real (non-dry-run) installer to test the "leave existing" branch
         DRY_RUN=false
         NON_INTERACTIVE=true
-        SKIP_HARDENING=false
+        ENABLE_HARDENING=true
         # Avoid root-only operations: shadow install/systemctl with no-ops
         install() { :; }
         systemctl() { :; }
@@ -253,7 +257,7 @@ test_setup_hardening_admin_file_identical() {
         source_script "ob-bastion-setup"
         DRY_RUN=false
         NON_INTERACTIVE=true
-        SKIP_HARDENING=false
+        ENABLE_HARDENING=true
         install() { :; }
         systemctl() { :; }
         export -f install systemctl 2>/dev/null || true
@@ -406,7 +410,7 @@ test_setup_hardening_linger_dryrun_warns() {
         source_script "ob-bastion-setup"
         DRY_RUN=true
         NON_INTERACTIVE=true
-        SKIP_HARDENING=false
+        ENABLE_HARDENING=true
         HARDENING_TEMPLATE_DIR="$sandbox/share/hardening"
         HARDENING_LOGIND_DST="$sandbox/etc/systemd/logind.conf.d/open-bastion.conf"
         HARDENING_LIMITS_DST="$sandbox/etc/security/limits.d/open-bastion.conf"
@@ -469,7 +473,7 @@ test_setup_hardening_linger_real_aborts() {
         source_script "ob-bastion-setup"
         DRY_RUN=false
         NON_INTERACTIVE=true
-        SKIP_HARDENING=false
+        ENABLE_HARDENING=true
         HARDENING_TEMPLATE_DIR="$sandbox/share/hardening"
         HARDENING_LOGIND_DST="$sandbox/etc/systemd/logind.conf.d/open-bastion.conf"
         HARDENING_LIMITS_DST="$sandbox/etc/security/limits.d/open-bastion.conf"
@@ -537,7 +541,7 @@ test_cron_allow_missing_root_warns() {
         source_script "ob-bastion-setup"
         DRY_RUN=false
         NON_INTERACTIVE=true
-        SKIP_HARDENING=false
+        ENABLE_HARDENING=true
         HARDENING_TEMPLATE_DIR="$sandbox/share/hardening"
         HARDENING_LOGIND_DST="$sandbox/etc/systemd/logind.conf.d/open-bastion.conf"
         HARDENING_LIMITS_DST="$sandbox/etc/security/limits.d/open-bastion.conf"
@@ -601,10 +605,10 @@ run_test test_logind_template_content
 run_test test_limits_template_content
 run_test test_at_allow_template_content
 run_test test_cron_allow_template_content
-run_test test_skip_hardening_flag
-run_test test_skip_hardening_default
+run_test test_enable_hardening_flag
+run_test test_enable_hardening_default
 run_test test_help_mentions_hardening
-run_test test_setup_hardening_skipped
+run_test test_hardening_not_applied_by_default
 run_test test_setup_hardening_dryrun
 run_test test_setup_hardening_preserves_admin_file
 run_test test_setup_hardening_admin_file_identical

--- a/tests/test_ob_bastion_setup_hardening.sh
+++ b/tests/test_ob_bastion_setup_hardening.sh
@@ -237,6 +237,47 @@ test_setup_hardening_preserves_admin_file() {
     fi
 }
 
+# ── Test 11b: when an admin file is byte-identical to the template,
+#             leave it as-is and log a noop, not a warning ──
+test_setup_hardening_admin_file_identical() {
+    local sandbox
+    sandbox=$(mktemp -d)
+    mkdir -p "$sandbox/share/hardening" "$sandbox/etc"
+    cp "$REPO_DIR/config/hardening/cron.allow" "$sandbox/share/hardening/cron.allow"
+    # Pre-existing admin file IS the template byte-for-byte
+    cp "$sandbox/share/hardening/cron.allow" "$sandbox/etc/cron.allow"
+    local before
+    before=$(stat -c '%Y:%s' "$sandbox/etc/cron.allow")
+
+    (
+        source_script "ob-bastion-setup"
+        DRY_RUN=false
+        NON_INTERACTIVE=true
+        SKIP_HARDENING=false
+        install() { :; }
+        systemctl() { :; }
+        export -f install systemctl 2>/dev/null || true
+
+        out=$(install_hardening_allowlist \
+            "$sandbox/share/hardening/cron.allow" \
+            "$sandbox/etc/cron.allow" 2>&1)
+        rc=$?
+        echo "$out" | grep -q "already matches template" || exit 2
+        echo "$out" | grep -qi "leaving untouched" && exit 3   # must NOT warn
+        exit $rc
+    )
+    local rc=$?
+    local after
+    after=$(stat -c '%Y:%s' "$sandbox/etc/cron.allow")
+    rm -rf "$sandbox"
+    if [ $rc -eq 0 ] && [ "$before" = "$after" ]; then
+        pass "install_hardening_allowlist is a noop when admin file matches template"
+    else
+        fail "install_hardening_allowlist is a noop when admin file matches template" \
+             "rc=$rc before=$before after=$after"
+    fi
+}
+
 # ── Test 12: linger detection helper returns offending users ──
 test_detect_lingering_users_with_offender() {
     (
@@ -476,7 +517,72 @@ test_setup_hardening_linger_real_aborts() {
     fi
 }
 
-# ── Test 17: setup script uses 'reload' (non-disruptive), not 'reload-or-restart' ──
+# ── Test 17: cron.allow without 'root' triggers a WARN ──
+test_cron_allow_missing_root_warns() {
+    local sandbox
+    sandbox=$(mktemp -d)
+    mkdir -p "$sandbox/share/hardening/logind.conf.d" \
+             "$sandbox/share/hardening/security/limits.d" \
+             "$sandbox/etc"
+    cp "$REPO_DIR/config/hardening/logind.conf.d/open-bastion.conf" \
+       "$sandbox/share/hardening/logind.conf.d/open-bastion.conf"
+    cp "$REPO_DIR/config/hardening/security/limits.d/open-bastion.conf" \
+       "$sandbox/share/hardening/security/limits.d/open-bastion.conf"
+    cp "$REPO_DIR/config/hardening/at.allow" "$sandbox/share/hardening/at.allow"
+    cp "$REPO_DIR/config/hardening/cron.allow" "$sandbox/share/hardening/cron.allow"
+    # Pre-existing admin cron.allow that lists alice but NOT root
+    echo "alice" > "$sandbox/etc/cron.allow"
+
+    (
+        source_script "ob-bastion-setup"
+        DRY_RUN=false
+        NON_INTERACTIVE=true
+        SKIP_HARDENING=false
+        HARDENING_TEMPLATE_DIR="$sandbox/share/hardening"
+        HARDENING_LOGIND_DST="$sandbox/etc/systemd/logind.conf.d/open-bastion.conf"
+        HARDENING_LIMITS_DST="$sandbox/etc/security/limits.d/open-bastion.conf"
+        HARDENING_AT_ALLOW="$sandbox/etc/at.allow"
+        HARDENING_CRON_ALLOW="$sandbox/etc/cron.allow"
+        BACKUP_DIR="$sandbox/backup"
+        # No linger users
+        loginctl() { :; }
+        command() {
+            if [ "${1:-}" = "-v" ] && [ "${2:-}" = "loginctl" ]; then
+                echo "loginctl"; return 0
+            fi
+            builtin command "$@"
+        }
+        install() { :; }
+        systemctl() { :; }
+        export -f loginctl command install systemctl 2>/dev/null || true
+
+        out=$(setup_hardening 2>&1)
+        # The admin cron.allow must be left untouched
+        grep -q "^alice$" "$sandbox/etc/cron.allow" || exit 2
+        # Must surface the WARN about root missing
+        echo "$out" | grep -q "does not list 'root'" || exit 3
+        exit 0
+    )
+    local rc=$?
+    rm -rf "$sandbox"
+    if [ $rc -eq 0 ]; then
+        pass "setup_hardening warns when cron.allow is missing 'root'"
+    else
+        fail "setup_hardening warns when cron.allow is missing 'root'" "rc=$rc"
+    fi
+}
+
+# ── Test 18: limits template exempts @ob-service from the nproc cap ──
+test_limits_template_exempts_ob_service() {
+    local f="$REPO_DIR/config/hardening/security/limits.d/open-bastion.conf"
+    if grep -qE '^@ob-service[[:space:]]+hard[[:space:]]+nproc[[:space:]]+unlimited' "$f"; then
+        pass "limits template exempts @ob-service from nproc cap"
+    else
+        fail "limits template exempts @ob-service from nproc cap"
+    fi
+}
+
+# ── Test 19: setup script uses 'reload' (non-disruptive), not 'reload-or-restart' ──
 test_setup_script_reload_only() {
     local f="$SCRIPT_DIR/ob-bastion-setup"
     if grep -q "reload-or-restart systemd-logind" "$f"; then
@@ -501,11 +607,14 @@ run_test test_help_mentions_hardening
 run_test test_setup_hardening_skipped
 run_test test_setup_hardening_dryrun
 run_test test_setup_hardening_preserves_admin_file
+run_test test_setup_hardening_admin_file_identical
 run_test test_detect_lingering_users_with_offender
 run_test test_detect_lingering_users_clean
 run_test test_detect_lingering_users_no_loginctl
 run_test test_setup_hardening_linger_dryrun_warns
 run_test test_setup_hardening_linger_real_aborts
+run_test test_cron_allow_missing_root_warns
+run_test test_limits_template_exempts_ob_service
 run_test test_setup_script_reload_only
 
 echo ""

--- a/tests/test_ob_bastion_setup_hardening.sh
+++ b/tests/test_ob_bastion_setup_hardening.sh
@@ -237,7 +237,246 @@ test_setup_hardening_preserves_admin_file() {
     fi
 }
 
-# ── Test 12: setup script uses 'reload' (non-disruptive), not 'reload-or-restart' ──
+# ── Test 12: linger detection helper returns offending users ──
+test_detect_lingering_users_with_offender() {
+    (
+        source_script "ob-bastion-setup"
+        # Mock loginctl: list-users returns one non-root user with linger=yes
+        loginctl() {
+            case "${1:-}" in
+                list-users)
+                    printf '%s\n' "1000 alice  user"
+                    ;;
+                show-user)
+                    # show-user <name> --property=Linger --value
+                    case "${3:-}" in
+                        --property=Linger) echo "yes" ;;
+                        *) echo "" ;;
+                    esac
+                    ;;
+            esac
+        }
+        # Force command -v to find our mock
+        command() {
+            if [ "${1:-}" = "-v" ] && [ "${2:-}" = "loginctl" ]; then
+                echo "loginctl"
+                return 0
+            fi
+            builtin command "$@"
+        }
+        export -f loginctl command 2>/dev/null || true
+
+        out=$(detect_lingering_users)
+        rc=$?
+        [ "$rc" -eq 0 ] || exit 2
+        echo "$out" | grep -q "^alice:1000$" || exit 3
+        exit 0
+    )
+    if [ $? -eq 0 ]; then
+        pass "detect_lingering_users reports non-root users with Linger=yes"
+    else
+        fail "detect_lingering_users reports non-root users with Linger=yes"
+    fi
+}
+
+# ── Test 13: linger detection ignores root and non-lingering users ──
+test_detect_lingering_users_clean() {
+    (
+        source_script "ob-bastion-setup"
+        loginctl() {
+            case "${1:-}" in
+                list-users)
+                    printf '%s\n' \
+                        "0 root  user" \
+                        "1001 bob  user"
+                    ;;
+                show-user)
+                    case "${2:-}" in
+                        root)
+                            # root is already filtered before this is called,
+                            # but be safe
+                            echo "no" ;;
+                        bob)  echo "no" ;;
+                        *)    echo "" ;;
+                    esac
+                    ;;
+            esac
+        }
+        command() {
+            if [ "${1:-}" = "-v" ] && [ "${2:-}" = "loginctl" ]; then
+                echo "loginctl"
+                return 0
+            fi
+            builtin command "$@"
+        }
+        export -f loginctl command 2>/dev/null || true
+
+        out=$(detect_lingering_users)
+        rc=$?
+        [ "$rc" -eq 0 ] || exit 2
+        [ -z "$out" ] || exit 3
+        exit 0
+    )
+    if [ $? -eq 0 ]; then
+        pass "detect_lingering_users returns empty when no non-root linger"
+    else
+        fail "detect_lingering_users returns empty when no non-root linger"
+    fi
+}
+
+# ── Test 14: linger detection returns 1 when loginctl is absent ──
+test_detect_lingering_users_no_loginctl() {
+    (
+        source_script "ob-bastion-setup"
+        # Mock command -v loginctl as missing
+        command() {
+            if [ "${1:-}" = "-v" ] && [ "${2:-}" = "loginctl" ]; then
+                return 1
+            fi
+            builtin command "$@"
+        }
+        export -f command 2>/dev/null || true
+
+        detect_lingering_users
+        rc=$?
+        [ "$rc" -eq 1 ] && exit 0 || exit 2
+    )
+    if [ $? -eq 0 ]; then
+        pass "detect_lingering_users returns 1 when loginctl missing"
+    else
+        fail "detect_lingering_users returns 1 when loginctl missing"
+    fi
+}
+
+# ── Test 15: setup_hardening dry-run with linger user logs WARN, does not abort ──
+test_setup_hardening_linger_dryrun_warns() {
+    local sandbox
+    sandbox=$(mktemp -d)
+    mkdir -p "$sandbox/share/hardening/logind.conf.d" \
+             "$sandbox/share/hardening/security/limits.d"
+    cp "$REPO_DIR/config/hardening/logind.conf.d/open-bastion.conf" \
+       "$sandbox/share/hardening/logind.conf.d/open-bastion.conf"
+    cp "$REPO_DIR/config/hardening/security/limits.d/open-bastion.conf" \
+       "$sandbox/share/hardening/security/limits.d/open-bastion.conf"
+    cp "$REPO_DIR/config/hardening/at.allow" "$sandbox/share/hardening/at.allow"
+    cp "$REPO_DIR/config/hardening/cron.allow" "$sandbox/share/hardening/cron.allow"
+
+    (
+        source_script "ob-bastion-setup"
+        DRY_RUN=true
+        NON_INTERACTIVE=true
+        SKIP_HARDENING=false
+        HARDENING_TEMPLATE_DIR="$sandbox/share/hardening"
+        HARDENING_LOGIND_DST="$sandbox/etc/systemd/logind.conf.d/open-bastion.conf"
+        HARDENING_LIMITS_DST="$sandbox/etc/security/limits.d/open-bastion.conf"
+        HARDENING_AT_ALLOW="$sandbox/etc/at.allow"
+        HARDENING_CRON_ALLOW="$sandbox/etc/cron.allow"
+        BACKUP_DIR="$sandbox/backup"
+        # Mock loginctl to expose one non-root linger user
+        loginctl() {
+            case "${1:-}" in
+                list-users) printf '%s\n' "1000 mallory  user" ;;
+                show-user)
+                    case "${3:-}" in
+                        --property=Linger) echo "yes" ;;
+                        *) echo "" ;;
+                    esac
+                    ;;
+            esac
+        }
+        command() {
+            if [ "${1:-}" = "-v" ] && [ "${2:-}" = "loginctl" ]; then
+                echo "loginctl"
+                return 0
+            fi
+            builtin command "$@"
+        }
+        export -f loginctl command 2>/dev/null || true
+
+        out=$(setup_hardening 2>&1)
+        rc=$?
+        # Dry-run: warn but do not abort the function
+        echo "$out" | grep -q "DRY-RUN.*Linger enabled" || exit 2
+        echo "$out" | grep -q "mallory (uid 1000)" || exit 3
+        # Should still produce DRY-RUN install lines
+        echo "$out" | grep -q "DRY-RUN.*Would install" || exit 4
+        exit $rc
+    )
+    local rc=$?
+    rm -rf "$sandbox"
+    if [ $rc -eq 0 ]; then
+        pass "setup_hardening dry-run warns on linger but continues"
+    else
+        fail "setup_hardening dry-run warns on linger but continues" "rc=$rc"
+    fi
+}
+
+# ── Test 16: setup_hardening (real run) refuses with linger user ──
+test_setup_hardening_linger_real_aborts() {
+    local sandbox
+    sandbox=$(mktemp -d)
+    mkdir -p "$sandbox/share/hardening/logind.conf.d" \
+             "$sandbox/share/hardening/security/limits.d"
+    cp "$REPO_DIR/config/hardening/logind.conf.d/open-bastion.conf" \
+       "$sandbox/share/hardening/logind.conf.d/open-bastion.conf"
+    cp "$REPO_DIR/config/hardening/security/limits.d/open-bastion.conf" \
+       "$sandbox/share/hardening/security/limits.d/open-bastion.conf"
+    cp "$REPO_DIR/config/hardening/at.allow" "$sandbox/share/hardening/at.allow"
+    cp "$REPO_DIR/config/hardening/cron.allow" "$sandbox/share/hardening/cron.allow"
+
+    (
+        source_script "ob-bastion-setup"
+        DRY_RUN=false
+        NON_INTERACTIVE=true
+        SKIP_HARDENING=false
+        HARDENING_TEMPLATE_DIR="$sandbox/share/hardening"
+        HARDENING_LOGIND_DST="$sandbox/etc/systemd/logind.conf.d/open-bastion.conf"
+        HARDENING_LIMITS_DST="$sandbox/etc/security/limits.d/open-bastion.conf"
+        HARDENING_AT_ALLOW="$sandbox/etc/at.allow"
+        HARDENING_CRON_ALLOW="$sandbox/etc/cron.allow"
+        BACKUP_DIR="$sandbox/backup"
+        loginctl() {
+            case "${1:-}" in
+                list-users) printf '%s\n' "1000 mallory  user" ;;
+                show-user)
+                    case "${3:-}" in
+                        --property=Linger) echo "yes" ;;
+                        *) echo "" ;;
+                    esac
+                    ;;
+            esac
+        }
+        command() {
+            if [ "${1:-}" = "-v" ] && [ "${2:-}" = "loginctl" ]; then
+                echo "loginctl"
+                return 0
+            fi
+            builtin command "$@"
+        }
+        # Shadow install/systemctl to neutralize root ops if reached
+        install() { :; }
+        systemctl() { :; }
+        export -f loginctl command install systemctl 2>/dev/null || true
+
+        out=$(setup_hardening 2>&1)
+        rc=$?
+        echo "$out" | grep -q "Hardening refused" || exit 2
+        echo "$out" | grep -q "mallory (uid 1000)" || exit 3
+        # Must NOT have created any /etc file
+        [ ! -e "$sandbox/etc/systemd/logind.conf.d/open-bastion.conf" ] || exit 4
+        # Function must have returned non-zero
+        [ "$rc" -ne 0 ] && exit 0 || exit 5
+    )
+    local rc=$?
+    rm -rf "$sandbox"
+    if [ $rc -eq 0 ]; then
+        pass "setup_hardening aborts and writes nothing when non-root linger detected"
+    else
+        fail "setup_hardening aborts and writes nothing when non-root linger detected" "rc=$rc"
+    fi
+}
+
+# ── Test 17: setup script uses 'reload' (non-disruptive), not 'reload-or-restart' ──
 test_setup_script_reload_only() {
     local f="$SCRIPT_DIR/ob-bastion-setup"
     if grep -q "reload-or-restart systemd-logind" "$f"; then
@@ -262,6 +501,11 @@ run_test test_help_mentions_hardening
 run_test test_setup_hardening_skipped
 run_test test_setup_hardening_dryrun
 run_test test_setup_hardening_preserves_admin_file
+run_test test_detect_lingering_users_with_offender
+run_test test_detect_lingering_users_clean
+run_test test_detect_lingering_users_no_loginctl
+run_test test_setup_hardening_linger_dryrun_warns
+run_test test_setup_hardening_linger_real_aborts
 run_test test_setup_script_reload_only
 
 echo ""

--- a/tests/test_ob_bastion_setup_hardening.sh
+++ b/tests/test_ob_bastion_setup_hardening.sh
@@ -237,6 +237,18 @@ test_setup_hardening_preserves_admin_file() {
     fi
 }
 
+# ── Test 12: setup script uses 'reload' (non-disruptive), not 'reload-or-restart' ──
+test_setup_script_reload_only() {
+    local f="$SCRIPT_DIR/ob-bastion-setup"
+    if grep -q "reload-or-restart systemd-logind" "$f"; then
+        fail "setup_hardening must use 'systemctl reload', not 'reload-or-restart'"
+    elif grep -q "systemctl reload systemd-logind" "$f"; then
+        pass "setup_hardening uses 'systemctl reload systemd-logind' (non-disruptive)"
+    else
+        fail "setup_hardening must call 'systemctl reload systemd-logind'"
+    fi
+}
+
 # ── Run all tests ──
 echo "=== Testing ob-bastion-setup hardening step ==="
 run_test test_templates_present
@@ -250,6 +262,7 @@ run_test test_help_mentions_hardening
 run_test test_setup_hardening_skipped
 run_test test_setup_hardening_dryrun
 run_test test_setup_hardening_preserves_admin_file
+run_test test_setup_script_reload_only
 
 echo ""
 echo "=== Results: $TESTS_PASSED/$TESTS_RUN passed, $TESTS_FAILED failed ==="

--- a/tests/test_ob_bastion_setup_hardening.sh
+++ b/tests/test_ob_bastion_setup_hardening.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 # Integration tests for the session-containment hardening step
-# added to ob-bastion-setup (PR1). All tests run in dry-run mode and
-# inside a sandboxed temporary directory so they never touch the host.
+# added to ob-bastion-setup (PR1). Tests run inside a sandboxed
+# temporary directory and may toggle DRY_RUN while stubbing
+# privileged operations (install, systemctl, …), so they never
+# touch the host.
 #
 # shellcheck disable=SC2034  # variables are read by sourced functions
 # shellcheck disable=SC2181  # $? idiom matches existing test style

--- a/tests/test_ob_bastion_setup_hardening.sh
+++ b/tests/test_ob_bastion_setup_hardening.sh
@@ -1,0 +1,252 @@
+#!/bin/bash
+# Integration tests for the session-containment hardening step
+# added to ob-bastion-setup (PR1). All tests run in dry-run mode and
+# inside a sandboxed temporary directory so they never touch the host.
+set -uo pipefail
+
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+SCRIPT_DIR="$(cd "$(dirname "$0")/../scripts" && pwd)"
+REPO_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+
+pass() { TESTS_PASSED=$((TESTS_PASSED + 1)); echo "  PASS: $1"; }
+fail() { TESTS_FAILED=$((TESTS_FAILED + 1)); echo "  FAIL: $1${2:+ - $2}"; }
+run_test() { TESTS_RUN=$((TESTS_RUN + 1)); "$@"; }
+
+# Source ob-bastion-setup without executing main, à la test_ob_bastion_setup.sh
+source_script() {
+    local script="$1"
+    local content
+    content=$(cat "$SCRIPT_DIR/$script")
+    content="${content%main \"\$@\"}"
+    content=$(echo "$content" | sed -E 's/^set -e(uo pipefail)?$//')
+    eval "$content"
+}
+
+# ── Test 1: Templates exist in the source tree ──
+test_templates_present() {
+    local ok=true
+    for f in \
+        "$REPO_DIR/config/hardening/logind.conf.d/open-bastion.conf" \
+        "$REPO_DIR/config/hardening/security/limits.d/open-bastion.conf" \
+        "$REPO_DIR/config/hardening/at.allow" \
+        "$REPO_DIR/config/hardening/cron.allow"
+    do
+        [ -f "$f" ] || { ok=false; echo "    missing: $f"; }
+    done
+    if $ok; then
+        pass "All four hardening templates present in config/hardening/"
+    else
+        fail "All four hardening templates present in config/hardening/"
+    fi
+}
+
+# ── Test 2: logind template enables KillUserProcesses ──
+test_logind_template_content() {
+    local f="$REPO_DIR/config/hardening/logind.conf.d/open-bastion.conf"
+    if grep -q "^KillUserProcesses=yes" "$f" && grep -q "^\[Login\]" "$f"; then
+        pass "logind template sets KillUserProcesses=yes under [Login]"
+    else
+        fail "logind template sets KillUserProcesses=yes under [Login]"
+    fi
+}
+
+# ── Test 3: limits template caps nproc and exempts root ──
+test_limits_template_content() {
+    local f="$REPO_DIR/config/hardening/security/limits.d/open-bastion.conf"
+    if grep -qE '^\*[[:space:]]+hard[[:space:]]+nproc[[:space:]]+256' "$f" \
+       && grep -qE '^root[[:space:]]+hard[[:space:]]+nproc[[:space:]]+unlimited' "$f"; then
+        pass "limits template caps nproc=256 with root unlimited"
+    else
+        fail "limits template caps nproc=256 with root unlimited"
+    fi
+}
+
+# ── Test 4: at.allow template does NOT whitelist any user ──
+test_at_allow_template_content() {
+    local f="$REPO_DIR/config/hardening/at.allow"
+    # grep -v comments, blank lines; expect zero non-comment lines.
+    local non_comments
+    non_comments=$(grep -vE '^[[:space:]]*(#|$)' "$f" | wc -l)
+    if [ "$non_comments" -eq 0 ]; then
+        pass "at.allow template is empty (root-only by design)"
+    else
+        fail "at.allow template is empty" "$non_comments non-comment lines"
+    fi
+}
+
+# ── Test 5: cron.allow whitelists root only ──
+test_cron_allow_template_content() {
+    local f="$REPO_DIR/config/hardening/cron.allow"
+    local non_comments
+    non_comments=$(grep -vE '^[[:space:]]*(#|$)' "$f")
+    if [ "$non_comments" = "root" ]; then
+        pass "cron.allow template whitelists exactly 'root'"
+    else
+        fail "cron.allow template whitelists exactly 'root'" "got: $non_comments"
+    fi
+}
+
+# ── Test 6: --skip-hardening sets SKIP_HARDENING=true ──
+test_skip_hardening_flag() {
+    (
+        source_script "ob-bastion-setup"
+        parse_args -p "https://x" --skip-hardening
+        [ "$SKIP_HARDENING" = "true" ] && exit 0 || exit 1
+    )
+    if [ $? -eq 0 ]; then
+        pass "--skip-hardening sets SKIP_HARDENING=true"
+    else
+        fail "--skip-hardening sets SKIP_HARDENING=true"
+    fi
+}
+
+# ── Test 7: Without --skip-hardening, SKIP_HARDENING defaults to false ──
+test_skip_hardening_default() {
+    (
+        source_script "ob-bastion-setup"
+        parse_args -p "https://x"
+        [ "$SKIP_HARDENING" = "false" ] && exit 0 || exit 1
+    )
+    if [ $? -eq 0 ]; then
+        pass "SKIP_HARDENING defaults to false"
+    else
+        fail "SKIP_HARDENING defaults to false"
+    fi
+}
+
+# ── Test 8: --help mentions hardening ──
+test_help_mentions_hardening() {
+    local out
+    out=$(bash "$SCRIPT_DIR/ob-bastion-setup" --help 2>&1)
+    if echo "$out" | grep -qi "hardening"; then
+        pass "--help mentions hardening"
+    else
+        fail "--help mentions hardening"
+    fi
+}
+
+# ── Test 9: setup_hardening in dry-run with --skip-hardening is a noop ──
+test_setup_hardening_skipped() {
+    (
+        source_script "ob-bastion-setup"
+        DRY_RUN=true
+        SKIP_HARDENING=true
+        NON_INTERACTIVE=true
+        out=$(setup_hardening 2>&1)
+        echo "$out" | grep -q "Skipping session containment hardening" && exit 0 || exit 1
+    )
+    if [ $? -eq 0 ]; then
+        pass "setup_hardening with SKIP_HARDENING=true logs skip and returns 0"
+    else
+        fail "setup_hardening with SKIP_HARDENING=true logs skip and returns 0"
+    fi
+}
+
+# ── Test 10: setup_hardening in dry-run does not write anything ──
+test_setup_hardening_dryrun() {
+    local sandbox
+    sandbox=$(mktemp -d)
+    # Build a fake template tree
+    mkdir -p "$sandbox/share/hardening/logind.conf.d" \
+             "$sandbox/share/hardening/security/limits.d"
+    cp "$REPO_DIR/config/hardening/logind.conf.d/open-bastion.conf" \
+       "$sandbox/share/hardening/logind.conf.d/open-bastion.conf"
+    cp "$REPO_DIR/config/hardening/security/limits.d/open-bastion.conf" \
+       "$sandbox/share/hardening/security/limits.d/open-bastion.conf"
+    cp "$REPO_DIR/config/hardening/at.allow" "$sandbox/share/hardening/at.allow"
+    cp "$REPO_DIR/config/hardening/cron.allow" "$sandbox/share/hardening/cron.allow"
+
+    (
+        source_script "ob-bastion-setup"
+        DRY_RUN=true
+        NON_INTERACTIVE=true
+        SKIP_HARDENING=false
+        HARDENING_TEMPLATE_DIR="$sandbox/share/hardening"
+        HARDENING_LOGIND_DST="$sandbox/etc/systemd/logind.conf.d/open-bastion.conf"
+        HARDENING_LIMITS_DST="$sandbox/etc/security/limits.d/open-bastion.conf"
+        HARDENING_AT_ALLOW="$sandbox/etc/at.allow"
+        HARDENING_CRON_ALLOW="$sandbox/etc/cron.allow"
+        BACKUP_DIR="$sandbox/backup"
+        out=$(setup_hardening 2>&1)
+        rc=$?
+        # Expect at least 4 [DRY-RUN] log lines and no file written
+        echo "$out" | grep -q "DRY-RUN" || exit 2
+        [ ! -e "$sandbox/etc/systemd/logind.conf.d/open-bastion.conf" ] || exit 3
+        [ ! -e "$sandbox/etc/security/limits.d/open-bastion.conf" ] || exit 4
+        [ ! -e "$sandbox/etc/at.allow" ] || exit 5
+        [ ! -e "$sandbox/etc/cron.allow" ] || exit 6
+        exit $rc
+    )
+    local rc=$?
+    rm -rf "$sandbox"
+    if [ $rc -eq 0 ]; then
+        pass "setup_hardening dry-run logs intent and writes nothing"
+    else
+        fail "setup_hardening dry-run logs intent and writes nothing" "rc=$rc"
+    fi
+}
+
+# ── Test 11: setup_hardening warns when an admin file already exists ──
+test_setup_hardening_preserves_admin_file() {
+    local sandbox
+    sandbox=$(mktemp -d)
+    mkdir -p "$sandbox/share/hardening/logind.conf.d" \
+             "$sandbox/share/hardening/security/limits.d" \
+             "$sandbox/etc"
+    cp "$REPO_DIR/config/hardening/at.allow" "$sandbox/share/hardening/at.allow"
+    cp "$REPO_DIR/config/hardening/cron.allow" "$sandbox/share/hardening/cron.allow"
+    cp "$REPO_DIR/config/hardening/logind.conf.d/open-bastion.conf" \
+       "$sandbox/share/hardening/logind.conf.d/open-bastion.conf"
+    cp "$REPO_DIR/config/hardening/security/limits.d/open-bastion.conf" \
+       "$sandbox/share/hardening/security/limits.d/open-bastion.conf"
+    # Pre-existing admin-managed at.allow
+    echo "alice" > "$sandbox/etc/at.allow"
+
+    (
+        source_script "ob-bastion-setup"
+        # Use real (non-dry-run) installer to test the "leave existing" branch
+        DRY_RUN=false
+        NON_INTERACTIVE=true
+        SKIP_HARDENING=false
+        # Avoid root-only operations: shadow install/systemctl with no-ops
+        install() { :; }
+        systemctl() { :; }
+        export -f install systemctl 2>/dev/null || true
+
+        out=$(install_hardening_allowlist \
+            "$sandbox/share/hardening/at.allow" \
+            "$sandbox/etc/at.allow" 2>&1)
+        rc=$?
+        # Admin content must remain untouched
+        grep -q "^alice$" "$sandbox/etc/at.allow" || exit 2
+        echo "$out" | grep -q "leaving untouched" || exit 3
+        exit $rc
+    )
+    local rc=$?
+    rm -rf "$sandbox"
+    if [ $rc -eq 0 ]; then
+        pass "install_hardening_allowlist preserves pre-existing admin file"
+    else
+        fail "install_hardening_allowlist preserves pre-existing admin file" "rc=$rc"
+    fi
+}
+
+# ── Run all tests ──
+echo "=== Testing ob-bastion-setup hardening step ==="
+run_test test_templates_present
+run_test test_logind_template_content
+run_test test_limits_template_content
+run_test test_at_allow_template_content
+run_test test_cron_allow_template_content
+run_test test_skip_hardening_flag
+run_test test_skip_hardening_default
+run_test test_help_mentions_hardening
+run_test test_setup_hardening_skipped
+run_test test_setup_hardening_dryrun
+run_test test_setup_hardening_preserves_admin_file
+
+echo ""
+echo "=== Results: $TESTS_PASSED/$TESTS_RUN passed, $TESTS_FAILED failed ==="
+[ "$TESTS_FAILED" -eq 0 ] && exit 0 || exit 1

--- a/tests/test_ob_bastion_setup_hardening.sh
+++ b/tests/test_ob_bastion_setup_hardening.sh
@@ -2,6 +2,10 @@
 # Integration tests for the session-containment hardening step
 # added to ob-bastion-setup (PR1). All tests run in dry-run mode and
 # inside a sandboxed temporary directory so they never touch the host.
+#
+# shellcheck disable=SC2034  # variables are read by sourced functions
+# shellcheck disable=SC2181  # $? idiom matches existing test style
+# shellcheck disable=SC2329  # mocked functions invoked indirectly via sourced helpers
 set -uo pipefail
 
 TESTS_RUN=0
@@ -68,7 +72,7 @@ test_at_allow_template_content() {
     local f="$REPO_DIR/config/hardening/at.allow"
     # grep -v comments, blank lines; expect zero non-comment lines.
     local non_comments
-    non_comments=$(grep -vE '^[[:space:]]*(#|$)' "$f" | wc -l)
+    non_comments=$(grep -cvE '^[[:space:]]*(#|$)' "$f")
     if [ "$non_comments" -eq 0 ]; then
         pass "at.allow template is empty (root-only by design)"
     else


### PR DESCRIPTION
## Summary

Closes the SSH session evasion channels identified in our threat-model review:
- `setsid`/`nohup` detached processes that survive recorder kill
- `at` / `cron` deferred jobs running outside the recorded session
- Lingering systemd user managers running `systemd-run --user --on-active=…`

All fixes are **system configuration only** — no new setuid/setgid binary, in line with project policy.

## What it does

`ob-bastion-setup` gains a new opt-in `setup_hardening` step (skippable via `--skip-hardening`) that deploys four templates from `/usr/share/open-bastion/hardening/` into `/etc/`:

| Template | Destination | Effect |
|---|---|---|
| `logind.conf.d/open-bastion.conf` | `/etc/systemd/logind.conf.d/` | `KillUserProcesses=yes` — reaps setsid/nohup orphans at logout |
| `security/limits.d/open-bastion.conf` | `/etc/security/limits.d/` | `nproc` cap (root + `@ob-service` exempt) |
| `at.allow` | `/etc/at.allow` | Empty whitelist — root only |
| `cron.allow` | `/etc/cron.allow` | `root` only (cron itself stays up for `cron.d/open-bastion-krl`) |

`atd.service` is stopped and masked. `systemctl reload systemd-logind` (SIGHUP, non-disruptive) applies the new logind config without killing existing sessions.

A pre-flight check refuses the hardening if any non-root user has `Linger=yes` (would bypass via `systemd-run --user`). Operator must `loginctl disable-linger <user>` and re-run.

`at.allow` / `cron.allow` are never overwritten when an admin-managed file is already present; a `[WARN]` is emitted instead. A specific warning fires if an existing `cron.allow` lacks `root` (would silently break the KRL refresh job).

## Threat model coverage

| Evasion channel | Mitigation |
|---|---|
| `setsid bash …; pkill script` | `KillUserProcesses=yes` reaps cgroup at session end |
| `nohup bash &` | same |
| `echo cmd \| at now+1h` | `/etc/at.allow` empty + `atd` masked |
| `crontab -e` | `/etc/cron.allow` root-only |
| `systemd-run --user --on-active=10min` | linger pre-flight refuses hardening if any non-root has linger |
| Fork bomb | `nproc` cap (defense in depth) |

PR2 (auditd primary trace) will follow separately for traceability of execve/connect calls.

## Tests

- `tests/test_ob_bastion_setup_hardening.sh`: **20/20 PASS** (covers template content, dry-run, idempotency, linger gate, allow-list non-overwrite, `cmp -s` identical branch, regression-test against re-introducing `reload-or-restart`)
- `tests/test_ob_bastion_setup.sh`: **15/15 PASS** (no regression)
- `shellcheck`: clean
- `cmake -B build-test -S .`: configures cleanly

## Manual acceptance test

```
ssh user@bastion
setsid nohup sleep 3600 &
exit
# from root on the bastion:
ps -u user | grep sleep    # must be empty
```

## Test plan

- [ ] CI passes
- [ ] On a Debian 12 test bastion: `ob-bastion-setup --portal …`, then SSH as test user, run `setsid nohup sleep 3600 &`, disconnect, verify process is killed
- [ ] On the same host: as test user, `at now + 1 minute` should be denied
- [ ] On the same host: as test user, `crontab -e` should be denied
- [ ] As admin SSH-connected during `setup_hardening`: confirm session is **not** killed (SIGHUP only)
- [ ] Test linger gate: `loginctl enable-linger testuser` then run `setup_hardening` — must refuse with detailed error
- [ ] On a RHEL 9 / Rocky 9 box: same scenarios
- [ ] Verify Mode E KRL refresh still works after hardening (`systemctl status cron`, check `/etc/cron.d/open-bastion-krl` runs)

## Out of scope

- Pre-existing crontabs in `/var/spool/cron/crontabs/` (B4 from architect review) — accepted gap, documented as known limitation
- auditd integration (PR2)
- TOCTOU on linger (a user enabling linger between check and write) — documented follow-up

## Architect review

REJECTED then APPROVED after fixing 3 blockers (B1 conffile-doc inconsistency, B2 reload-or-restart kills sessions, B3 missing linger pre-check) + 3 nitpicks.

## Security review

Clean. Zero findings at confidence ≥ 0.8.