### PR TITLE
fix(heartbeat): allow the timer to rewrite the access token (silent 1h token expiry)

### DIFF
--- a/systemd/ob-heartbeat.service
+++ b/systemd/ob-heartbeat.service
@@ -23,9 +23,17 @@ RestrictSUIDSGID=yes
 MemoryDenyWriteExecute=yes
 LockPersonality=yes
 
-# Allow reading config and token files
+# ob-heartbeat refreshes the access token, so it must REWRITE
+# /etc/open-bastion/token — atomically (mktemp in the directory + rename),
+# which requires the directory itself to be writable. Under
+# ProtectSystem=strict the previous ReadOnlyPaths=/etc/open-bastion/token (and
+# the implicitly read-only directory) made every timer-triggered refresh fail
+# with "Read-only file system", so the access token silently expired after ~1h
+# (a manual `ob-heartbeat`, which runs without the sandbox, masked this).
+# Make the directory writable; keep the config file read-only (the more
+# restrictive entry wins). The token's on-disk perms remain 0600 root.
+ReadWritePaths=/etc/open-bastion
 ReadOnlyPaths=/etc/open-bastion/openbastion.conf
-ReadOnlyPaths=/etc/open-bastion/token
 ReadWritePaths=/var/lib/open-bastion
 
 # Network access required


### PR DESCRIPTION
## Problem

`ob-heartbeat.service` runs under `ProtectSystem=strict` with:

```ini
ReadOnlyPaths=/etc/open-bastion/openbastion.conf
ReadOnlyPaths=/etc/open-bastion/token      # ← the token is read-only
ReadWritePaths=/var/lib/open-bastion
```

But `ob-heartbeat` **refreshes the access token**, rewriting `/etc/open-bastion/token` atomically (`mktemp` in the directory + `rename`). With the token file marked read-only and the directory implicitly read-only under `ProtectSystem=strict`, every **timer-triggered** run failed:

```
ob-heartbeat[...]: mktemp: failed to create file via template
  '/etc/open-bastion/token.XXXXXX': Read-only file system
ob-heartbeat.service: Main process exited, code=exited, status=1/FAILURE
```

So the short-lived access token **silently expired ~1h after enrollment**, breaking `getent passwd <sso-user>` (NSS) and `/pam/authorize` on bastions and backends. A manual `sudo ob-heartbeat` runs *without* the systemd sandbox, which is exactly why earlier validation (and the README step that runs it by hand) never caught this — only a real >1h soak driven by the timer reveals it.

## Fix

Make `/etc/open-bastion` writable for the service and keep `openbastion.conf` read-only (the more-restrictive entry wins). The token's on-disk permissions stay `0600 root`.

## Validation (2-host VM lab, up ~8.5h)

- **Before:** timer-path `systemctl start ob-heartbeat.service` → exit 1; token `expires_at` ~6.5h in the past; `getent passwd dwho` empty on the bastion.
- **After:** the sandboxed service exits 0 and advances `expires_at` to `now+3600` on **both** hosts; NSS resolves again; the full bastion→backend certificate-vouching hop succeeds.

Found while verifying that two long-running lab VMs still accepted SSH after several hours.