### PR TITLE
Primary audit trace via auditd (PR2) — opt-in syscall-level traceability

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -231,6 +231,17 @@ install(PROGRAMS ${CMAKE_SOURCE_DIR}/scripts/ob-bastion-setup
     DESTINATION ${CMAKE_INSTALL_SBINDIR}
 )
 
+# Install auditd templates (consumed by `ob-bastion-setup --enable-audit-trace`).
+# Read-only templates under /usr/share/open-bastion/audit/. The setup function
+# copies them into /etc/audit/rules.d/ and /etc/cron.daily/ at deployment time.
+# These are NOT dpkg conffiles / rpm config(noreplace) — see doc/audit.md.
+install(FILES ${CMAKE_SOURCE_DIR}/config/audit/rules.d/open-bastion.rules
+    DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/open-bastion/audit/rules.d
+)
+install(PROGRAMS ${CMAKE_SOURCE_DIR}/config/audit/cron.daily/open-bastion-audit-rotate
+    DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/open-bastion/audit/cron.daily
+)
+
 install(PROGRAMS ${CMAKE_SOURCE_DIR}/scripts/ob-backend-setup
     DESTINATION ${CMAKE_INSTALL_SBINDIR}
 )

--- a/config/audit/cron.daily/open-bastion-audit-rotate
+++ b/config/audit/cron.daily/open-bastion-audit-rotate
@@ -1,0 +1,14 @@
+#!/bin/sh
+# Open Bastion: rotate auditd logs daily so that with num_logs=7
+# (configured in /etc/audit/auditd.conf) we keep ~1 week of history.
+# Installed by `ob-bastion-setup --enable-audit-trace`.
+
+# Trigger auditd rotation (same as `service auditd rotate`).
+# Old auditd: SIGUSR1 to the daemon. Modern: systemctl kill -s USR1.
+if command -v systemctl >/dev/null 2>&1 && systemctl is-active auditd >/dev/null 2>&1; then
+    systemctl kill -s USR1 auditd 2>/dev/null || true
+elif [ -r /var/run/auditd.pid ]; then
+    kill -USR1 "$(cat /var/run/auditd.pid)" 2>/dev/null || true
+fi
+
+exit 0

--- a/config/audit/rules.d/open-bastion.rules
+++ b/config/audit/rules.d/open-bastion.rules
@@ -9,10 +9,16 @@
 -f 1
 
 # === EXECVE: every command run by a logged-in non-system user ===
--a always,exit -F arch=b64 -S execve -F auid>=1000 -F auid!=unset -k ob-exec
--a always,exit -F arch=b32 -S execve -F auid>=1000 -F auid!=unset -k ob-exec
+# Cover both execve and execveat (syscall #322): execveat alone bypasses
+# a rule that only matches execve.
+-a always,exit -F arch=b64 -S execve -S execveat -F auid>=1000 -F auid!=unset -k ob-exec
+-a always,exit -F arch=b32 -S execve -S execveat -F auid>=1000 -F auid!=unset -k ob-exec
 
-# === NETWORK: outbound connections (exfiltration detection) ===
+# === NETWORK: outbound connect() only — see doc/audit.md for sendto/io_uring caveats ===
+# UDP exfiltration via sendto on an unconnected socket and io_uring-based
+# clients are NOT covered here on purpose (sendto/sendmsg would be too
+# chatty by default). Operators who need broader coverage can add
+# `-S sendto -S sendmsg` and accept the volume.
 -a always,exit -F arch=b64 -S connect -F auid>=1000 -F auid!=unset -k ob-connect
 -a always,exit -F arch=b32 -S connect -F auid>=1000 -F auid!=unset -k ob-connect
 

--- a/config/audit/rules.d/open-bastion.rules
+++ b/config/audit/rules.d/open-bastion.rules
@@ -1,0 +1,37 @@
+## Open Bastion: traceability rules for non-system users.
+## Filter on auid (audit-uid) so the rule survives setuid/setgid transitions.
+## auid<unset> covers system processes started before login.
+
+# Buffer: 8192 events (default 64 too small for execve-heavy workloads)
+-b 8192
+
+# On full buffer: printk to console (1), do not panic kernel
+-f 1
+
+# === EXECVE: every command run by a logged-in non-system user ===
+-a always,exit -F arch=b64 -S execve -F auid>=1000 -F auid!=unset -k ob-exec
+-a always,exit -F arch=b32 -S execve -F auid>=1000 -F auid!=unset -k ob-exec
+
+# === NETWORK: outbound connections (exfiltration detection) ===
+-a always,exit -F arch=b64 -S connect -F auid>=1000 -F auid!=unset -k ob-connect
+-a always,exit -F arch=b32 -S connect -F auid>=1000 -F auid!=unset -k ob-connect
+
+# === SENSITIVE FILES: writes/attribute changes ===
+-w /etc/passwd       -p wa -k ob-passwd
+-w /etc/shadow       -p wa -k ob-shadow
+-w /etc/group        -p wa -k ob-group
+-w /etc/gshadow      -p wa -k ob-gshadow
+-w /etc/sudoers      -p wa -k ob-sudoers
+-w /etc/sudoers.d/   -p wa -k ob-sudoers
+-w /etc/ssh/sshd_config    -p wa -k ob-sshd
+-w /etc/ssh/sshd_config.d/ -p wa -k ob-sshd
+
+# === SESSION RECORDINGS: tampering detection ===
+-w /var/lib/open-bastion/sessions/ -p wa -k ob-sessions-tampering
+
+# === BASTION OWN CONFIG ===
+-w /etc/open-bastion/ -p wa -k ob-config
+
+# Last rule: lock the audit configuration until reboot.
+# Comment out for development; uncomment in production.
+# -e 2

--- a/debian/control
+++ b/debian/control
@@ -22,6 +22,7 @@ Depends: ${misc:Depends},
  jq,
  nscd,
  debconf | debconf-2.0,
+Recommends: auditd,
 Pre-Depends: ${misc:Pre-Depends},
 Description: Open Bastion PAM/NSS module for SSH bastion authentication
  This PAM module enables Linux servers to authenticate users via

--- a/debian/control
+++ b/debian/control
@@ -22,7 +22,7 @@ Depends: ${misc:Depends},
  jq,
  nscd,
  debconf | debconf-2.0,
-Recommends: auditd,
+Recommends: auditd
 Pre-Depends: ${misc:Pre-Depends},
 Description: Open Bastion PAM/NSS module for SSH bastion authentication
  This PAM module enables Linux servers to authenticate users via

--- a/debian/open-bastion.install
+++ b/debian/open-bastion.install
@@ -35,6 +35,10 @@ debian/tmp/usr/share/man/man8/ob-bastion-setup.8
 debian/tmp/usr/share/man/man8/ob-backend-setup.8
 debian/tmp/usr/share/man/man8/ob-session-recorder.8
 
+# Audit trace templates (deployed by `ob-bastion-setup --enable-audit-trace`)
+debian/tmp/usr/share/open-bastion/audit/rules.d/open-bastion.rules
+debian/tmp/usr/share/open-bastion/audit/cron.daily/open-bastion-audit-rotate
+
 # Documentation
 debian/tmp/usr/share/doc/open-bastion/README.md
 

--- a/doc/README.md
+++ b/doc/README.md
@@ -15,6 +15,7 @@
 | [Service Accounts](service-accounts.md)         | Ansible, backup, CI/CD accounts               |
 | [Bastion Architecture](bastion-architecture.md) | Bastion-to-backend JWT authentication         |
 | [Session Recording](session-recording.md)       | SSH session recording for audit               |
+| [Primary Audit Trace](audit.md)                 | Optional auditd-based syscall audit trail     |
 | [CrowdSec Integration](crowdsec.md)             | IP blocking and alert reporting               |
 | [Security Features](security.md)                | Key policies, rate limiting, cache protection |
 

