### PR TITLE
ci: bump GitHub Actions to Node.js 24-compatible versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Install dependencies
       run: |
@@ -77,7 +77,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Install dependencies
       run: |
@@ -116,7 +116,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Install dependencies
       run: |
@@ -140,7 +140,7 @@ jobs:
         cpack -G DEB
 
     - name: Upload Debian package
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: debian-package
         path: build/*.deb
@@ -160,7 +160,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Install dependencies
       run: |
@@ -188,7 +188,7 @@ jobs:
         rpmbuild -ba rpm/open-bastion.spec
 
     - name: Upload RPM package
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: rpm-package-el${{ matrix.version }}
         path: ~/rpmbuild/RPMS/*/*.rpm
@@ -202,7 +202,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Run ShellCheck
       uses: ludeeus/action-shellcheck@master
@@ -219,7 +219,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Install llng CLI
       run: |
@@ -235,7 +235,7 @@ jobs:
         sudo apt-get install -y jq curl openssh-client
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@v4
 
     - name: Run integration tests
       run: |
@@ -258,7 +258,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Install llng CLI
       run: |
@@ -273,7 +273,7 @@ jobs:
         sudo apt-get install -y jq curl openssh-client
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@v4
 
     - name: Run Mode E integration tests
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install build dependencies
         run: |
@@ -59,7 +59,7 @@ jobs:
           mv ../*.deb packages/
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: deb-${{ matrix.codename }}
           path: packages/*.deb
@@ -84,7 +84,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install build dependencies
         run: |
@@ -129,7 +129,7 @@ jobs:
           mv ~/rpmbuild/RPMS/x86_64/*.rpm packages/
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: rpm-${{ matrix.codename }}
           path: packages/*.rpm
@@ -424,7 +424,7 @@ jobs:
           cd ..
 
       - name: Upload repository
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: repo
           path: repo/


### PR DESCRIPTION
## Summary

Silences the deprecation warnings that fired on every job of the v0.2.0 CI run:

> Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: `actions/checkout@v4`, `actions/upload-artifact@v4`, `docker/setup-buildx-action@v3`.

Node.js 20 will be **removed** from GitHub Actions runners on **2026-09-16**; the default already flips to Node.js 24 on **2026-06-02**. Bumping now avoids breakage at either deadline.

## Changes

| Action | Before | After | Latest as of today |
|---|---|---|---|
| `actions/checkout` | `@v4` | `@v6` | v6.0.2 |
| `actions/upload-artifact` | `@v4` | `@v7` | v7.0.1 |
| `docker/setup-buildx-action` | `@v3` | `@v4` | v4.0.0 |

Floating major tags so we follow patch + minor releases without churning this file again.

## Files

- `.github/workflows/ci.yml` (11 references)
- `.github/workflows/release.yml` (5 references)

## Risk

Low. None of the bumps changes the action's interface in ways the workflows use. Re-running the existing job graph on the new versions is the only thing that changes; the actual outputs (built artifacts, test results) should be byte-identical.

## Test plan

- [ ] CI passes on the branch (the same 9 jobs that just passed for v0.2.0 should pass here too: ShellCheck, Build×2, Sanitizers, Debian package, RPM, Integration×2, CodeQL)
- [ ] The deprecation warnings disappear from the Annotations section of each job