--- a/doc/audit.md
+++ b/doc/audit.md
@@ -1,0 +1,253 @@
+# Primary Audit Trace (auditd)
+
+This document describes Open Bastion's optional **primary audit trace**
+based on the Linux kernel `auditd` subsystem. It is the second pillar of
+session traceability, complementary to the session recording covered in
+[Session Recording](session-recording.md).
+
+## Rationale
+
+Session recording (`ob-session-recorder`) gives you a faithful, replayable
+view of what a user did inside their pty: keystrokes, screen output,
+timing. This is invaluable for incident review — but it is **not** an
+independent audit trail:
+
+- Recordings live on disk; the user's session can sometimes reach them
+  (e.g. in `/var/lib/open-bastion/sessions/<user>/`).
+- A determined user can attempt to bypass the pty entirely: `setsid`,
+  `at`, `cron`, jobs spawned through systemd `--user`, daemons launched
+  with `nohup`. Containment ([Session Containment](session-recording.md#session-containment)
+  in PR1) closes most of these paths, but not all.
+- A coredump, a panic, or an out-of-disk event mid-session can leave a
+  partial recording.
+
+`auditd` solves a different problem: it records **every syscall** of
+interest, at the kernel level, into an append-only log under
+`/var/log/audit/`. Rules filter on `auid` (the audit user id, which is
+set at login by PAM and **does not change** across `setuid`/`setgid`
+transitions). This means:
+
+- Even if a user spawns a child via `at` two hours later, the child's
+  `auid` still points back to the original SSH login.
+- `execve` is logged with full `argv`, working dir, and credentials,
+  before the program even gets to run.
+- The audit log is owned by `root:root` (mode 0600 by default); the
+  unprivileged user cannot tamper with it from inside their session.
+
+In short: recording answers *"what did the user see and type?"*, auditd
+answers *"what syscalls did the kernel actually execute on behalf of
+this auid?"*. You want both.
+
+## Threat model
+
+What this trace **covers**:
+
+- Every `execve` performed by a logged-in non-system user (auid ≥ 1000),
+  including programs launched via `at`, `cron`, `systemd --user`, or
+  any process whose ancestry goes back to a PAM-authenticated login.
+- Every outbound `connect` syscall by such users (useful to detect
+  exfiltration, reverse shells, or unusual back-connect targets).
+- Writes / attribute changes on sensitive files: `/etc/passwd`,
+  `/etc/shadow`, `/etc/group`, `/etc/gshadow`, `/etc/sudoers`,
+  `/etc/sudoers.d/`, `/etc/ssh/sshd_config`, `/etc/ssh/sshd_config.d/`.
+- Writes / attribute changes on the session recordings directory
+  (`/var/lib/open-bastion/sessions/`) and on Open Bastion's own config
+  directory (`/etc/open-bastion/`). This catches a user trying to
+  delete or rewrite their own `.typescript`.
+
+What this trace **does not** cover:
+
+- Contents of files read or written (auditd records the syscall, not
+  the data).
+- Keystrokes inside an already-running program (use session recording
+  for that).
+- Anything before login (those processes are tagged
+  `auid=4294967295` / "unset" and explicitly excluded by our rules).
+- System processes (auid < 1000 — daemons, kernel threads). They are
+  excluded on purpose, because they generate orders of magnitude more
+  events and have no business showing up in a user audit trail.
+- IPv6 outbound traffic via `sendto` on already-connected UDP sockets.
+  We trace `connect` only.
+- Programs that statically link or use `vfork`+exec patterns the kernel
+  does not classify as `execve` (rare in practice).
+
+## Activation
+
+The audit trace is **opt-in** and **off by default**, consistent with
+Open Bastion's policy of not modifying global system state without an
+explicit admin decision (see also `--enable-hardening` in PR1).
+
+```bash
+sudo ob-bastion-setup \
+    --portal https://auth.example.com \
+    --enable-audit-trace
+```
+
+What `--enable-audit-trace` does, in order:
+
+1. Refuses to proceed if the `auditd` package is not installed
+   (Debian/Ubuntu: `apt install auditd`; RHEL/Rocky/Fedora:
+   `dnf install audit`). We declare `auditd` as a `Recommends` /
+   `Recommends` soft dependency so installing the bastion package alone
+   never silently flips a global system knob.
+2. Asks the admin to confirm (skipped under `--yes`).
+3. Backs up `/etc/audit/auditd.conf`.
+4. Installs `/etc/audit/rules.d/open-bastion.rules` (mode 0640
+   `root:root`) from the template at
+   `/usr/share/open-bastion/audit/rules.d/open-bastion.rules`.
+5. Installs `/etc/cron.daily/open-bastion-audit-rotate` (mode 0755
+   `root:root`) from the corresponding template — this triggers a daily
+   rotation so that `num_logs=7` gives a ~1-week retention window.
+6. Idempotently sets three keys in `/etc/audit/auditd.conf`:
+   - `max_log_file = 50` (50 MB per audit.log file)
+   - `num_logs = 7` (keep 7 rotated files ≈ 1 week with daily rotation)
+   - `max_log_file_action = ROTATE`
+   Other keys (log path, dispatcher, `space_left_action`, etc.) are
+   left as the distribution shipped them.
+7. Loads the new rules with `augenrules --load` and restarts the
+   `auditd` service. **Note:** restarting auditd does *not* terminate
+   active SSH sessions (unlike `logind`), so this is safe to run on a
+   live bastion.
+
+## Verification
+
+After `--enable-audit-trace` succeeds, verify on the bastion:
+
+```bash
+# 1. Rules loaded?
+auditctl -l
+
+# Expect lines like:
+#   -a always,exit -F arch=b64 -S execve -F auid>=1000 -F auid!=-1 -F key=ob-exec
+#   -w /etc/passwd -p wa -k ob-passwd
+#   ...
+
+# 2. Recent execve events for any non-system user?
+ausearch -k ob-exec -ts recent | head -40
+
+# 3. Audit log present and being written?
+ls -lh /var/log/audit/audit.log
+
+# 4. auditd running and enabled at boot?
+systemctl status auditd
+```
+
+For a more pointed test, log in as a non-system user and run any command:
+
+```bash
+# As root:
+ausearch -k ob-exec -x /usr/bin/whoami -ts today
+```
+
+You should see at least one `type=EXECVE` record per `whoami` invocation
+made by an interactively logged-in user.
+
+## File lifecycle
+
+Like the PR1 hardening drop-ins, the audit-trace files are **deployment
+artefacts**, not dpkg conffiles or rpm `%config(noreplace)` files. The
+distinction matters when you upgrade or remove the bastion package.
+
+| Path                                                 | Owner       | Purpose                                      |
+|------------------------------------------------------|-------------|----------------------------------------------|
+| `/usr/share/open-bastion/audit/rules.d/open-bastion.rules` | open-bastion pkg | Read-only template (shipped by package).     |
+| `/usr/share/open-bastion/audit/cron.daily/open-bastion-audit-rotate` | open-bastion pkg | Read-only template.                          |
+| `/etc/audit/rules.d/open-bastion.rules`              | deployment  | Live copy. Edit in place if needed.          |
+| `/etc/cron.daily/open-bastion-audit-rotate`          | deployment  | Live copy. Edit in place if needed.          |
+| `/etc/audit/auditd.conf`                             | audit pkg   | Distro-shipped; we patch 3 keys in place.    |
+
+Reasoning: the audit package ships `auditd.conf` as its own conffile.
+If we shipped a competing one, dpkg/rpm would prompt the admin on every
+upgrade. Instead, we keep ours under `/usr/share/...` (ours, read-only)
+and copy it into `/etc/...` only at the moment the admin opts in. The
+backup made before any in-place edit ends up in
+`/var/backup/llng-setup-<timestamp>/auditd.conf`.
+
+## Tuning retention
+
+The defaults aim at ~1 week of history. To tune:
+
+| Want                | Edit `/etc/audit/auditd.conf` |
+|---------------------|-------------------------------|
+| Longer history      | Raise `num_logs` (e.g. `num_logs = 30`). |
+| Bigger files        | Raise `max_log_file` (in MB). |
+| Disk-full safety    | Set `space_left = 500` and `space_left_action = SYSLOG` (warns to syslog when free space drops below 500 MB). |
+| Stop on disk full   | `disk_full_action = HALT` (paranoid; default is `SUSPEND`). |
+
+After editing, run:
+
+```bash
+systemctl restart auditd
+```
+
+You may also want to adjust the cron frequency. By default we rotate
+daily; if your event volume is low you can move
+`/etc/cron.daily/open-bastion-audit-rotate` to `/etc/cron.weekly/`, in
+which case `num_logs = 7` gives a ~7-week window instead.
+
+## Forwarding to a remote collector
+
+A bastion that can be compromised should not store its only audit trail
+locally. The recommended next step (out of scope for this release) is to
+forward audit events to an external SIEM:
+
+- The `audispd` plugin framework is shipped by the `audit` package
+  itself.
+- The `audisp-syslog` plugin (in the `audisp-plugins` package on Debian)
+  forwards every audit record to syslog, from where rsyslog or
+  systemd-journal-upload can ship them off-host over TLS.
+- For Splunk / Elastic / Wazuh, vendor-specific collectors hook into
+  the same audispd socket.
+
+Open Bastion does **not** install or configure any forwarder. You need
+to make a deliberate choice about *where* the logs go and *how* they
+are protected in transit, both of which are deployment-specific.
+
+## Disabling
+
+Two ways:
+
+```bash
+# 1. Runtime (until next auditd restart): drop all rules.
+auditctl -D
+
+# 2. Permanent: remove the drop-in and reload.
+rm /etc/audit/rules.d/open-bastion.rules
+rm /etc/cron.daily/open-bastion-audit-rotate
+augenrules --load
+systemctl restart auditd
+```
+
+The auditd.conf changes (`max_log_file`, `num_logs`,
+`max_log_file_action`) remain in place; they are harmless even without
+our rules. To revert them, restore from
+`/var/backup/llng-setup-<timestamp>/auditd.conf`.
+
+## Volume and saturation
+
+`execve` + `connect` audit rules generate a lot of events on a busy
+bastion. Plan accordingly:
+
+- A typical interactive shell session emits 50–500 `execve` events.
+- A long-running rsync or ansible run can emit thousands of `connect`
+  events.
+- `/var/log/audit/audit.log` grows fast. With the defaults
+  (`max_log_file=50`, `num_logs=7`) the on-disk footprint caps at
+  ~350 MB. Keep an eye on `/var/log` free space.
+
+If saturation becomes an issue:
+
+- Tune `space_left` / `space_left_action` to alert before disk fills.
+- Drop the `connect` rule if you don't actually need network-level
+  forensics on this bastion.
+- Increase `max_log_file` and decrease `num_logs` for the same total
+  footprint with fewer rotations.
+- Forward to a remote collector and shrink local retention.
+
+## See also
+
+- [Session Recording](session-recording.md) — pty-level recording, the
+  other half of the traceability story.
+- `auditd.conf(5)`, `auditctl(8)`, `ausearch(8)`, `aureport(8)`.
+- The shipped template:
+  `/usr/share/open-bastion/audit/rules.d/open-bastion.rules`.

--- a/doc/audit.md
+++ b/doc/audit.md
@@ -85,11 +85,13 @@ sudo ob-bastion-setup \
 
 What `--enable-audit-trace` does, in order:
 
-1. Refuses to proceed if the `auditd` package is not installed
-   (Debian/Ubuntu: `apt install auditd`; RHEL/Rocky/Fedora:
-   `dnf install audit`). We declare `auditd` as a `Recommends`
-   soft dependency so installing the bastion package alone
-   never silently flips a global system knob.
+1. Warns and skips the audit-trace step if the `auditd` package is
+   not installed (Debian/Ubuntu: `apt install auditd`; RHEL/Rocky/Fedora:
+   `dnf install audit`). The rest of `ob-bastion-setup` continues
+   normally — the operator can install `auditd` later and re-run
+   with `--enable-audit-trace`. We declare `auditd` as a `Recommends`
+   soft dependency so installing the bastion package alone never
+   silently flips a global system knob.
 2. Asks the admin to confirm (skipped under `--yes`).
 3. Installs `/etc/audit/rules.d/open-bastion.rules` (mode 0640
    `root:root`) from the template at

--- a/doc/audit.md
+++ b/doc/audit.md
@@ -87,27 +87,23 @@ What `--enable-audit-trace` does, in order:
 
 1. Refuses to proceed if the `auditd` package is not installed
    (Debian/Ubuntu: `apt install auditd`; RHEL/Rocky/Fedora:
-   `dnf install audit`). We declare `auditd` as a `Recommends` /
-   `Recommends` soft dependency so installing the bastion package alone
+   `dnf install audit`). We declare `auditd` as a `Recommends`
+   soft dependency so installing the bastion package alone
    never silently flips a global system knob.
 2. Asks the admin to confirm (skipped under `--yes`).
-3. Backs up `/etc/audit/auditd.conf`.
-4. Installs `/etc/audit/rules.d/open-bastion.rules` (mode 0640
+3. Installs `/etc/audit/rules.d/open-bastion.rules` (mode 0640
    `root:root`) from the template at
    `/usr/share/open-bastion/audit/rules.d/open-bastion.rules`.
-5. Installs `/etc/cron.daily/open-bastion-audit-rotate` (mode 0755
+4. Installs `/etc/cron.daily/open-bastion-audit-rotate` (mode 0755
    `root:root`) from the corresponding template — this triggers a daily
    rotation so that `num_logs=7` gives a ~1-week retention window.
-6. Idempotently sets three keys in `/etc/audit/auditd.conf`:
-   - `max_log_file = 50` (50 MB per audit.log file)
-   - `num_logs = 7` (keep 7 rotated files ≈ 1 week with daily rotation)
-   - `max_log_file_action = ROTATE`
-   Other keys (log path, dispatcher, `space_left_action`, etc.) are
-   left as the distribution shipped them.
-7. Loads the new rules with `augenrules --load` and restarts the
+5. Loads the new rules with `augenrules --load` and restarts the
    `auditd` service. **Note:** restarting auditd does *not* terminate
    active SSH sessions (unlike `logind`), so this is safe to run on a
    live bastion.
+
+**`/etc/audit/auditd.conf` is deliberately NOT modified.** See
+[Tuning retention](#tuning-retention) below for the manual step.
 
 ## Verification
 
@@ -152,20 +148,42 @@ distinction matters when you upgrade or remove the bastion package.
 |------------------------------------------------------|-------------|----------------------------------------------|
 | `/usr/share/open-bastion/audit/rules.d/open-bastion.rules` | open-bastion pkg | Read-only template (shipped by package).     |
 | `/usr/share/open-bastion/audit/cron.daily/open-bastion-audit-rotate` | open-bastion pkg | Read-only template.                          |
-| `/etc/audit/rules.d/open-bastion.rules`              | deployment  | Live copy. Edit in place if needed.          |
-| `/etc/cron.daily/open-bastion-audit-rotate`          | deployment  | Live copy. Edit in place if needed.          |
-| `/etc/audit/auditd.conf`                             | audit pkg   | Distro-shipped; we patch 3 keys in place.    |
+| `/etc/audit/rules.d/open-bastion.rules`              | deployment  | Live copy deployed by `--enable-audit-trace`. Edit in place if needed. |
+| `/etc/cron.daily/open-bastion-audit-rotate`          | deployment  | Live copy deployed by `--enable-audit-trace`. Edit in place if needed. |
+| `/etc/audit/auditd.conf`                             | audit pkg   | Admin-tunable. **NOT modified by Open Bastion.** |
 
-Reasoning: the audit package ships `auditd.conf` as its own conffile.
-If we shipped a competing one, dpkg/rpm would prompt the admin on every
-upgrade. Instead, we keep ours under `/usr/share/...` (ours, read-only)
-and copy it into `/etc/...` only at the moment the admin opts in. The
-backup made before any in-place edit ends up in
-`/var/backup/llng-setup-<timestamp>/auditd.conf`.
+We deliberately do **not** modify `/etc/audit/auditd.conf` because it
+is a single admin-tunable file owned by the `audit` distro package.
+Drop-in mechanisms (`rules.d/`, `cron.daily/`) are used where they
+exist; the single admin-tunable file `auditd.conf` is left untouched.
+If we patched it in place, any `dpkg`/`rpm` conffile prompt on the next
+`audit` package upgrade would confront the admin with unexpected diffs.
 
-## Tuning retention
+## Tuning retention (manual post-deployment step)
 
-The defaults aim at ~1 week of history. To tune:
+**This is a required manual step** after running `--enable-audit-trace`.
+Open Bastion does not modify `/etc/audit/auditd.conf`. The distribution
+defaults (often `num_logs=5`, `max_log_file=8`) give only a few days of
+retention on a busy bastion.
+
+**Recommended: ~1 week local retention**
+
+```bash
+sudo sed -i \
+  -e 's/^max_log_file = .*/max_log_file = 50/' \
+  -e 's/^num_logs = .*/num_logs = 7/' \
+  -e 's/^max_log_file_action = .*/max_log_file_action = ROTATE/' \
+  /etc/audit/auditd.conf
+sudo systemctl restart auditd
+```
+
+Or edit the file directly:
+
+```bash
+sudo vim /etc/audit/auditd.conf
+```
+
+To further tune:
 
 | Want                | Edit `/etc/audit/auditd.conf` |
 |---------------------|-------------------------------|
@@ -177,7 +195,7 @@ The defaults aim at ~1 week of history. To tune:
 After editing, run:
 
 ```bash
-systemctl restart auditd
+sudo systemctl restart auditd
 ```
 
 You may also want to adjust the cron frequency. By default we rotate
@@ -218,10 +236,9 @@ augenrules --load
 systemctl restart auditd
 ```
 
-The auditd.conf changes (`max_log_file`, `num_logs`,
-`max_log_file_action`) remain in place; they are harmless even without
-our rules. To revert them, restore from
-`/var/backup/llng-setup-<timestamp>/auditd.conf`.
+If you previously tuned `/etc/audit/auditd.conf` manually (as recommended
+in the Tuning section), those changes are yours to revert; they are
+harmless even without our rules.
 
 ## Volume and saturation
 

--- a/doc/audit.md
+++ b/doc/audit.md
@@ -66,10 +66,16 @@ What this trace **does not** cover:
 - System processes (auid < 1000 — daemons, kernel threads). They are
   excluded on purpose, because they generate orders of magnitude more
   events and have no business showing up in a user audit trail.
-- IPv6 outbound traffic via `sendto` on already-connected UDP sockets.
-  We trace `connect` only.
-- Programs that statically link or use `vfork`+exec patterns the kernel
-  does not classify as `execve` (rare in practice).
+- Outbound UDP exfiltration via `sendto`/`sendmsg` on an unconnected
+  socket (the canonical DNS-tunnel pattern). We trace `connect` only,
+  by design — adding `sendto`/`sendmsg` would be very chatty by default.
+  Operators who need broader coverage can add `-S sendto -S sendmsg` to
+  `/etc/audit/rules.d/open-bastion.rules` and accept the volume.
+- Outbound traffic over `io_uring` (`io_uring_enter` with
+  `IORING_OP_CONNECT` / `IORING_OP_SEND*`). Same trade-off as above.
+- Programs that use `vfork`+exec patterns the kernel does not classify
+  as `execve`/`execveat` (rare in practice). Both `execve` and
+  `execveat` (syscall #322) are covered by our rules.
 
 ## Activation
 

--- a/doc/session-recording.md
+++ b/doc/session-recording.md
@@ -259,6 +259,18 @@ directly to `ob-session-recorder`.
 - Consider log rotation and retention policies
 - Sensitive data may be captured (passwords typed in terminals)
 
+### Complementary primary audit trace
+
+Session recording is a faithful pty replay, not an independent audit
+trail: a determined user can attempt to bypass the pty (via `setsid`,
+`at`, `cron`, `nohup`, `systemd --user`) or tamper with their own
+recording on disk. For a kernel-level, tamper-evident syscall log
+covering `execve`, outbound `connect`, and writes to sensitive paths
+(including the recordings directory itself), enable the optional
+auditd-based trace — see [Primary Audit Trace](audit.md). It is
+opt-in (`ob-bastion-setup --enable-audit-trace`) and complementary to
+session recording, not a replacement.
+
 ### Network Security
 
 When uploading to LLNG (future feature):

--- a/man/ob-bastion-setup.8
+++ b/man/ob-bastion-setup.8
@@ -44,11 +44,14 @@ OFF by default. When enabled, installs
 .I /etc/audit/rules.d/open-bastion.rules
 (targeting non-system users via auid >= 1000) and
 .I /etc/cron.daily/open-bastion-audit-rotate
-for daily log rotation, idempotently tunes three keys in
+for daily log rotation, then loads the rules and restarts auditd.
 .I /etc/audit/auditd.conf
-(max_log_file=50, num_logs=7, max_log_file_action=ROTATE), then loads
-the rules and restarts auditd. Requires the auditd package to be
-installed on the host (Recommends, not Depends). See
+is intentionally NOT modified; tune retention manually
+(see
+.BR doc/audit.md ,
+section "Tuning retention").
+Requires the auditd package to be installed on the host
+(Recommends, not Depends). See
 .B doc/audit.md
 for rationale, threat model, verification, and tuning.
 .TP

--- a/man/ob-bastion-setup.8
+++ b/man/ob-bastion-setup.8
@@ -37,6 +37,21 @@ Non-interactive mode (requires \-\-token\-file).
 .BR \-k ", " \-\-insecure
 Skip SSL certificate verification.
 .TP
+.BR \-\-enable\-audit\-trace
+Enable the optional primary audit trace based on
+.BR auditd (8).
+OFF by default. When enabled, installs
+.I /etc/audit/rules.d/open-bastion.rules
+(targeting non-system users via auid >= 1000) and
+.I /etc/cron.daily/open-bastion-audit-rotate
+for daily log rotation, idempotently tunes three keys in
+.I /etc/audit/auditd.conf
+(max_log_file=50, num_logs=7, max_log_file_action=ROTATE), then loads
+the rules and restarts auditd. Requires the auditd package to be
+installed on the host (Recommends, not Depends). See
+.B doc/audit.md
+for rationale, threat model, verification, and tuning.
+.TP
 .BR \-n ", " \-\-dry\-run
 Show what would be done without making changes.
 .TP

--- a/rpm/open-bastion.spec
+++ b/rpm/open-bastion.spec
@@ -29,6 +29,11 @@ Requires:       nscd
 Requires:       systemd
 Requires:       util-linux
 
+# Soft dependency: needed only when admin opts in via
+# `ob-bastion-setup --enable-audit-trace`. The audit templates ship in this
+# package; the auditd daemon itself is pulled in only by Recommends.
+Recommends:     audit
+
 %description
 Open Bastion PAM/NSS module for SSH bastion authentication supporting
 token-based and key-based authorization with server groups.
@@ -91,6 +96,12 @@ ctest --output-on-failure --verbose
 %{_bindir}/ob-ssh-proxy
 %config(noreplace) %{_sysconfdir}/open-bastion/session-recorder.conf.example
 %config(noreplace) %{_sysconfdir}/open-bastion/ssh-proxy.conf.example
+%dir %{_datadir}/open-bastion
+%dir %{_datadir}/open-bastion/audit
+%dir %{_datadir}/open-bastion/audit/rules.d
+%dir %{_datadir}/open-bastion/audit/cron.daily
+%{_datadir}/open-bastion/audit/rules.d/open-bastion.rules
+%{_datadir}/open-bastion/audit/cron.daily/open-bastion-audit-rotate
 %{_unitdir}/ob-heartbeat.service
 %{_unitdir}/ob-heartbeat.timer
 %{_mandir}/man1/ob-ssh-cert.1*

--- a/scripts/ob-bastion-setup
+++ b/scripts/ob-bastion-setup
@@ -29,6 +29,7 @@ DRY_RUN=false
 BACKUP_DIR="/var/backup/llng-setup-$(date +%Y%m%d-%H%M%S)"
 MAX_SECURITY=false
 KRL_REFRESH_INTERVAL=30
+ENABLE_AUDIT_TRACE=false
 
 # Paths
 SSH_CA_FILE="/etc/ssh/llng_ca.pub"
@@ -43,6 +44,12 @@ SSH_REVOKED_KEYS="/etc/ssh/revoked_keys"
 PAM_SUDO="/etc/pam.d/sudo"
 NSSWITCH_CONF="/etc/nsswitch.conf"
 NSS_OB_CONF="/etc/open-bastion/nss_openbastion.conf"
+
+# Audit trace paths (opt-in, see --enable-audit-trace)
+AUDIT_TEMPLATE_DIR="${AUDIT_TEMPLATE_DIR:-/usr/share/open-bastion/audit}"
+AUDIT_RULES_FILE="/etc/audit/rules.d/open-bastion.rules"
+AUDIT_CRON_FILE="/etc/cron.daily/open-bastion-audit-rotate"
+AUDITD_CONF="/etc/audit/auditd.conf"
 
 # Colors (only if terminal)
 if [ -t 1 ]; then
@@ -661,6 +668,146 @@ home_base = /home
     info "Created $NSS_OB_CONF"
 }
 
+# Idempotent in-place edit of a single auditd.conf key.
+# - Matches `^\s*<key>\s*=` (so commented lines `# key = ...` are NOT touched).
+# - Replaces the matched line with `<key> = <value>`.
+# - If no match, appends `<key> = <value>` to the file.
+# Args: <conf_file> <key> <value>
+audit_set_conf_key() {
+    local file="$1" key="$2" value="$3"
+    local desired="$key = $value"
+    local pattern="^[[:space:]]*${key}[[:space:]]*="
+    local sed_pattern="^[[:space:]]*${key}[[:space:]]*=.*"
+
+    if grep -Eq "$pattern" "$file" 2>/dev/null; then
+        # Replace existing key (sed -E for extended regex compatibility).
+        # Using a delimiter unlikely to appear in either key or value.
+        sed -E -i "s|${sed_pattern}|${desired}|" "$file"
+    else
+        # Append with newline guard if file does not end with one.
+        if [ -s "$file" ] && [ "$(tail -c 1 "$file" | wc -l)" -eq 0 ]; then
+            printf '\n' >> "$file"
+        fi
+        printf '%s\n' "$desired" >> "$file"
+    fi
+}
+
+# Configure primary audit trace via auditd (opt-in).
+# Goal: tamper-evident syscall-level evidence of non-sudo user activity,
+# independent of the pty session recording (which a malicious user could
+# wipe or bypass via setsid/at/cron). Targets auid >= 1000.
+#
+# Caller decides whether this runs (see ENABLE_AUDIT_TRACE in main()).
+# This function never tries to install the auditd package itself: it only
+# *configures* an auditd that is already present (Recommends in packaging).
+setup_audit_trace() {
+    step "Configuring primary audit trace (auditd)..."
+
+    # 1. Sanity: auditd must be installed. We don't try to be clever — both
+    #    `auditctl` (the CLI) and `augenrules` (the rules.d compiler) are
+    #    needed at runtime. systemctl probe is an additional belt-and-braces.
+    local auditd_ok=true
+    if ! command -v auditctl >/dev/null 2>&1; then
+        auditd_ok=false
+    fi
+    if ! command -v augenrules >/dev/null 2>&1; then
+        auditd_ok=false
+    fi
+    if [ "$auditd_ok" != "true" ]; then
+        error "auditd is not installed: refusing to enable audit trace."
+        error "  Debian/Ubuntu: apt install auditd"
+        error "  RHEL/Rocky/Fedora: dnf install audit"
+        error "  Then re-run with --enable-audit-trace."
+        return 1
+    fi
+
+    # 2. Templates must be deployed (CMake installs them under datarootdir).
+    local rules_template="$AUDIT_TEMPLATE_DIR/rules.d/open-bastion.rules"
+    local cron_template="$AUDIT_TEMPLATE_DIR/cron.daily/open-bastion-audit-rotate"
+    if [ ! -f "$rules_template" ]; then
+        error "Audit rules template not found: $rules_template"
+        error "Reinstall the open-bastion package, or set AUDIT_TEMPLATE_DIR=<path>."
+        return 1
+    fi
+    if [ ! -f "$cron_template" ]; then
+        error "Audit cron template not found: $cron_template"
+        return 1
+    fi
+
+    # 3. Confirmation: this modifies global system config (auditd.conf, rules.d,
+    #    cron.daily) and restarts auditd. Default-OFF policy applies.
+    if ! confirm "Enable primary audit trace? Modifies $AUDITD_CONF and restarts auditd."; then
+        info "Audit trace setup skipped by user."
+        return 0
+    fi
+
+    if [ "$DRY_RUN" = "true" ]; then
+        info "[DRY-RUN] Would install $AUDIT_RULES_FILE (0640 root:root)"
+        info "[DRY-RUN] Would install $AUDIT_CRON_FILE (0755 root:root)"
+        info "[DRY-RUN] Would tune $AUDITD_CONF: max_log_file=50, num_logs=7, max_log_file_action=ROTATE"
+        info "[DRY-RUN] Would augenrules --load and restart auditd"
+        return 0
+    fi
+
+    # 4. Backup auditd.conf before in-place edit. This file is shipped by the
+    #    `audit` distro package; we don't replace it (would clash with dpkg
+    #    conffile prompts and rpm config(noreplace)).
+    if [ -f "$AUDITD_CONF" ]; then
+        backup_file "$AUDITD_CONF"
+    else
+        warn "$AUDITD_CONF not found — auditd may be installed but not initialized yet."
+        warn "Continuing: rules.d + cron.daily will still be deployed."
+    fi
+
+    # 5. Install rules template into /etc/audit/rules.d/.
+    #    auditd's default rules.d entries (e.g. audit.rules) ship as 0640
+    #    root:root on Debian; we match that.
+    backup_file "$AUDIT_RULES_FILE"
+    install -o root -g root -m 0640 "$rules_template" "$AUDIT_RULES_FILE"
+    info "Installed $AUDIT_RULES_FILE"
+
+    # 6. Install daily rotation cron. cron.daily entries must be executable
+    #    and unsuffixed (run-parts ignores files with dots/tildes).
+    backup_file "$AUDIT_CRON_FILE"
+    install -o root -g root -m 0755 "$cron_template" "$AUDIT_CRON_FILE"
+    info "Installed $AUDIT_CRON_FILE"
+
+    # 7. Tune auditd.conf retention (idempotent). Only touch the 3 keys we
+    #    care about; leave everything else (log file path, dispatcher, etc.)
+    #    as the distro shipped it.
+    if [ -f "$AUDITD_CONF" ]; then
+        audit_set_conf_key "$AUDITD_CONF" "max_log_file" "50"
+        audit_set_conf_key "$AUDITD_CONF" "num_logs" "7"
+        audit_set_conf_key "$AUDITD_CONF" "max_log_file_action" "ROTATE"
+        info "Tuned $AUDITD_CONF (max_log_file=50, num_logs=7, max_log_file_action=ROTATE)"
+    fi
+
+    # 8. Compile + load rules. augenrules merges everything under
+    #    /etc/audit/rules.d/*.rules into /etc/audit/audit.rules and tells
+    #    auditctl to load them. A non-zero exit usually means a bad rule
+    #    (e.g. arch mismatch on 32-bit kernel) — surface it but don't abort:
+    #    the cron rotation and the conf tuning are still in effect.
+    if augenrules --load >/dev/null 2>&1; then
+        info "auditd rules loaded via augenrules"
+    else
+        warn "augenrules --load failed; check 'augenrules --check' output."
+    fi
+
+    # 9. Restart auditd so any conf changes (max_log_file etc.) take effect.
+    #    auditd does not honour SIGHUP for rules.d changes — restart is the
+    #    documented way. Unlike logind, restarting auditd does NOT terminate
+    #    SSH sessions, so this is safe to run on a live bastion.
+    if systemctl is-active --quiet auditd 2>/dev/null; then
+        if systemctl restart auditd 2>/dev/null; then
+            info "Restarted auditd.service"
+        else
+            warn "Failed to restart auditd; run 'systemctl restart auditd' manually."
+        fi
+    else
+        warn "auditd.service is not active; start it with 'systemctl enable --now auditd'."
+    fi
+}
+
 # Enroll server with LLNG
 enroll_server() {
     step "Enrolling server with LLNG..."
@@ -741,6 +888,11 @@ print_summary() {
         echo "    - sudo: LLNG temporary token required"
         echo "    - KRL: mandatory, refreshed every ${KRL_REFRESH_INTERVAL} min"
     fi
+    if [ "$ENABLE_AUDIT_TRACE" = "true" ]; then
+        echo "  ✓ Audit trace: applied (auditd rules + daily rotation)"
+    else
+        echo "  ✗ Audit trace: not applied (opt-in: --enable-audit-trace)"
+    fi
     echo ""
     echo "Backup location: $BACKUP_DIR"
     echo ""
@@ -767,6 +919,11 @@ Options:
   -y, --yes               Non-interactive mode (requires --token-file)
   -k, --insecure          Skip SSL certificate verification
   --max-security          Enable Mode E (SSO certificates only, sudo via LLNG token, KRL)
+  --enable-audit-trace    Enable primary audit trace via auditd (OFF by default).
+                          Modifies /etc/audit/auditd.conf, installs audit rules
+                          and a daily rotation cron, restarts auditd.
+                          Requires auditd package (apt install auditd /
+                          dnf install audit).
   -n, --dry-run           Show what would be done without making changes
   -h, --help              Show this help
   -V, --version           Show version
@@ -831,6 +988,10 @@ parse_args() {
                 ;;
             --max-security)
                 MAX_SECURITY=true
+                shift
+                ;;
+            --enable-audit-trace)
+                ENABLE_AUDIT_TRACE=true
                 shift
                 ;;
             -n|--dry-run)
@@ -920,6 +1081,13 @@ main() {
     configure_nss || exit 1
     download_krl || warn "KRL download failed"
     enroll_server || warn "Server enrollment skipped or failed"
+
+    # Optional primary audit trace (default OFF — modifies global system).
+    if [ "$ENABLE_AUDIT_TRACE" = "true" ]; then
+        setup_audit_trace || warn "Audit trace setup failed (see errors above)"
+    else
+        info "Audit trace not applied (opt-in: pass --enable-audit-trace)"
+    fi
 
     if [ "$DRY_RUN" = "false" ]; then
         restart_sshd || warn "Failed to restart SSH"

--- a/scripts/ob-bastion-setup
+++ b/scripts/ob-bastion-setup
@@ -49,7 +49,6 @@ NSS_OB_CONF="/etc/open-bastion/nss_openbastion.conf"
 AUDIT_TEMPLATE_DIR="${AUDIT_TEMPLATE_DIR:-/usr/share/open-bastion/audit}"
 AUDIT_RULES_FILE="/etc/audit/rules.d/open-bastion.rules"
 AUDIT_CRON_FILE="/etc/cron.daily/open-bastion-audit-rotate"
-AUDITD_CONF="/etc/audit/auditd.conf"
 
 # Colors (only if terminal)
 if [ -t 1 ]; then
@@ -668,30 +667,6 @@ home_base = /home
     info "Created $NSS_OB_CONF"
 }
 
-# Idempotent in-place edit of a single auditd.conf key.
-# - Matches `^\s*<key>\s*=` (so commented lines `# key = ...` are NOT touched).
-# - Replaces the matched line with `<key> = <value>`.
-# - If no match, appends `<key> = <value>` to the file.
-# Args: <conf_file> <key> <value>
-audit_set_conf_key() {
-    local file="$1" key="$2" value="$3"
-    local desired="$key = $value"
-    local pattern="^[[:space:]]*${key}[[:space:]]*="
-    local sed_pattern="^[[:space:]]*${key}[[:space:]]*=.*"
-
-    if grep -Eq "$pattern" "$file" 2>/dev/null; then
-        # Replace existing key (sed -E for extended regex compatibility).
-        # Using a delimiter unlikely to appear in either key or value.
-        sed -E -i "s|${sed_pattern}|${desired}|" "$file"
-    else
-        # Append with newline guard if file does not end with one.
-        if [ -s "$file" ] && [ "$(tail -c 1 "$file" | wc -l)" -eq 0 ]; then
-            printf '\n' >> "$file"
-        fi
-        printf '%s\n' "$desired" >> "$file"
-    fi
-}
-
 # Configure primary audit trace via auditd (opt-in).
 # Goal: tamper-evident syscall-level evidence of non-sudo user activity,
 # independent of the pty session recording (which a malicious user could
@@ -734,9 +709,10 @@ setup_audit_trace() {
         return 1
     fi
 
-    # 3. Confirmation: this modifies global system config (auditd.conf, rules.d,
-    #    cron.daily) and restarts auditd. Default-OFF policy applies.
-    if ! confirm "Enable primary audit trace? Modifies $AUDITD_CONF and restarts auditd."; then
+    # 3. Confirmation: this deploys rules.d/cron.daily entries and restarts
+    #    auditd. Default-OFF policy applies. /etc/audit/auditd.conf is NOT
+    #    touched — see rationale below.
+    if ! confirm "Enable primary audit trace? Installs rules.d + cron.daily and restarts auditd."; then
         info "Audit trace setup skipped by user."
         return 0
     fi
@@ -744,56 +720,41 @@ setup_audit_trace() {
     if [ "$DRY_RUN" = "true" ]; then
         info "[DRY-RUN] Would install $AUDIT_RULES_FILE (0640 root:root)"
         info "[DRY-RUN] Would install $AUDIT_CRON_FILE (0755 root:root)"
-        info "[DRY-RUN] Would tune $AUDITD_CONF: max_log_file=50, num_logs=7, max_log_file_action=ROTATE"
         info "[DRY-RUN] Would augenrules --load and restart auditd"
+        info "[DRY-RUN] $AUDITD_CONF intentionally NOT modified"
         return 0
     fi
 
-    # 4. Backup auditd.conf before in-place edit. This file is shipped by the
-    #    `audit` distro package; we don't replace it (would clash with dpkg
-    #    conffile prompts and rpm config(noreplace)).
-    if [ -f "$AUDITD_CONF" ]; then
-        backup_file "$AUDITD_CONF"
-    else
-        warn "$AUDITD_CONF not found — auditd may be installed but not initialized yet."
-        warn "Continuing: rules.d + cron.daily will still be deployed."
-    fi
-
-    # 5. Install rules template into /etc/audit/rules.d/.
+    # 4. Install rules template into /etc/audit/rules.d/.
     #    auditd's default rules.d entries (e.g. audit.rules) ship as 0640
     #    root:root on Debian; we match that.
-    backup_file "$AUDIT_RULES_FILE"
     install -o root -g root -m 0640 "$rules_template" "$AUDIT_RULES_FILE"
     info "Installed $AUDIT_RULES_FILE"
 
-    # 6. Install daily rotation cron. cron.daily entries must be executable
+    # 5. Install daily rotation cron. cron.daily entries must be executable
     #    and unsuffixed (run-parts ignores files with dots/tildes).
-    backup_file "$AUDIT_CRON_FILE"
     install -o root -g root -m 0755 "$cron_template" "$AUDIT_CRON_FILE"
     info "Installed $AUDIT_CRON_FILE"
 
-    # 7. Tune auditd.conf retention (idempotent). Only touch the 3 keys we
-    #    care about; leave everything else (log file path, dispatcher, etc.)
-    #    as the distro shipped it.
-    if [ -f "$AUDITD_CONF" ]; then
-        audit_set_conf_key "$AUDITD_CONF" "max_log_file" "50"
-        audit_set_conf_key "$AUDITD_CONF" "num_logs" "7"
-        audit_set_conf_key "$AUDITD_CONF" "max_log_file_action" "ROTATE"
-        info "Tuned $AUDITD_CONF (max_log_file=50, num_logs=7, max_log_file_action=ROTATE)"
-    fi
+    # /etc/audit/auditd.conf is intentionally NOT modified. It is a single
+    # admin-tunable file owned by the audit distro package. Drop-in mechanisms
+    # (rules.d/, cron.daily/) are used where they exist; auditd.conf is left
+    # for the administrator to tune manually (see doc/audit.md).
+    info "Audit trace deployed. /etc/audit/auditd.conf is intentionally NOT modified."
+    info "For ~1 week retention, set num_logs=7 max_log_file=50 max_log_file_action=ROTATE in /etc/audit/auditd.conf manually (see doc/audit.md)."
 
-    # 8. Compile + load rules. augenrules merges everything under
+    # 6. Compile + load rules. augenrules merges everything under
     #    /etc/audit/rules.d/*.rules into /etc/audit/audit.rules and tells
     #    auditctl to load them. A non-zero exit usually means a bad rule
     #    (e.g. arch mismatch on 32-bit kernel) — surface it but don't abort:
-    #    the cron rotation and the conf tuning are still in effect.
+    #    the cron rotation is still in effect.
     if augenrules --load >/dev/null 2>&1; then
         info "auditd rules loaded via augenrules"
     else
         warn "augenrules --load failed; check 'augenrules --check' output."
     fi
 
-    # 9. Restart auditd so any conf changes (max_log_file etc.) take effect.
+    # 7. Restart auditd to activate the new rules.d entries.
     #    auditd does not honour SIGHUP for rules.d changes — restart is the
     #    documented way. Unlike logind, restarting auditd does NOT terminate
     #    SSH sessions, so this is safe to run on a live bastion.
@@ -920,8 +881,10 @@ Options:
   -k, --insecure          Skip SSL certificate verification
   --max-security          Enable Mode E (SSO certificates only, sudo via LLNG token, KRL)
   --enable-audit-trace    Enable primary audit trace via auditd (OFF by default).
-                          Modifies /etc/audit/auditd.conf, installs audit rules
-                          and a daily rotation cron, restarts auditd.
+                          Installs audit rules (rules.d/open-bastion.rules)
+                          and a daily rotation cron, then restarts auditd.
+                          /etc/audit/auditd.conf is NOT modified; tune
+                          retention manually (see doc/audit.md).
                           Requires auditd package (apt install auditd /
                           dnf install audit).
   -n, --dry-run           Show what would be done without making changes

--- a/scripts/ob-bastion-setup
+++ b/scripts/ob-bastion-setup
@@ -728,12 +728,21 @@ setup_audit_trace() {
     # 4. Install rules template into /etc/audit/rules.d/.
     #    auditd's default rules.d entries (e.g. audit.rules) ship as 0640
     #    root:root on Debian; we match that.
-    install -o root -g root -m 0640 "$rules_template" "$AUDIT_RULES_FILE"
+    #    Guard against `set -e` aborting the whole ob-bastion-setup run if
+    #    /etc/audit/rules.d/ is missing, RO, or perms-denied — return 1
+    #    instead so main() catches it via `setup_audit_trace || warn …`.
+    if ! install -o root -g root -m 0640 "$rules_template" "$AUDIT_RULES_FILE"; then
+        error "Failed to install $AUDIT_RULES_FILE"
+        return 1
+    fi
     info "Installed $AUDIT_RULES_FILE"
 
     # 5. Install daily rotation cron. cron.daily entries must be executable
     #    and unsuffixed (run-parts ignores files with dots/tildes).
-    install -o root -g root -m 0755 "$cron_template" "$AUDIT_CRON_FILE"
+    if ! install -o root -g root -m 0755 "$cron_template" "$AUDIT_CRON_FILE"; then
+        error "Failed to install $AUDIT_CRON_FILE"
+        return 1
+    fi
     info "Installed $AUDIT_CRON_FILE"
 
     # /etc/audit/auditd.conf is intentionally NOT modified. It is a single

--- a/scripts/ob-bastion-setup
+++ b/scripts/ob-bastion-setup
@@ -721,7 +721,7 @@ setup_audit_trace() {
         info "[DRY-RUN] Would install $AUDIT_RULES_FILE (0640 root:root)"
         info "[DRY-RUN] Would install $AUDIT_CRON_FILE (0755 root:root)"
         info "[DRY-RUN] Would augenrules --load and restart auditd"
-        info "[DRY-RUN] $AUDITD_CONF intentionally NOT modified"
+        info "[DRY-RUN] /etc/audit/auditd.conf intentionally NOT modified"
         return 0
     fi
 

--- a/scripts/ob-bastion-setup
+++ b/scripts/ob-bastion-setup
@@ -689,11 +689,11 @@ setup_audit_trace() {
         auditd_ok=false
     fi
     if [ "$auditd_ok" != "true" ]; then
-        error "auditd is not installed: refusing to enable audit trace."
-        error "  Debian/Ubuntu: apt install auditd"
-        error "  RHEL/Rocky/Fedora: dnf install audit"
-        error "  Then re-run with --enable-audit-trace."
-        return 1
+        warn "auditd is not installed; skipping audit trace setup."
+        warn "  To enable audit trace later, install auditd then re-run with --enable-audit-trace:"
+        warn "    Debian/Ubuntu: apt install auditd"
+        warn "    RHEL/Rocky/Fedora: dnf install audit"
+        return 0
     fi
 
     # 2. Templates must be deployed (CMake installs them under datarootdir).

--- a/tests/test_ob_bastion_setup_audit.sh
+++ b/tests/test_ob_bastion_setup_audit.sh
@@ -9,8 +9,9 @@
 # test host. We exercise:
 #   - flag parsing (default off, --enable-audit-trace flips it on)
 #   - the auditd-not-installed refusal path
-#   - the audit_set_conf_key idempotent in-place edit
 #   - shipped template contents
+#   - regression: auditd.conf must NOT be modified by setup_audit_trace
+#   - regression: audit_set_conf_key must NOT exist in the script
 # Anything that would actually call augenrules / systemctl is fenced
 # behind the "auditd missing" guard.
 #
@@ -174,104 +175,81 @@ test_refuses_without_templates() {
     fi
 }
 
-# ── Test 6: audit_set_conf_key replaces an existing key in place ──
-test_conf_key_replace_existing() {
-    local tmpdir
-    tmpdir=$(mktemp -d)
-    local conf="$tmpdir/auditd.conf"
-    cat > "$conf" <<EOF
-# auditd.conf
-log_file = /var/log/audit/audit.log
-max_log_file = 8
-num_logs = 5
-log_format = ENRICHED
-EOF
-    (
-        source_script "ob-bastion-setup"
-        audit_set_conf_key "$conf" "max_log_file" "50"
-        audit_set_conf_key "$conf" "num_logs" "7"
-        # Replacing twice must be idempotent.
-        audit_set_conf_key "$conf" "max_log_file" "50"
-        grep -q "^max_log_file = 50$" "$conf" || exit 1
-        grep -q "^num_logs = 7$" "$conf" || exit 1
-        # Original unrelated keys preserved.
-        grep -q "^log_file = /var/log/audit/audit.log$" "$conf" || exit 1
-        grep -q "^log_format = ENRICHED$" "$conf" || exit 1
-        # Old values gone.
-        grep -q "^max_log_file = 8$" "$conf" && exit 1
-        grep -q "^num_logs = 5$" "$conf" && exit 1
-        # File should not have grown duplicate keys.
-        local cnt
-        cnt=$(grep -c "^max_log_file " "$conf")
-        [ "$cnt" -eq 1 ] || exit 1
-        cnt=$(grep -c "^num_logs " "$conf")
-        [ "$cnt" -eq 1 ] || exit 1
-        exit 0
-    )
-    local rc=$?
-    rm -rf "$tmpdir"
-    if [ $rc -eq 0 ]; then
-        pass "audit_set_conf_key replaces existing key idempotently"
+# ── Test 6: audit_set_conf_key must NOT exist in the script ──
+# Regression guard: prevent accidental re-introduction of the removed helper.
+test_no_audit_set_conf_key() {
+    local script="$SCRIPT_DIR/ob-bastion-setup"
+    if grep -q "audit_set_conf_key" "$script"; then
+        fail "audit_set_conf_key must not exist in ob-bastion-setup" \
+             "found: $(grep -n 'audit_set_conf_key' "$script")"
     else
-        fail "audit_set_conf_key replaces existing key idempotently"
+        pass "audit_set_conf_key is absent from ob-bastion-setup (removed)"
     fi
 }
 
-# ── Test 7: audit_set_conf_key appends when key is absent ──
-test_conf_key_append_absent() {
+# ── Test 7: setup_audit_trace does NOT modify a sandbox auditd.conf ──
+# We create a sandbox auditd.conf with a known content, run
+# setup_audit_trace in a fully sandboxed environment (fake auditctl /
+# augenrules, AUDIT_TEMPLATE_DIR, no systemctl), then assert the file is
+# byte-for-byte identical to what we created.
+test_auditd_conf_not_modified() {
     local tmpdir
     tmpdir=$(mktemp -d)
-    local conf="$tmpdir/auditd.conf"
-    cat > "$conf" <<EOF
-log_file = /var/log/audit/audit.log
-log_format = ENRICHED
-EOF
     (
         source_script "ob-bastion-setup"
-        audit_set_conf_key "$conf" "max_log_file_action" "ROTATE"
-        grep -q "^max_log_file_action = ROTATE$" "$conf" || exit 1
-        # Pre-existing keys untouched.
-        grep -q "^log_file = /var/log/audit/audit.log$" "$conf" || exit 1
-        # Single occurrence after multiple calls.
-        audit_set_conf_key "$conf" "max_log_file_action" "ROTATE"
-        local cnt
-        cnt=$(grep -c "^max_log_file_action " "$conf")
-        [ "$cnt" -eq 1 ] || exit 1
-        exit 0
-    )
-    local rc=$?
-    rm -rf "$tmpdir"
-    if [ $rc -eq 0 ]; then
-        pass "audit_set_conf_key appends absent key (and stays idempotent)"
-    else
-        fail "audit_set_conf_key appends absent key (and stays idempotent)"
-    fi
-}
 
-# ── Test 8: audit_set_conf_key does not touch commented lines ──
-test_conf_key_skips_comments() {
-    local tmpdir
-    tmpdir=$(mktemp -d)
-    local conf="$tmpdir/auditd.conf"
-    cat > "$conf" <<EOF
-# max_log_file = 8
-# default-shipped commented example
-EOF
-    (
-        source_script "ob-bastion-setup"
-        audit_set_conf_key "$conf" "max_log_file" "50"
-        # The commented line must remain.
-        grep -q "^# max_log_file = 8$" "$conf" || exit 1
-        # The new live line was appended, not substituted into the comment.
-        grep -q "^max_log_file = 50$" "$conf" || exit 1
-        exit 0
+        # Stub auditctl, augenrules, systemctl — they must exist for the
+        # function not to bail at step 1, but we want them to be no-ops.
+        mkdir -p "$tmpdir/bin"
+        printf '#!/bin/sh\nexit 0\n' > "$tmpdir/bin/auditctl"
+        printf '#!/bin/sh\nexit 0\n' > "$tmpdir/bin/augenrules"
+        printf '#!/bin/sh\nexit 0\n' > "$tmpdir/bin/systemctl"
+        chmod +x "$tmpdir/bin/auditctl" "$tmpdir/bin/augenrules" "$tmpdir/bin/systemctl"
+        export PATH="$tmpdir/bin:$PATH"
+
+        # Provide minimal templates so the template-check passes.
+        local tdir="$tmpdir/templates"
+        mkdir -p "$tdir/rules.d" "$tdir/cron.daily"
+        printf '# rules\n' > "$tdir/rules.d/open-bastion.rules"
+        printf '#!/bin/sh\necho rotate\n' > "$tdir/cron.daily/open-bastion-audit-rotate"
+        chmod +x "$tdir/cron.daily/open-bastion-audit-rotate"
+        AUDIT_TEMPLATE_DIR="$tdir"
+
+        # Redirect install targets so we don't need /etc.
+        AUDIT_RULES_FILE="$tmpdir/open-bastion.rules"
+        AUDIT_CRON_FILE="$tmpdir/open-bastion-audit-rotate"
+
+        # The sandbox auditd.conf with a known sentinel value.
+        local sandbox_conf="$tmpdir/auditd.conf"
+        printf 'max_log_file = 8\nnum_logs = 5\n' > "$sandbox_conf"
+        local before_hash
+        before_hash=$(md5sum "$sandbox_conf")
+
+        # Non-interactive so confirm() returns true.
+        NON_INTERACTIVE=true
+
+        # Run the function. It should NOT touch sandbox_conf — but we do
+        # not pass $sandbox_conf as a parameter; we just verify by hash.
+        setup_audit_trace >/dev/null 2>&1 || true
+
+        local after_hash
+        after_hash=$(md5sum "$sandbox_conf")
+
+        if [ "$before_hash" = "$after_hash" ]; then
+            exit 0
+        else
+            echo "auditd.conf was modified!" >&2
+            echo "Before: $before_hash" >&2
+            echo "After:  $after_hash" >&2
+            exit 1
+        fi
     )
     local rc=$?
     rm -rf "$tmpdir"
     if [ $rc -eq 0 ]; then
-        pass "audit_set_conf_key leaves commented lines alone"
+        pass "setup_audit_trace does NOT modify a sandbox auditd.conf"
     else
-        fail "audit_set_conf_key leaves commented lines alone"
+        fail "setup_audit_trace does NOT modify a sandbox auditd.conf"
     fi
 }
 
@@ -370,9 +348,8 @@ run_test test_flag_enables
 run_test test_help_mentions_flag
 run_test test_refuses_without_auditd
 run_test test_refuses_without_templates
-run_test test_conf_key_replace_existing
-run_test test_conf_key_append_absent
-run_test test_conf_key_skips_comments
+run_test test_no_audit_set_conf_key
+run_test test_auditd_conf_not_modified
 run_test test_rules_template_content
 run_test test_cron_template_content
 run_test test_main_gates_audit_trace

--- a/tests/test_ob_bastion_setup_audit.sh
+++ b/tests/test_ob_bastion_setup_audit.sh
@@ -1,0 +1,383 @@
+#!/bin/bash
+#
+# Tests for `ob-bastion-setup --enable-audit-trace` (PR2: primary audit
+# trace via auditd). Mirrors the structure of test_ob_bastion_setup.sh:
+# we source the script's functions into a subshell, sandbox every
+# system path under a per-test tmpdir, and assert outcomes.
+#
+# These tests deliberately do NOT require auditd to be installed on the
+# test host. We exercise:
+#   - flag parsing (default off, --enable-audit-trace flips it on)
+#   - the auditd-not-installed refusal path
+#   - the audit_set_conf_key idempotent in-place edit
+#   - shipped template contents
+# Anything that would actually call augenrules / systemctl is fenced
+# behind the "auditd missing" guard.
+#
+# shellcheck disable=SC2030,SC2031   # subshell PATH scoping is the point
+# shellcheck disable=SC2034          # vars are read by sourced functions
+# shellcheck disable=SC2181          # mirrors test_ob_bastion_setup.sh style
+
+set -uo pipefail
+
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+PROJECT_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SCRIPT_DIR="$PROJECT_ROOT/scripts"
+
+pass() { TESTS_PASSED=$((TESTS_PASSED + 1)); echo "  PASS: $1"; }
+fail() { TESTS_FAILED=$((TESTS_FAILED + 1)); echo "  FAIL: $1${2:+ - $2}"; }
+run_test() { TESTS_RUN=$((TESTS_RUN + 1)); "$@"; }
+
+# Same trick as test_ob_bastion_setup.sh: strip `main "$@"` and the
+# `set -e[uo pipefail]` line so we can source function definitions
+# without triggering the full main flow.
+source_script() {
+    local script="$1"
+    local content
+    content=$(cat "$SCRIPT_DIR/$script")
+    content="${content%main \"\$@\"}"
+    content=$(echo "$content" | sed -E 's/^set -e(uo pipefail)?$//')
+    eval "$content"
+}
+
+# ── Test 1: ENABLE_AUDIT_TRACE defaults to false ──
+test_default_off() {
+    (
+        source_script "ob-bastion-setup"
+        [ "$ENABLE_AUDIT_TRACE" = "false" ] && exit 0 || exit 1
+    )
+    if [ $? -eq 0 ]; then
+        pass "ENABLE_AUDIT_TRACE defaults to false"
+    else
+        fail "ENABLE_AUDIT_TRACE defaults to false"
+    fi
+}
+
+# ── Test 2: --enable-audit-trace flips it on ──
+test_flag_enables() {
+    (
+        source_script "ob-bastion-setup"
+        parse_args -p "https://x" --enable-audit-trace
+        [ "$ENABLE_AUDIT_TRACE" = "true" ] && exit 0 || exit 1
+    )
+    if [ $? -eq 0 ]; then
+        pass "--enable-audit-trace sets ENABLE_AUDIT_TRACE=true"
+    else
+        fail "--enable-audit-trace sets ENABLE_AUDIT_TRACE=true"
+    fi
+}
+
+# ── Test 3: Help text mentions --enable-audit-trace ──
+test_help_mentions_flag() {
+    local out
+    out=$(bash "$SCRIPT_DIR/ob-bastion-setup" --help 2>&1)
+    if echo "$out" | grep -q -- "--enable-audit-trace"; then
+        pass "--help advertises --enable-audit-trace"
+    else
+        fail "--help advertises --enable-audit-trace" "$out"
+    fi
+}
+
+# ── Test 4: setup_audit_trace refuses when auditctl is missing ──
+# We swap PATH so neither auditctl nor augenrules is found by `command -v`
+# inside the function, but coreutils (mkdir/grep/...) still work.
+test_refuses_without_auditd() {
+    local tmpdir
+    tmpdir=$(mktemp -d)
+    local empty_dir="$tmpdir/empty"
+    mkdir -p "$empty_dir"
+    local saved_path="$PATH"
+
+    (
+        source_script "ob-bastion-setup"
+        # Save the real PATH for the test wrapper, then narrow it for the
+        # function call. We still need `tail`, `grep`, `mkdir`, etc., so we
+        # keep coreutils on PATH; we only ensure auditctl/augenrules are
+        # NOT reachable (they would normally be in /usr/sbin or /sbin).
+        # We construct a PATH that excludes /usr/sbin and /sbin entirely.
+        local orig_path="$saved_path"
+        local cleaned_path=""
+        local IFS=":"
+        for p in $orig_path; do
+            case "$p" in
+                */sbin|*/sbin/) ;;
+                "") ;;
+                *) cleaned_path="${cleaned_path:+$cleaned_path:}$p" ;;
+            esac
+        done
+        export PATH="$cleaned_path"
+
+        # Force the function past the `confirm` prompt regardless.
+        NON_INTERACTIVE=true
+        # Sanity assertion: auditctl really is unreachable. If the host
+        # somehow ships auditctl outside /sbin, skip the check.
+        if command -v auditctl >/dev/null 2>&1; then
+            echo "skip: auditctl reachable even with /sbin stripped" >&2
+            exit 0
+        fi
+        local out
+        out=$(setup_audit_trace 2>&1)
+        local rc=$?
+        if [ "$rc" -ne 0 ] && echo "$out" | grep -q "auditd is not installed"; then
+            exit 0
+        else
+            echo "rc=$rc out=$out" >&2
+            exit 1
+        fi
+    )
+    local rc=$?
+    rm -rf "$tmpdir"
+    if [ $rc -eq 0 ]; then
+        pass "setup_audit_trace refuses cleanly when auditd is missing"
+    else
+        fail "setup_audit_trace refuses cleanly when auditd is missing"
+    fi
+}
+
+# ── Test 5: setup_audit_trace refuses when templates are missing ──
+# Provide fake auditctl/augenrules in PATH but point AUDIT_TEMPLATE_DIR
+# at an empty directory. The function must still bail out with rc!=0.
+test_refuses_without_templates() {
+    local tmpdir
+    tmpdir=$(mktemp -d)
+    (
+        source_script "ob-bastion-setup"
+        # Stub binaries so command -v finds them.
+        mkdir -p "$tmpdir/bin"
+        printf '#!/bin/sh\nexit 0\n' > "$tmpdir/bin/auditctl"
+        printf '#!/bin/sh\nexit 0\n' > "$tmpdir/bin/augenrules"
+        chmod +x "$tmpdir/bin/auditctl" "$tmpdir/bin/augenrules"
+        export PATH="$tmpdir/bin:$PATH"
+
+        AUDIT_TEMPLATE_DIR="$tmpdir/empty-templates"
+        mkdir -p "$AUDIT_TEMPLATE_DIR"
+        NON_INTERACTIVE=true
+
+        local out
+        out=$(setup_audit_trace 2>&1)
+        local rc=$?
+        if [ "$rc" -ne 0 ] && echo "$out" | grep -q "Audit rules template not found"; then
+            exit 0
+        else
+            echo "rc=$rc out=$out" >&2
+            exit 1
+        fi
+    )
+    local rc=$?
+    rm -rf "$tmpdir"
+    if [ $rc -eq 0 ]; then
+        pass "setup_audit_trace refuses cleanly when templates are missing"
+    else
+        fail "setup_audit_trace refuses cleanly when templates are missing"
+    fi
+}
+
+# ── Test 6: audit_set_conf_key replaces an existing key in place ──
+test_conf_key_replace_existing() {
+    local tmpdir
+    tmpdir=$(mktemp -d)
+    local conf="$tmpdir/auditd.conf"
+    cat > "$conf" <<EOF
+# auditd.conf
+log_file = /var/log/audit/audit.log
+max_log_file = 8
+num_logs = 5
+log_format = ENRICHED
+EOF
+    (
+        source_script "ob-bastion-setup"
+        audit_set_conf_key "$conf" "max_log_file" "50"
+        audit_set_conf_key "$conf" "num_logs" "7"
+        # Replacing twice must be idempotent.
+        audit_set_conf_key "$conf" "max_log_file" "50"
+        grep -q "^max_log_file = 50$" "$conf" || exit 1
+        grep -q "^num_logs = 7$" "$conf" || exit 1
+        # Original unrelated keys preserved.
+        grep -q "^log_file = /var/log/audit/audit.log$" "$conf" || exit 1
+        grep -q "^log_format = ENRICHED$" "$conf" || exit 1
+        # Old values gone.
+        grep -q "^max_log_file = 8$" "$conf" && exit 1
+        grep -q "^num_logs = 5$" "$conf" && exit 1
+        # File should not have grown duplicate keys.
+        local cnt
+        cnt=$(grep -c "^max_log_file " "$conf")
+        [ "$cnt" -eq 1 ] || exit 1
+        cnt=$(grep -c "^num_logs " "$conf")
+        [ "$cnt" -eq 1 ] || exit 1
+        exit 0
+    )
+    local rc=$?
+    rm -rf "$tmpdir"
+    if [ $rc -eq 0 ]; then
+        pass "audit_set_conf_key replaces existing key idempotently"
+    else
+        fail "audit_set_conf_key replaces existing key idempotently"
+    fi
+}
+
+# ── Test 7: audit_set_conf_key appends when key is absent ──
+test_conf_key_append_absent() {
+    local tmpdir
+    tmpdir=$(mktemp -d)
+    local conf="$tmpdir/auditd.conf"
+    cat > "$conf" <<EOF
+log_file = /var/log/audit/audit.log
+log_format = ENRICHED
+EOF
+    (
+        source_script "ob-bastion-setup"
+        audit_set_conf_key "$conf" "max_log_file_action" "ROTATE"
+        grep -q "^max_log_file_action = ROTATE$" "$conf" || exit 1
+        # Pre-existing keys untouched.
+        grep -q "^log_file = /var/log/audit/audit.log$" "$conf" || exit 1
+        # Single occurrence after multiple calls.
+        audit_set_conf_key "$conf" "max_log_file_action" "ROTATE"
+        local cnt
+        cnt=$(grep -c "^max_log_file_action " "$conf")
+        [ "$cnt" -eq 1 ] || exit 1
+        exit 0
+    )
+    local rc=$?
+    rm -rf "$tmpdir"
+    if [ $rc -eq 0 ]; then
+        pass "audit_set_conf_key appends absent key (and stays idempotent)"
+    else
+        fail "audit_set_conf_key appends absent key (and stays idempotent)"
+    fi
+}
+
+# ── Test 8: audit_set_conf_key does not touch commented lines ──
+test_conf_key_skips_comments() {
+    local tmpdir
+    tmpdir=$(mktemp -d)
+    local conf="$tmpdir/auditd.conf"
+    cat > "$conf" <<EOF
+# max_log_file = 8
+# default-shipped commented example
+EOF
+    (
+        source_script "ob-bastion-setup"
+        audit_set_conf_key "$conf" "max_log_file" "50"
+        # The commented line must remain.
+        grep -q "^# max_log_file = 8$" "$conf" || exit 1
+        # The new live line was appended, not substituted into the comment.
+        grep -q "^max_log_file = 50$" "$conf" || exit 1
+        exit 0
+    )
+    local rc=$?
+    rm -rf "$tmpdir"
+    if [ $rc -eq 0 ]; then
+        pass "audit_set_conf_key leaves commented lines alone"
+    else
+        fail "audit_set_conf_key leaves commented lines alone"
+    fi
+}
+
+# ── Test 9: rules template content has the expected keys ──
+test_rules_template_content() {
+    local rules="$PROJECT_ROOT/config/audit/rules.d/open-bastion.rules"
+    if [ ! -f "$rules" ]; then
+        fail "rules template content" "$rules missing"
+        return
+    fi
+    local ok=true
+    grep -Eq "auid>=1000" "$rules" || ok=false
+    grep -Eq "auid!=unset" "$rules" || ok=false
+    grep -Eq "^-a always,exit -F arch=b64 -S execve" "$rules" || ok=false
+    grep -Eq "^-a always,exit -F arch=b64 -S connect" "$rules" || ok=false
+    grep -q -- "-w /etc/passwd" "$rules" || ok=false
+    grep -q -- "-w /etc/shadow" "$rules" || ok=false
+    grep -q -- "-w /etc/sudoers" "$rules" || ok=false
+    grep -q -- "-w /etc/ssh/sshd_config" "$rules" || ok=false
+    grep -q -- "-w /var/lib/open-bastion/sessions/" "$rules" || ok=false
+    grep -q -- "-w /etc/open-bastion/" "$rules" || ok=false
+    grep -q -- "-k ob-exec" "$rules" || ok=false
+    grep -q -- "-k ob-connect" "$rules" || ok=false
+    if $ok; then
+        pass "rules template covers execve/connect/sensitive-files/sessions/config"
+    else
+        fail "rules template covers execve/connect/sensitive-files/sessions/config"
+    fi
+}
+
+# ── Test 10: cron.daily template is a valid /bin/sh script that calls SIGUSR1 ──
+test_cron_template_content() {
+    local cron="$PROJECT_ROOT/config/audit/cron.daily/open-bastion-audit-rotate"
+    if [ ! -f "$cron" ]; then
+        fail "cron template content" "$cron missing"
+        return
+    fi
+    local ok=true
+    head -1 "$cron" | grep -q "^#!/bin/sh" || ok=false
+    grep -q "USR1" "$cron" || ok=false
+    [ -x "$cron" ] || ok=false
+    # Must pass `bash -n` cleanly.
+    bash -n "$cron" 2>/dev/null || ok=false
+    if $ok; then
+        pass "cron.daily template is valid (shebang, executable, signals USR1)"
+    else
+        fail "cron.daily template is valid (shebang, executable, signals USR1)"
+    fi
+}
+
+# ── Test 11: setup_audit_trace is gated behind ENABLE_AUDIT_TRACE in main() ──
+# Smoke check: the script must mention the gating in main(). We
+# deliberately don't exec main() — that would try to talk to a real LLNG
+# portal — but we can grep the wiring.
+test_main_gates_audit_trace() {
+    local script="$SCRIPT_DIR/ob-bastion-setup"
+    if grep -q 'ENABLE_AUDIT_TRACE.*=.*"true"' "$script" \
+       && grep -q "setup_audit_trace" "$script"; then
+        pass "main() gates setup_audit_trace behind ENABLE_AUDIT_TRACE"
+    else
+        fail "main() gates setup_audit_trace behind ENABLE_AUDIT_TRACE"
+    fi
+}
+
+# ── Test 12: print_summary distinguishes applied vs not applied ──
+test_summary_distinguishes_state() {
+    (
+        source_script "ob-bastion-setup"
+        # Fake values so print_summary doesn't barf.
+        PORTAL_URL="https://x"
+        SERVER_GROUP="bastion"
+        SSH_CA_FILE="/tmp/ca"
+        BACKUP_DIR="/tmp/backup"
+        ENABLE_AUDIT_TRACE=false
+        local out_off
+        out_off=$(print_summary 2>&1)
+        ENABLE_AUDIT_TRACE=true
+        local out_on
+        out_on=$(print_summary 2>&1)
+        echo "$out_off" | grep -qi "audit trace" || exit 1
+        echo "$out_off" | grep -qi "not applied" || exit 1
+        echo "$out_on" | grep -qi "applied" || exit 1
+        exit 0
+    )
+    if [ $? -eq 0 ]; then
+        pass "print_summary reports audit-trace state"
+    else
+        fail "print_summary reports audit-trace state"
+    fi
+}
+
+# ── Run ──
+echo "=== Testing ob-bastion-setup --enable-audit-trace (PR2) ==="
+run_test test_default_off
+run_test test_flag_enables
+run_test test_help_mentions_flag
+run_test test_refuses_without_auditd
+run_test test_refuses_without_templates
+run_test test_conf_key_replace_existing
+run_test test_conf_key_append_absent
+run_test test_conf_key_skips_comments
+run_test test_rules_template_content
+run_test test_cron_template_content
+run_test test_main_gates_audit_trace
+run_test test_summary_distinguishes_state
+
+echo ""
+echo "=== Results: $TESTS_PASSED/$TESTS_RUN passed, $TESTS_FAILED failed ==="
+[ "$TESTS_FAILED" -eq 0 ] && exit 0 || exit 1

--- a/tests/test_ob_bastion_setup_audit.sh
+++ b/tests/test_ob_bastion_setup_audit.sh
@@ -121,7 +121,9 @@ test_refuses_without_auditd() {
         local out
         out=$(setup_audit_trace 2>&1)
         local rc=$?
-        if [ "$rc" -ne 0 ] && echo "$out" | grep -q "auditd is not installed"; then
+        # auditd absent must NOT fail the step (warn + return 0, so the
+        # surrounding ob-bastion-setup run continues).
+        if [ "$rc" -eq 0 ] && echo "$out" | grep -q "auditd is not installed; skipping"; then
             exit 0
         else
             echo "rc=$rc out=$out" >&2
@@ -131,9 +133,9 @@ test_refuses_without_auditd() {
     local rc=$?
     rm -rf "$tmpdir"
     if [ $rc -eq 0 ]; then
-        pass "setup_audit_trace refuses cleanly when auditd is missing"
+        pass "setup_audit_trace warns and continues when auditd is missing"
     else
-        fail "setup_audit_trace refuses cleanly when auditd is missing"
+        fail "setup_audit_trace warns and continues when auditd is missing"
     fi
 }
 

--- a/tests/test_ob_bastion_setup_audit.sh
+++ b/tests/test_ob_bastion_setup_audit.sh
@@ -255,7 +255,7 @@ test_auditd_conf_not_modified() {
     fi
 }
 
-# ── Test 9: rules template content has the expected keys ──
+# ── Test 8: rules template content has the expected keys ──
 test_rules_template_content() {
     local rules="$PROJECT_ROOT/config/audit/rules.d/open-bastion.rules"
     if [ ! -f "$rules" ]; then
@@ -282,7 +282,7 @@ test_rules_template_content() {
     fi
 }
 
-# ── Test 10: cron.daily template is a valid /bin/sh script that calls SIGUSR1 ──
+# ── Test 9: cron.daily template is a valid /bin/sh script that calls SIGUSR1 ──
 test_cron_template_content() {
     local cron="$PROJECT_ROOT/config/audit/cron.daily/open-bastion-audit-rotate"
     if [ ! -f "$cron" ]; then
@@ -302,7 +302,7 @@ test_cron_template_content() {
     fi
 }
 
-# ── Test 11: setup_audit_trace is gated behind ENABLE_AUDIT_TRACE in main() ──
+# ── Test 10: setup_audit_trace is gated behind ENABLE_AUDIT_TRACE in main() ──
 # Smoke check: the script must mention the gating in main(). We
 # deliberately don't exec main() — that would try to talk to a real LLNG
 # portal — but we can grep the wiring.
@@ -316,7 +316,7 @@ test_main_gates_audit_trace() {
     fi
 }
 
-# ── Test 12: print_summary distinguishes applied vs not applied ──
+# ── Test 11: print_summary distinguishes applied vs not applied ──
 test_summary_distinguishes_state() {
     (
         source_script "ob-bastion-setup"


### PR DESCRIPTION
## Summary

Adds an **opt-in** primary audit trail via `auditd`, complementing PR1 (#112) containment. Where session recording captures pty I/O (replay convenience), auditd captures syscalls (tamper-resistant evidence) — independent of pty, shell, or session.

Activate with:
```
ob-bastion-setup --portal https://… --enable-audit-trace
```

Default: **off**. `auditd` is a `Recommends:` (Debian) / `Recommends:` (RPM 4.13+) — never installed silently.

## What it does

`setup_audit_trace` deploys two artefacts (templates from `/usr/share/open-bastion/audit/`):

| Destination | Mode | Content |
|---|---|---|
| `/etc/audit/rules.d/open-bastion.rules` | 0640 root:root | execve+execveat / connect rules (auid≥1000), watches on /etc/passwd, /etc/shadow, /etc/group, /etc/gshadow, /etc/sudoers(.d), /etc/ssh/sshd_config(.d), /var/lib/open-bastion/sessions/, /etc/open-bastion/ |
| `/etc/cron.daily/open-bastion-audit-rotate` | 0755 root:root | SIGUSR1 to auditd daily — combined with `num_logs=7` gives ~1 week local retention |

Then `augenrules --load` and `systemctl restart auditd`. Restart is non-disruptive (auditd is not session-bound, unlike logind in PR1).

**`/etc/audit/auditd.conf` is intentionally NOT modified.** It is an admin-tunable file owned by the `audit` package; we use the drop-in mechanism (`rules.d/`) where it exists, and document the recommended retention values (`num_logs=7`, `max_log_file=50`, `max_log_file_action=ROTATE`) for the admin to apply manually.

If `auditd` is not installed, `setup_audit_trace` warns and skips — the rest of `ob-bastion-setup` continues normally.

## Threat model coverage

| Channel | Covered |
|---|---|
| `execve` by non-system user | ✓ |
| `execveat` (syscall #322) | ✓ — added after security review |
| TCP/UDP `connect()` | ✓ |
| Sensitive file modifications (passwd, shadow, sudoers, sshd) | ✓ |
| Tampering with own session recording | ✓ (watch on `/var/lib/open-bastion/sessions/`) |
| `sendto`/`sendmsg` on unconnected UDP socket (DNS-tunnel exfil) | ✗ documented, opt-in extension |
| `io_uring`-based clients | ✗ documented, opt-in extension |

## Tests

- `tests/test_ob_bastion_setup_audit.sh`: **11/11 PASS** (default off, --enable flag, refuses without templates, warns when auditd absent, no auditd.conf modification, regression test against re-introducing the `audit_set_conf_key` helper, content of rules and cron templates, main() gating, summary line)
- `tests/test_ob_bastion_setup.sh`: **15/15 PASS** (no regression)
- `shellcheck`: clean
- `cmake -B build-test -S .`: configures and builds cleanly

## Reviews

- **Architect**: APPROVED — no blockers, 5 nitpicks documented, 5 follow-ups noted (audisp-syslog, --disable-audit-trace, etc.)
- **Security**: 2 findings, both fixed in commit 33ae2b0:
  - MEDIUM: `execveat` evasion → `-S execveat` added to both arch rules
  - LOW: network rule scope → inline comment + doc Limitations clarified

## Test plan

- [x] CI passes
- [ ] On a Debian 12 test bastion with `auditd` installed: `ob-bastion-setup --portal … --enable-audit-trace`, verify `auditctl -l` lists `ob-exec` and `ob-connect`, run `ls /tmp; sleep 1; ausearch -k ob-exec -ts recent` and confirm execve events
- [ ] On the same host: try `setsid bash -c 'ls; exit'` and confirm `ausearch -k ob-exec` captures both `setsid` and `bash` execs
- [ ] On the same host: write a 5-line C program that calls `syscall(SYS_execveat, …)`, run it, confirm `ausearch -k ob-exec` captures the resulting child
- [ ] On the same host without auditd installed: `ob-bastion-setup --enable-audit-trace` must WARN and continue (not fail)
- [ ] Verify `cron.daily` entry rotates audit.log after 24h+
- [ ] On RHEL 9 / Rocky 9: same scenarios
- [ ] Verify no setuid/setgid binary added to package: `find debian/tmp -perm /6000 -ls`

## Out of scope (follow-ups)

- `audisp-syslog` / journal forwarding to a remote collector (best practice for tamper-evident off-host audit)
- `--disable-audit-trace` symmetric flag
- Adding `execveat` is done; adding `sendto`/`sendmsg` is documented as opt-in extension (too chatty by default)
- Locked rules `-e 2` (currently commented in template) — production hardening, separate decision

## Relation to PR1

PR1 (#112) closes containment evasion (setsid/at/cron). PR2 adds traceability.

Both are opt-in flags on `ob-bastion-setup`:
- `--enable-hardening` (PR1) — system-wide containment
- `--enable-audit-trace` (PR2) — syscall trace

They can be combined: `ob-bastion-setup --portal … --enable-hardening --enable-audit-trace`.