### PR TITLE
docs(security): refresh threat model for cert vouching + heartbeat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,7 @@ wire — only operator-side ergonomics and packaging.
 
 - **`ob-enroll`**: new `OB_ENROLL_STATE_FILE` env var. When set,
   `ob-enroll` writes `{user_code, verification_uri, portal_url,
-  interval}` to that file as soon as LLNG returns the device-grant
+interval}` to that file as soon as LLNG returns the device-grant
   initiation, then continues polling. External orchestrators
   (notably the new Ansible auto-approve flow) can read this file
   to drive the approval while `ob-enroll` is still polling. The
@@ -49,8 +49,8 @@ wire — only operator-side ergonomics and packaging.
 
 - **Docker demo images** (`docker-demo-{cert,token,maxsec,token-svc}/`):
   all 10 build Dockerfiles now use `cmake -DCMAKE_INSTALL_PREFIX=/usr
-  ... && make install` instead of per-Dockerfile allowlists of
-  `cp ../scripts/ob-X` lines. New ob-* scripts added to `CMakeLists.txt`
+... && make install` instead of per-Dockerfile allowlists of
+  `cp ../scripts/ob-X` lines. New ob-\* scripts added to `CMakeLists.txt`
   automatically land in the demo containers; no per-Dockerfile
   maintenance needed.
 
@@ -196,18 +196,18 @@ or NSS modules.
 - **`ob-bastion-setup` / `ob-backend-setup`**: stop looking for the
   defunct `/usr/sbin/llng-pam-enroll` (renamed to `ob-enroll`); a
   fresh setup no longer prints `[WARN] Server not enrolled. Run
-  llng-pam-enroll manually after installation.` after a successful
+llng-pam-enroll manually after installation.` after a successful
   enrollment.
 
 - **`ob-bastion-setup`**: give /var/lib/open-bastion/sessions mode 3771
-    ob-bastion-setup posed mode 1770 (drwxrwx--T) on the sessions
-    parent. The ob-session-recorder-wrapper setgid binary creates the
-    per-user subdir while it holds effective gid ob-sessions, then
-    drops back to the user's gid and execs the recorder script. With
-    the parent at 1770 the connecting user (not a member of ob-sessions)
-    has no traverse right on the parent, so the script cannot stat
-    its own subdir and logs "User sessions directory ... does not
-    exist and could not be created", leaving sessions unrecorded.
+  ob-bastion-setup posed mode 1770 (drwxrwx--T) on the sessions
+  parent. The ob-session-recorder-wrapper setgid binary creates the
+  per-user subdir while it holds effective gid ob-sessions, then
+  drops back to the user's gid and execs the recorder script. With
+  the parent at 1770 the connecting user (not a member of ob-sessions)
+  has no traverse right on the parent, so the script cannot stat
+  its own subdir and logs "User sessions directory ... does not
+  exist and could not be created", leaving sessions unrecorded.
 
 - Sweep the remaining `llng-*` leftovers across scripts, docs,
   configs and Docker demos so paths, modules, units, packages and
@@ -271,7 +271,7 @@ never published; its contents are folded into v0.2.0.)
     `tests/test_integration_maxsec.sh`).
 
 - **Session-containment hardening** (`ob-bastion-setup
-  --enable-hardening`, opt-in, off by default) — closes the known
+--enable-hardening`, opt-in, off by default) — closes the known
   SSH evasion channels (`setsid`+`nohup` orphans, deferred
   `at`/`cron` jobs, `systemd-run --user` timers) without any new
   setuid binary.
@@ -284,7 +284,7 @@ never published; its contents are folded into v0.2.0.)
     `/etc/cron.d/open-bastion-krl`).
   - Pre-flight refusal if any non-root user has `Linger=yes`, which
     would let them schedule jobs via `systemd-run --user
-    --on-active=…` (operator must `loginctl disable-linger <user>`
+--on-active=…` (operator must `loginctl disable-linger <user>`
     before re-running).
   - `nproc` cap (256, `@ob-service` group exempt) as defense in depth
     against fork-bomb-style runaway processes.
@@ -295,7 +295,7 @@ never published; its contents are folded into v0.2.0.)
     (20 tests).
 
 - **Primary audit trace via auditd** (`ob-bastion-setup
-  --enable-audit-trace`, opt-in, off by default) — syscall-level,
+--enable-audit-trace`, opt-in, off by default) — syscall-level,
   tamper-evident audit independent of the pty session recording.
   - `/etc/audit/rules.d/open-bastion.rules`: `-S execve -S execveat`
     (both — `execveat` alone bypasses an `execve`-only rule),
@@ -321,20 +321,20 @@ never published; its contents are folded into v0.2.0.)
 - **Security analysis updated** (`doc/security/02-ssh-connection.md`,
   `doc/security/99-risk-reduce.md`):
   - **R-S18 corrected** — the previous claim that the setgid wrapper
-    + sticky bit prevented users from deleting their own recordings
-    was inaccurate: the per-user subdirectory is
-    `2770 user:ob-sessions`, so the user is owner and can `rm` their
-    own files. Score revised from `(P=1, I=1)` to `(P=2, I=1)` —
-    syslog `auth.info` (start/end) and the new auditd watch on
-    `/var/lib/open-bastion/sessions/` preserve the timeline and
-    record any unlink even if the file is deleted. The wrapper still
-    provides cross-user isolation (which is what it was always
-    really doing).
+    - sticky bit prevented users from deleting their own recordings
+      was inaccurate: the per-user subdirectory is
+      `2770 user:ob-sessions`, so the user is owner and can `rm` their
+      own files. Score revised from `(P=1, I=1)` to `(P=2, I=1)` —
+      syslog `auth.info` (start/end) and the new auditd watch on
+      `/var/lib/open-bastion/sessions/` preserve the timeline and
+      record any unlink even if the file is deleted. The wrapper still
+      provides cross-user isolation (which is what it was always
+      really doing).
   - **R-S19 (new)** — session-containment evasion via `setsid`/`nohup`.
     Initial `(P=3, I=3)`; residual `(P=1, I=1)` with hardening +
     audit trace activated.
   - **R-S20 (new)** — deferred action via `at`/`cron`/`systemd-run
-    --user --on-active=…`. Initial `(P=2, I=3)`; residual `(P=1, I=2)`
+--user --on-active=…`. Initial `(P=2, I=3)`; residual `(P=1, I=2)`
     with hardening (limit: pre-existing crontabs in
     `/var/spool/cron/crontabs/` are not purged on activation).
   - **R-S21 (new)** — action not captured by the pty (`execveat`,

--- a/README.md
+++ b/README.md
@@ -168,17 +168,17 @@ Password: <paste LLNG token from portal>
 
 See the full [documentation index](doc/README.md) or jump directly to:
 
-| Document                                                 | Description                            |
-| -------------------------------------------------------- | -------------------------------------- |
-| [LemonLDAP::NG Configuration](doc/llng-configuration.md) | Server-side LLNG setup and plugins     |
-| [PAM Authentication Modes](doc/pam-modes.md)             | All 4 PAM configurations with examples |
-| [Configuration Reference](doc/configuration.md)          | All configuration options              |
-| [Service Accounts](doc/service-accounts.md)              | Ansible, backup, CI/CD accounts        |
-| [Bastion Architecture](doc/bastion-architecture.md)      | Bastion-to-backend certificate vouching |
-| [Session Recording](doc/session-recording.md)            | SSH session recording for audit        |
-| [CrowdSec Integration](doc/crowdsec.md)                  | IP blocking and alert reporting        |
-| [Security Features](doc/security.md)                     | Key policies, rate limiting, audit     |
-| [Admin Guide](doc/admin-guide.md)                        | Complete administration guide          |
+| Document                                                 | Description                               |
+| -------------------------------------------------------- | ----------------------------------------- |
+| [LemonLDAP::NG Configuration](doc/llng-configuration.md) | Server-side LLNG setup and plugins        |
+| [PAM Authentication Modes](doc/pam-modes.md)             | All 4 PAM configurations with examples    |
+| [Configuration Reference](doc/configuration.md)          | All configuration options                 |
+| [Service Accounts](doc/service-accounts.md)              | Ansible, backup, CI/CD accounts           |
+| [Bastion Architecture](doc/bastion-architecture.md)      | Bastion-to-backend certificate vouching   |
+| [Session Recording](doc/session-recording.md)            | SSH session recording for audit           |
+| [CrowdSec Integration](doc/crowdsec.md)                  | IP blocking and alert reporting           |
+| [Security Features](doc/security.md)                     | Key policies, rate limiting, audit        |
+| [Admin Guide](doc/admin-guide.md)                        | Complete administration guide             |
 | [Deployment Builder](admin-builder/README.md)            | Generate shell / Ansible deploy artefacts |
 
 ## Troubleshooting

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -162,11 +162,11 @@ flowchart LR
 
 The `key-id` field of the ephemeral cert carries structured audit and enforcement data:
 
-| Field       | Format                 | Description                                    |
-| ----------- | ---------------------- | ---------------------------------------------- |
-| `bastion`   | `bastion=<bastion_id>` | Enrolling OIDC `client_id` of the bastion      |
-| `user`      | `user=<username>`      | Username authorized on the bastion             |
-| `target`    | `target=<hostname>`    | Target backend hostname                        |
+| Field     | Format                 | Description                               |
+| --------- | ---------------------- | ----------------------------------------- |
+| `bastion` | `bastion=<bastion_id>` | Enrolling OIDC `client_id` of the bastion |
+| `user`    | `user=<username>`      | Username authorized on the bastion        |
+| `target`  | `target=<hostname>`    | Target backend hostname                   |
 
 Full key-id example: `bastion=bastion-01;user=alice;target=db-server`
 
@@ -203,13 +203,13 @@ when an `allowed_bastions` file is present.
 
 ### Voucher Lifecycle
 
-| Property   | Value                                                                         |
-| ---------- | ----------------------------------------------------------------------------- |
-| Bound to   | `(bastion_id, user)` — minted at `/pam/authorize`, keyed per pair             |
-| Validity   | `min(now + pamAccessBastionVoucherTtl, SSO cert expires_at)`, default 12 h    |
-| Reusable   | Yes — multiplexed hops and `scp host1: host2:` all work with the same voucher |
-| Expiry     | Fail-closed: `ob-ssh-proxy` prints a clear error and exits non-zero           |
-| Renewal    | User reconnects to the bastion; no silent re-vouching                         |
+| Property | Value                                                                         |
+| -------- | ----------------------------------------------------------------------------- |
+| Bound to | `(bastion_id, user)` — minted at `/pam/authorize`, keyed per pair             |
+| Validity | `min(now + pamAccessBastionVoucherTtl, SSO cert expires_at)`, default 12 h    |
+| Reusable | Yes — multiplexed hops and `scp host1: host2:` all work with the same voucher |
+| Expiry   | Fail-closed: `ob-ssh-proxy` prints a clear error and exits non-zero           |
+| Renewal  | User reconnects to the bastion; no silent re-vouching                         |
 
 ## Token Cache Security
 
@@ -366,22 +366,22 @@ For real-time security monitoring:
 
 ### Secrets Management
 
-| Setting                | Default    | Description             |
-| ---------------------- | ---------- | ----------------------- |
-| `secrets_encrypted`    | true       | Encrypt secrets at rest |
-| `secrets_use_keyring`  | true       | Use kernel keyring      |
+| Setting                | Default        | Description             |
+| ---------------------- | -------------- | ----------------------- |
+| `secrets_encrypted`    | true           | Encrypt secrets at rest |
+| `secrets_use_keyring`  | true           | Use kernel keyring      |
 | `secrets_keyring_name` | "open-bastion" | Keyring identifier      |
 
 ### File Permissions
 
 Recommended permissions:
 
-| File                 | Permissions | Owner |
-| -------------------- | ----------- | ----- |
+| File                                 | Permissions | Owner |
+| ------------------------------------ | ----------- | ----- |
 | `/etc/open-bastion/openbastion.conf` | 0600        | root  |
-| Server token file    | 0600        | root  |
-| Cache directory      | 0700        | root  |
-| Rate limit state dir | 0700        | root  |
+| Server token file                    | 0600        | root  |
+| Cache directory                      | 0700        | root  |
+| Rate limit state dir                 | 0700        | root  |
 
 ## Operational Security Considerations
 
@@ -767,25 +767,25 @@ sessions are terminated after `offline_max_sso_unreachable` seconds (default: 1h
 
 ## Threat Mitigations
 
-| Threat                    | Mitigation                                                       |
-| ------------------------- | ---------------------------------------------------------------- |
-| Token replay              | Single-use tokens, cache invalidation                            |
-| MITM attacks              | TLS 1.3, certificate pinning                                     |
-| Brute force               | Rate limiting with exponential backoff                           |
-| Cache tampering           | AES-256-GCM authenticated encryption                             |
-| Path injection            | Strict path validation, approved lists                           |
-| Buffer overflow           | Bounds-checked string operations, snprintf with null-termination |
-| UID collision             | Fail-safe collision detection                                    |
-| Request tampering         | Optional HMAC request signing with nonces                        |
-| Memory exhaustion DoS     | Response size limits (256KB), group limits (256 max)             |
-| Integer overflow          | Input validation in base64 encoding, backoff calculations        |
-| Malformed JSON            | Type validation for critical response fields                     |
-| Client secret exposure    | JWT Client Assertion (RFC 7523) - secret never transmitted       |
+| Threat                    | Mitigation                                                                             |
+| ------------------------- | -------------------------------------------------------------------------------------- |
+| Token replay              | Single-use tokens, cache invalidation                                                  |
+| MITM attacks              | TLS 1.3, certificate pinning                                                           |
+| Brute force               | Rate limiting with exponential backoff                                                 |
+| Cache tampering           | AES-256-GCM authenticated encryption                                                   |
+| Path injection            | Strict path validation, approved lists                                                 |
+| Buffer overflow           | Bounds-checked string operations, snprintf with null-termination                       |
+| UID collision             | Fail-safe collision detection                                                          |
+| Request tampering         | Optional HMAC request signing with nonces                                              |
+| Memory exhaustion DoS     | Response size limits (256KB), group limits (256 max)                                   |
+| Integer overflow          | Input validation in base64 encoding, backoff calculations                              |
+| Malformed JSON            | Type validation for critical response fields                                           |
+| Client secret exposure    | JWT Client Assertion (RFC 7523) - secret never transmitted                             |
 | Bastion bypass            | LLNG-signed ephemeral cert; source-address critical option; allowed_bastions allowlist |
 | Direct backend access     | TrustedUserCAKeys + cert source-address + AuthorizedPrincipalsCommand enforcement      |
-| Offline cache theft       | AES-256-GCM encryption + machine-id binding                      |
-| Offline brute force       | Argon2id + per-user lockout after 5 attempts                     |
-| Stale offline credentials | Configurable TTL (default 7 days)                                |
+| Offline cache theft       | AES-256-GCM encryption + machine-id binding                                            |
+| Offline brute force       | Argon2id + per-user lockout after 5 attempts                                           |
+| Stale offline credentials | Configurable TTL (default 7 days)                                                      |
 
 ## Security Reporting
 

--- a/admin-builder/README.md
+++ b/admin-builder/README.md
@@ -43,13 +43,13 @@ scenario: max-security
 portal_url: https://sso.example.com
 client_id: backend-prod
 client_id_policy: fixed
-client_secret_mode: prompt    # none | prompt | embedded
+client_secret_mode: prompt # none | prompt | embedded
 # embedded_client_secret: ...  # required when client_secret_mode=embedded
 server_group: backend-prod-us-east
 server_group_policy: fixed
 target_role: backend
 auto_enroll_setup: prompt
-ansible_auto_approve: no       # yes = Ansible role can approve device codes via LLNG cookie
+ansible_auto_approve: no # yes = Ansible role can approve device codes via LLNG cookie
 # repo_keyring: /etc/apt/keyrings/your-own.gpg   # optional; defaults to the Linagora keyring
 apt_url: https://linagora.github.io/open-bastion
 apt_suite: trixie
@@ -79,6 +79,7 @@ ssh server.example.com sudo /tmp/bootstrap-prod-backend.sh
 ```
 
 The script performs:
+
 - Repository configuration (APT sources + GPG key)
 - Deployment of Open Bastion configuration to `/etc/open-bastion/openbastion.conf`
 - Installation of the `open-bastion` package
@@ -89,6 +90,7 @@ Run with `./bootstrap-prod-backend.sh info` to inspect embedded metadata (scenar
 ### Ansible Role Tree
 
 The generated Ansible role is ready for fleet deployments. It includes:
+
 - Pre-populated defaults (configuration from the build)
 - Tasks for repository setup, package installation, and enrollment
 - SSH CA and signing keys embedded as files
@@ -131,20 +133,20 @@ manual browser-approval flow.
 
 The generated shell installer accepts CLI flags to override embedded defaults. Precedence: **CLI flag > environment variable > embedded default > interactive prompt**.
 
-| Flag | Environment | Description |
-|------|-------------|-------------|
-| `--client-id ID` | `OB_CLIENT_ID` | Override OIDC client_id (if policy allows) |
-| `--client-secret SECRET` | `OB_CLIENT_SECRET` | Provide secret directly (insecure; visible in `/proc`) |
+| Flag                        | Environment             | Description                                                                  |
+| --------------------------- | ----------------------- | ---------------------------------------------------------------------------- |
+| `--client-id ID`            | `OB_CLIENT_ID`          | Override OIDC client_id (if policy allows)                                   |
+| `--client-secret SECRET`    | `OB_CLIENT_SECRET`      | Provide secret directly (insecure; visible in `/proc`)                       |
 | `--client-secret-file PATH` | `OB_CLIENT_SECRET_FILE` | Read secret from file (use `-` for stdin); recommended for fleet deployments |
-| `--server-group GROUP` | `OB_SERVER_GROUP` | Override server group |
-| `--portal-url URL` | `OB_PORTAL_URL` | Override SSO URL (rare; mainly for testing) |
-| `-y, --yes` | - | Answer yes to all prompts (auto-enroll and auto-setup) |
-| `--skip-enroll` | - | Install package and config, but skip `ob-enroll` |
-| `--skip-setup` | - | Run `ob-enroll` but skip `ob-bastion-setup` / `ob-backend-setup` |
-| `--dry-run` | - | Print actions without executing them |
-| `--force` | - | Overwrite existing `/etc/open-bastion` (normally refused) |
-| `--non-interactive` | - | Fail instead of prompting (for CI strict mode) |
-| `-h, --help` | - | Show help and embedded scenario details |
+| `--server-group GROUP`      | `OB_SERVER_GROUP`       | Override server group                                                        |
+| `--portal-url URL`          | `OB_PORTAL_URL`         | Override SSO URL (rare; mainly for testing)                                  |
+| `-y, --yes`                 | -                       | Answer yes to all prompts (auto-enroll and auto-setup)                       |
+| `--skip-enroll`             | -                       | Install package and config, but skip `ob-enroll`                             |
+| `--skip-setup`              | -                       | Run `ob-enroll` but skip `ob-bastion-setup` / `ob-backend-setup`             |
+| `--dry-run`                 | -                       | Print actions without executing them                                         |
+| `--force`                   | -                       | Overwrite existing `/etc/open-bastion` (normally refused)                    |
+| `--non-interactive`         | -                       | Fail instead of prompting (for CI strict mode)                               |
+| `-h, --help`                | -                       | Show help and embedded scenario details                                      |
 
 Example: deploy with a secret from a file and auto-enroll:
 

--- a/admin-builder/templates/ansible/role/README.md
+++ b/admin-builder/templates/ansible/role/README.md
@@ -19,6 +19,7 @@ role/
 ```
 
 The `files/` directory (not shipped here) must contain:
+
 - `open-bastion.gpg` — APT signing key
 - `open-bastion-ca.pub` — SSH CA public key (downloaded from LLNG portal)
 - `open-bastion-krl` — Key Revocation List (Mode E only)
@@ -28,38 +29,38 @@ The `files/` directory (not shipped here) must contain:
 All variables are prefixed with `ob_`. Build-time defaults live in
 `defaults/main.yml`; override them via host_vars, group_vars, or extra-vars.
 
-| Variable | Description |
-|---|---|
-| `ob_portal_url` | LLNG portal URL (required) |
-| `ob_client_id` | OIDC client_id for enrollment |
-| `ob_client_secret` | OIDC client secret — use ansible-vault |
-| `ob_server_group` | Server group name (set per-host for fleet deployments) |
-| `ob_role` | `bastion`, `backend`, or `standalone` |
-| `ob_pam_mode` | PAM mode A–E (see doc/pam-modes.md) |
-| `ob_max_security` | `true` for Mode E (KRL, cert-only SSH, sudo via LLNG token) |
-| `ob_auto_enroll` | Run ob-enroll during the play |
-| `ob_auto_setup` | Run ob-bastion-setup / ob-backend-setup during the play |
-| `ob_apt_sources_list_line` | APT sources.list entry for the Open Bastion repository |
-| `ob_ansible_auto_approve` | Enable LLNG-cookie-based device-code auto-approval (build-time) |
-| `ob_llng_cookie` | LLNG session cookie used to auto-approve — asked at every play run via vars_prompt, never stored |
+| Variable                   | Description                                                                                      |
+| -------------------------- | ------------------------------------------------------------------------------------------------ |
+| `ob_portal_url`            | LLNG portal URL (required)                                                                       |
+| `ob_client_id`             | OIDC client_id for enrollment                                                                    |
+| `ob_client_secret`         | OIDC client secret — use ansible-vault                                                           |
+| `ob_server_group`          | Server group name (set per-host for fleet deployments)                                           |
+| `ob_role`                  | `bastion`, `backend`, or `standalone`                                                            |
+| `ob_pam_mode`              | PAM mode A–E (see doc/pam-modes.md)                                                              |
+| `ob_max_security`          | `true` for Mode E (KRL, cert-only SSH, sudo via LLNG token)                                      |
+| `ob_auto_enroll`           | Run ob-enroll during the play                                                                    |
+| `ob_auto_setup`            | Run ob-bastion-setup / ob-backend-setup during the play                                          |
+| `ob_apt_sources_list_line` | APT sources.list entry for the Open Bastion repository                                           |
+| `ob_ansible_auto_approve`  | Enable LLNG-cookie-based device-code auto-approval (build-time)                                  |
+| `ob_llng_cookie`           | LLNG session cookie used to auto-approve — asked at every play run via vars_prompt, never stored |
 
 Backend-only "accept only this bastion" variable (populated by ob-builder for
 backend scenarios when an allowlist was given):
 
-| Variable | Description |
-|---|---|
+| Variable                      | Description                                                                                                                                                                                                         |
+| ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `ob_bastion_allowed_bastions` | Comma/space-separated bastion_id (= enrolling client_id) the backend accepts certs from. Empty/undefined = any vouched bastion. Enforced by ob-backend-setup via the cert key-id (`bastion=<id>`) + source-address. |
 
 Mode-specific variables (populated by ob-builder from the selected PAM mode):
 
-| Variable | Example (Mode E) |
-|---|---|
-| `ob_min_tls_version` | `13` |
-| `ob_cache_ttl` | `60` |
-| `ob_ssh_key_policy_enabled` | `true` |
-| `ob_ssh_key_allowed_types` | `ed25519,rsa` |
-| `ob_cache_rate_limit_enabled` | `true` |
-| `ob_cache_rate_limit_max_attempts` | `3` |
+| Variable                           | Example (Mode E) |
+| ---------------------------------- | ---------------- |
+| `ob_min_tls_version`               | `13`             |
+| `ob_cache_ttl`                     | `60`             |
+| `ob_ssh_key_policy_enabled`        | `true`           |
+| `ob_ssh_key_allowed_types`         | `ed25519,rsa`    |
+| `ob_cache_rate_limit_enabled`      | `true`           |
+| `ob_cache_rate_limit_max_attempts` | `3`              |
 
 ## Protecting the client secret with ansible-vault
 
@@ -124,11 +125,12 @@ so it's not worth persisting. An empty `ob_llng_cookie` falls back to the
 manual flow above.
 
 Under the hood, the auto-approve path:
+
 1. Runs `ob-enroll` asynchronously on the target, with
    `OB_ENROLL_STATE_FILE=/run/open-bastion/enroll-state.json` so the user code
    and verification URI are written to disk as soon as LLNG issues them.
 2. Slurps that file back to the Ansible controller, where the play `delegate_to:
-   localhost` performs:
+localhost` performs:
    - `GET ${portal}/device?user_code=...` with the cookie, to extract the CSRF
      token from the form.
    - `POST ${portal}/device` with `user_code`, `action=approve`, and the CSRF

--- a/doc/admin-guide.md
+++ b/doc/admin-guide.md
@@ -818,24 +818,24 @@ journalctl -u sshd | grep "SSH key policy"
 
 ### File Locations
 
-| File                                      | Purpose                           |
-| ----------------------------------------- | --------------------------------- |
-| `/etc/open-bastion/openbastion.conf`      | PAM module configuration          |
-| `/etc/open-bastion/token`                 | Server enrollment token           |
-| `/etc/open-bastion/nss_openbastion.conf`  | NSS module configuration          |
-| `/etc/open-bastion/session-recorder.conf` | Session recorder configuration    |
-| `/etc/open-bastion/ssh-proxy.conf`        | SSH proxy configuration (bastion) |
-| `/var/lib/open-bastion/sessions/`         | Session recordings                |
+| File                                      | Purpose                              |
+| ----------------------------------------- | ------------------------------------ |
+| `/etc/open-bastion/openbastion.conf`      | PAM module configuration             |
+| `/etc/open-bastion/token`                 | Server enrollment token              |
+| `/etc/open-bastion/nss_openbastion.conf`  | NSS module configuration             |
+| `/etc/open-bastion/session-recorder.conf` | Session recorder configuration       |
+| `/etc/open-bastion/ssh-proxy.conf`        | SSH proxy configuration (bastion)    |
+| `/var/lib/open-bastion/sessions/`         | Session recordings                   |
 | `/etc/open-bastion/allowed_bastions`      | Allowed bastion client_ids (backend) |
-| `/var/log/open-bastion/audit.json`        | Audit log                         |
+| `/var/log/open-bastion/audit.json`        | Audit log                            |
 
 ### Commands
 
-| Command               | Purpose                             |
-| --------------------- | ----------------------------------- |
-| `ob-enroll`           | Enroll server with LLNG             |
-| `ob-enroll -g GROUP`  | Enroll with specific server group   |
-| `ob-session-recorder` | Record SSH session (ForceCommand)   |
+| Command               | Purpose                                       |
+| --------------------- | --------------------------------------------- |
+| `ob-enroll`           | Enroll server with LLNG                       |
+| `ob-enroll -g GROUP`  | Enroll with specific server group             |
+| `ob-session-recorder` | Record SSH session (ForceCommand)             |
 | `ob-ssh-proxy HOST`   | Connect to backend via bastion ephemeral cert |
 
 ## CrowdSec Integration

--- a/doc/bastion-architecture.md
+++ b/doc/bastion-architecture.md
@@ -76,8 +76,8 @@ Jump servers that users connect to first:
 
 Internal servers accessed through bastions:
 
-| Component               | Purpose                                |
-| ----------------------- | -------------------------------------- |
+| Component               | Purpose                                                     |
+| ----------------------- | ----------------------------------------------------------- |
 | `pam_openbastion.so`    | Authorize access; enforce bastion allowlist via cert key-id |
 | `libnss_openbastion.so` | Resolve users, auto-create accounts                         |
 | Standard SSH            | Accept connections through bastion (cert vouching)          |
@@ -582,24 +582,24 @@ SSO cert (no `bastion=` key-id prefix) is rejected before PAM runs.
 
 #### LLNG Portal (`pam-access` plugin)
 
-| Parameter                    | Default  | Description                                      |
-| ---------------------------- | -------- | ------------------------------------------------ |
-| `pamAccessBastionGroups`     | `bastion`| Server groups whose tokens may call `/pam/bastion-cert` |
-| `pamAccessBastionVoucherTtl` | `43200`  | Max voucher age in seconds (12 h); effective exp also capped by SSO cert expiry |
-| `pamAccessBastionCertTtl`    | `120`    | Ephemeral user-cert validity in seconds          |
+| Parameter                    | Default   | Description                                                                     |
+| ---------------------------- | --------- | ------------------------------------------------------------------------------- |
+| `pamAccessBastionGroups`     | `bastion` | Server groups whose tokens may call `/pam/bastion-cert`                         |
+| `pamAccessBastionVoucherTtl` | `43200`   | Max voucher age in seconds (12 h); effective exp also capped by SSO cert expiry |
+| `pamAccessBastionCertTtl`    | `120`     | Ephemeral user-cert validity in seconds                                         |
 
 The `ssh-ca` plugin must be active (`sshCaActivation=1`). `bastion_id` equals the
 enrolling OIDC `client_id`; give each bastion its own OIDC client to distinguish them.
 
 ### Ephemeral Certificate Fields
 
-| Field              | Value                                                            |
-| ------------------ | ---------------------------------------------------------------- |
-| Principal          | username                                                         |
-| Key-ID             | `bastion=<bastion_id>;user=<user>;target=<target_host>`          |
-| Validity           | ~120 s (`pamAccessBastionCertTtl`)                               |
-| `source-address`   | Bastion IP (sshd rejects cert from any other source)             |
-| Extension          | `bastion-id@open-bastion = <bastion_id>` (optional, for tooling) |
+| Field            | Value                                                            |
+| ---------------- | ---------------------------------------------------------------- |
+| Principal        | username                                                         |
+| Key-ID           | `bastion=<bastion_id>;user=<user>;target=<target_host>`          |
+| Validity         | ~120 s (`pamAccessBastionCertTtl`)                               |
+| `source-address` | Bastion IP (sshd rejects cert from any other source)             |
+| Extension        | `bastion-id@open-bastion = <bastion_id>` (optional, for tooling) |
 
 ## See Also
 

--- a/doc/design/bastion-cert-vouching.md
+++ b/doc/design/bastion-cert-vouching.md
@@ -11,8 +11,8 @@ backend via `ssh -o SendEnv=LLNG_BASTION_JWT`; `pam_openbastion` read it with
 `bastion_jwt_required=true` and it was empty.
 
 **Proven broken (docker-demo-cert, 12/06/2026):** `SendEnv`/`AcceptEnv` populate only
-the eventual *child process* environment (a login shell's `echo $VAR` sees it), never
-the **PAM** environment that `pam_getenv` reads — at *any* stage (account or session,
+the eventual _child process_ environment (a login shell's `echo $VAR` sees it), never
+the **PAM** environment that `pam_getenv` reads — at _any_ stage (account or session,
 pty or not). A `pam_exec.so session` probe shows `LLNG_BASTION_JWT=[<unset>]` while the
 child shell shows `SESSION_SEES=[MARKER]`. So `pam_getenv` can never see it, and moving
 the check to `pam_sm_open_session` does not help. The only client data sshd exposes to
@@ -27,16 +27,17 @@ The user only authenticates to the bastion with their normal SSO cert; the basti
 vouches by obtaining a per-hop certificate.
 
 ### Flow
+
 1. User SSHes to the bastion with their SSO-issued cert (`ssh-ca` / `ob-ssh-cert`).
    `pam_openbastion` on the bastion authorizes them and stamps `_pamSeen` (already done).
 2. `ob-ssh-proxy <backend>` on the bastion:
    a. generates an **ephemeral** keypair in tmpfs (private key never leaves the bastion);
    b. `POST /pam/bastion-cert` to LLNG, **Bearer = the bastion's device-grant server
-      token**, body `{ user, target_host, target_group, public_key, voucher }`
-      (the `voucher` proves this user really connected to this bastion — see below);
+   token**, body `{ user, target_host, target_group, public_key, voucher }`
+   (the `voucher` proves this user really connected to this bastion — see below);
    c. receives a signed certificate; writes ephemeral key + cert to tmpfs;
    d. `ssh -i <ephkey> -o CertificateFile=<cert> -o IdentitiesOnly=yes <user>@<backend>`
-      (or `-W` in ProxyCommand mode); wipes the temp files afterwards.
+   (or `-W` in ProxyCommand mode); wipes the temp files afterwards.
 3. Backend sshd (`TrustedUserCAKeys` = LLNG CA, already configured) validates the cert
    natively: CA signature, validity window, `principal == login user`, and the
    `source-address` critical option (if set, sshd itself refuses the cert unless the
@@ -47,16 +48,17 @@ vouches by obtaining a per-hop certificate.
 
 ### Vouching binding & voucher lifecycle (the core security property)
 
-**Problem the voucher solves.** Today's `bastionToken` only gates on the *portal-global*
+**Problem the voucher solves.** Today's `bastionToken` only gates on the _portal-global_
 `_pamSeen` marker — "did this user use pam-access anywhere on this portal in the last 7
-days". It does **not** prove "*this* user is connected to *this* bastion". A bastion
+days". It does **not** prove "_this_ user is connected to _this_ bastion". A bastion
 holding a valid bastion-group device token could therefore mint a cert for **any** user
 who touched the portal recently, even one who never connected to it. We close this with a
 per-`(bastion_id, user)` voucher.
 
 **Voucher = a reusable, session-scoped capability** (NOT a one-time nonce — a strict
-one-time nonce would break `scp backend1:/f backend2:/g` run *from the bastion*, which
+one-time nonce would break `scp backend1:/f backend2:/g` run _from the bastion_, which
 opens two outbound SSH connections → two `/pam/bastion-cert` calls):
+
 - Minted in `/pam/authorize` when the user actually connects to the bastion: that handler
   already knows `server_id = client_id` (= `bastion_id`) **and** `user`, and has just
   re-validated the user's SSH cert fingerprint. When the caller's `server_group` is a
@@ -64,7 +66,7 @@ opens two outbound SSH connections → two `/pam/bastion-cert` calls):
   session under `_pamBastionVouchers->{ $bastion_id } = { nonce, exp }` and return it in
   the authorize response (`bastion_voucher`, `bastion_voucher_expires_in`).
 - **Validity = the user's SSO cert lifetime.** `exp = min(now +
-  pamAccessBastionVoucherTtl, userCert.expires_at)`, where `userCert.expires_at` comes from
+pamAccessBastionVoucherTtl, userCert.expires_at)`, where `userCert.expires_at` comes from
   the cert record `_checkSshFingerprint` already returns at authorize time. The user's SSO
   cert lasts hours (ssh-ca config), so a multi-hour admin session is covered as long as the
   cert is valid — there is no separate "idle timeout" to trip over. `pamAccessBastionVoucherTtl`
@@ -85,27 +87,30 @@ have `ob-ssh-proxy` silently re-authorize: reconnecting is the explicit, auditab
 of presence, and it removes the threat-model ambiguity of on-demand re-vouching.
 
 **Transport (bastion-local, so the `SendEnv`/`pam_getenv` trap does not apply):** the
-voucher reaches `ob-ssh-proxy` on the *same host* — `pam_putenv` at login seeds it into the
+voucher reaches `ob-ssh-proxy` on the _same host_ — `pam_putenv` at login seeds it into the
 session, and/or it is cached in a per-session tmpfs file (`$XDG_RUNTIME_DIR`, mode 600)
 so renewals/refreshes persist across hops. The voucher is useless without the bastion's
 root-only server token (required as Bearer on `/pam/bastion-cert`), so a user reading their
 own voucher gains nothing, and it is bound to `(bastion_id, user)` anyway.
 
 ### LLNG `pam-access`: new `POST /pam/bastion-cert`
+
 Same vouching gates as today's `bastionToken` (grant_type=device_code, server_group ∈
 `pamAccessBastionGroups`, probe mode for `ob-bastion-id`) **plus** the per-`(bastion_id,
 user)` voucher check above (replacing the coarse global `_pamSeen` gate). Instead of
 signing a JWT, sign the supplied `public_key` with the **`ssh-ca` CA key** (reuse SSHCA
 signing internals via `$self->p->loadedModules->{'...::SSHCA'}->_signSshKey`), producing a
 user cert with:
+
 - `principal = user`;
 - short validity (config `pamAccessBastionCertTtl`, default ~120 s);
 - `key-id` carrying `bastion=<bastion_id>;user=<user>;target=<target_host>` (audit + allowlist);
 - custom extension `bastion-id@open-bastion = <bastion_id>` (+ optional `user-groups`);
 - optional `source-address` critical option = the bastion's IP (`$req->address`).
-Keep `/pam/bastion-token` temporarily for backward-compat, or remove with a CHANGELOG note.
+  Keep `/pam/bastion-token` temporarily for backward-compat, or remove with a CHANGELOG note.
 
 ### open-bastion changes
+
 - `scripts/ob-ssh-proxy`: ephemeral keypair → `/pam/bastion-cert` → `CertificateFile`
   connect; drop `SendEnv=LLNG_BASTION_JWT`.
 - `src/pam_openbastion.c`: read `bastion_id` from the presented cert (extend existing
@@ -122,12 +127,14 @@ Keep `/pam/bastion-token` temporarily for backward-compat, or remove with a CHAN
   (the gap that hid this bug).
 
 ### New config parameters (`pam-access`)
+
 - `pamAccessBastionCertTtl` — ephemeral user-cert validity, default **120 s**.
 - `pamAccessBastionVoucherTtl` — optional upper cap on `(bastion_id, user)` voucher
   validity, default **43200 s (12 h)**. Effective voucher exp = `min(now + this,
-  userCert.expires_at)`, so the user's SSO cert lifetime is the real bound.
+userCert.expires_at)`, so the user's SSO cert lifetime is the real bound.
 
 ### Resolved decisions
+
 - "Only this bastion" enforced **both** ways: cert `source-address` critical option
   (sshd-native, refuses the cert off-bastion) **and** the `bastion_id` allowlist parsed by
   `pam_openbastion`. Defense in depth.
@@ -138,8 +145,9 @@ Keep `/pam/bastion-token` temporarily for backward-compat, or remove with a CHAN
 - Voucher is **reusable + sliding TTL**, renewal is **fail-closed + reconnect** (above).
 
 ### Open questions
+
 - Backward-compat / deprecation of `/pam/bastion-token` and the `bastion_jwt_*` config
   (keep one release with a CHANGELOG deprecation note, then remove).
-- `scp host1:/f host2:/g` *initiated on a backend* (not on the bastion) — re-vouching
+- `scp host1:/f host2:/g` _initiated on a backend_ (not on the bastion) — re-vouching
   backend→backend without a user key on the backend — is a separate, harder topic; out of
   scope here, noted as future work.

--- a/doc/security/00-architecture.md
+++ b/doc/security/00-architecture.md
@@ -173,13 +173,13 @@ flowchart LR
 
 ### Bénéfices de Sécurité
 
-| Menace                          | Sans vouching cert                    | Avec vouching cert                                                               |
-| ------------------------------- | ------------------------------------- | -------------------------------------------------------------------------------- |
-| Accès direct au backend         | Possible si réseau accessible         | Bloqué — cert SSO direct refusé (key-id sans `bastion=`), cert épinglé à l'IP du bastion |
-| Contournement VPN vers backend  | Possible                              | Bloqué — `source-address` critique dans le cert, sshd refuse hors IP bastion    |
-| Mauvaise configuration pare-feu | Expose les backends                   | Backends toujours protégés — enforcement sshd-natif                             |
-| Rejeu d'un identifiant volé     | Clé/token compromis = accès backend   | Voucher volé inutile sans le jeton server root ; cert valide 120 s seulement    |
-| Bastion non autorisé            | N/A                                   | Bloqué — `allowed_bastions` vérifié par `ob-ssh-principals` (AuthorizedPrincipalsCommand, avant PAM) via le key-id du cert |
+| Menace                          | Sans vouching cert                  | Avec vouching cert                                                                                                         |
+| ------------------------------- | ----------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| Accès direct au backend         | Possible si réseau accessible       | Bloqué — cert SSO direct refusé (key-id sans `bastion=`), cert épinglé à l'IP du bastion                                   |
+| Contournement VPN vers backend  | Possible                            | Bloqué — `source-address` critique dans le cert, sshd refuse hors IP bastion                                               |
+| Mauvaise configuration pare-feu | Expose les backends                 | Backends toujours protégés — enforcement sshd-natif                                                                        |
+| Rejeu d'un identifiant volé     | Clé/token compromis = accès backend | Voucher volé inutile sans le jeton server root ; cert valide 120 s seulement                                               |
+| Bastion non autorisé            | N/A                                 | Bloqué — `allowed_bastions` vérifié par `ob-ssh-principals` (AuthorizedPrincipalsCommand, avant PAM) via le key-id du cert |
 
 ### Configuration (Backend)
 
@@ -201,23 +201,23 @@ AuthorizedPrincipalsCommandUser nobody
 
 ### Champs du Certificat Éphémère
 
-| Champ cert SSH   | Valeur                                                                  |
-| ---------------- | ----------------------------------------------------------------------- |
-| `principal`      | Nom d'utilisateur proxifié                                              |
-| `key-id`         | `bastion=<bastion_id>;user=<user>;target=<target_host>`                 |
-| `validity`       | ~120 s (`pamAccessBastionCertTtl`)                                      |
-| `source-address` | IP du bastion (option critique — sshd refuse si connexion hors IP)      |
-| `extension`      | `bastion-id@open-bastion = <bastion_id>` (optionnel, audit)             |
+| Champ cert SSH   | Valeur                                                             |
+| ---------------- | ------------------------------------------------------------------ |
+| `principal`      | Nom d'utilisateur proxifié                                         |
+| `key-id`         | `bastion=<bastion_id>;user=<user>;target=<target_host>`            |
+| `validity`       | ~120 s (`pamAccessBastionCertTtl`)                                 |
+| `source-address` | IP du bastion (option critique — sshd refuse si connexion hors IP) |
+| `extension`      | `bastion-id@open-bastion = <bastion_id>` (optionnel, audit)        |
 
 ### Paramètres LLNG (`pam-access`)
 
-| Paramètre                     | Défaut  | Description                                                                |
-| ----------------------------- | ------- | -------------------------------------------------------------------------- |
-| `pamAccessBastionGroups`      | bastion | Groupes autorisés à obtenir des vouchers / certs bastion                   |
-| `pamAccessBastionVoucherTtl`  | 43200   | Plafond de validité du voucher en secondes (12 h) ; la durée du cert SSO prime |
-| `pamAccessBastionCertTtl`     | 120     | Validité du certificat éphémère en secondes                                |
-| `pamAccessServerGroups`       | —       | Table `client_id → groupe` ; `/pam/bastion-cert` ne fait jamais confiance à un groupe revendiqué |
-| `sshCaActivation`             | 0       | Doit être mis à **1** pour activer le plugin ssh-ca requis par ce mécanisme |
+| Paramètre                    | Défaut  | Description                                                                                      |
+| ---------------------------- | ------- | ------------------------------------------------------------------------------------------------ |
+| `pamAccessBastionGroups`     | bastion | Groupes autorisés à obtenir des vouchers / certs bastion                                         |
+| `pamAccessBastionVoucherTtl` | 43200   | Plafond de validité du voucher en secondes (12 h) ; la durée du cert SSO prime                   |
+| `pamAccessBastionCertTtl`    | 120     | Validité du certificat éphémère en secondes                                                      |
+| `pamAccessServerGroups`      | —       | Table `client_id → groupe` ; `/pam/bastion-cert` ne fait jamais confiance à un groupe revendiqué |
+| `sshCaActivation`            | 0       | Doit être mis à **1** pour activer le plugin ssh-ca requis par ce mécanisme                      |
 
 ## Sécurité du Cache de Tokens
 
@@ -393,22 +393,22 @@ Pour la surveillance de sécurité en temps réel :
 
 ### Gestion des Secrets
 
-| Paramètre              | Défaut     | Description                   |
-| ---------------------- | ---------- | ----------------------------- |
-| `secrets_encrypted`    | true       | Chiffrer les secrets au repos |
-| `secrets_use_keyring`  | true       | Utiliser le trousseau noyau   |
+| Paramètre              | Défaut         | Description                   |
+| ---------------------- | -------------- | ----------------------------- |
+| `secrets_encrypted`    | true           | Chiffrer les secrets au repos |
+| `secrets_use_keyring`  | true           | Utiliser le trousseau noyau   |
 | `secrets_keyring_name` | "open-bastion" | Identifiant du trousseau      |
 
 ### Permissions des Fichiers
 
 Permissions recommandées :
 
-| Fichier                             | Permissions | Propriétaire |
-| ----------------------------------- | ----------- | ------------ |
+| Fichier                              | Permissions | Propriétaire |
+| ------------------------------------ | ----------- | ------------ |
 | `/etc/open-bastion/openbastion.conf` | 0600        | root         |
-| Fichier token serveur               | 0600        | root         |
-| Répertoire cache                    | 0700        | root         |
-| Répertoire état limitation de débit | 0700        | root         |
+| Fichier token serveur                | 0600        | root         |
+| Répertoire cache                     | 0700        | root         |
+| Répertoire état limitation de débit  | 0700        | root         |
 
 ## Sécurité des Scripts
 
@@ -637,21 +637,21 @@ Cette configuration n'autorise que les clés Ed25519 et les clés de sécurité 
 
 ## Atténuation des Menaces
 
-| Menace                      | Atténuation                                                                               |
-| --------------------------- | ----------------------------------------------------------------------------------------- |
-| Rejeu de token              | Tokens à usage unique, invalidation du cache                                              |
-| Attaques MITM               | TLS 1.3, épinglage de certificat                                                          |
-| Force brute                 | Limitation de débit avec attente exponentielle                                            |
-| Falsification du cache      | Chiffrement authentifié AES-256-GCM                                                       |
-| Injection de chemin         | Validation stricte des chemins, listes approuvées                                         |
-| Débordement de tampon       | Opérations sur chaînes avec vérification des limites, snprintf avec terminaison null      |
-| Collision d'UID             | Détection de collision à sécurité intégrée                                                |
-| Falsification de requête    | Signature HMAC optionnelle avec nonces                                                    |
-| DoS par épuisement mémoire  | Limites de taille de réponse (256 Ko), limites de groupes (256 max)                       |
-| Dépassement d'entier        | Validation des entrées dans l'encodage base64, calculs d'attente                          |
-| JSON malformé               | Validation de type pour les champs de réponse critiques                                   |
-| Exposition du secret client | JWT Client Assertion (RFC 7523) - secret jamais transmis                                  |
-| Contournement du bastion    | Certificat éphémère lié à `(bastion_id, user)` via voucher serveur ; `source-address` épinglée à l'IP du bastion |
+| Menace                      | Atténuation                                                                                                             |
+| --------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| Rejeu de token              | Tokens à usage unique, invalidation du cache                                                                            |
+| Attaques MITM               | TLS 1.3, épinglage de certificat                                                                                        |
+| Force brute                 | Limitation de débit avec attente exponentielle                                                                          |
+| Falsification du cache      | Chiffrement authentifié AES-256-GCM                                                                                     |
+| Injection de chemin         | Validation stricte des chemins, listes approuvées                                                                       |
+| Débordement de tampon       | Opérations sur chaînes avec vérification des limites, snprintf avec terminaison null                                    |
+| Collision d'UID             | Détection de collision à sécurité intégrée                                                                              |
+| Falsification de requête    | Signature HMAC optionnelle avec nonces                                                                                  |
+| DoS par épuisement mémoire  | Limites de taille de réponse (256 Ko), limites de groupes (256 max)                                                     |
+| Dépassement d'entier        | Validation des entrées dans l'encodage base64, calculs d'attente                                                        |
+| JSON malformé               | Validation de type pour les champs de réponse critiques                                                                 |
+| Exposition du secret client | JWT Client Assertion (RFC 7523) - secret jamais transmis                                                                |
+| Contournement du bastion    | Certificat éphémère lié à `(bastion_id, user)` via voucher serveur ; `source-address` épinglée à l'IP du bastion        |
 | Accès direct au backend     | Cert SSO direct refusé (key-id sans `bastion=`) ; cert éphémère épinglé à l'IP du bastion via `source-address` critique |
-| Clés SSH faibles            | Application de la politique de clés SSH avec restrictions de type/taille                  |
-| Force brute sur le cache    | Limitation de débit pour les consultations de cache hors-ligne avec attente exponentielle |
+| Clés SSH faibles            | Application de la politique de clés SSH avec restrictions de type/taille                                                |
+| Force brute sur le cache    | Limitation de débit pour les consultations de cache hors-ligne avec attente exponentielle                               |

--- a/doc/security/02-ssh-connection.md
+++ b/doc/security/02-ssh-connection.md
@@ -467,10 +467,10 @@ ssh backend.internal.example.com
 ob-ssh-proxy backend.internal.example.com
 ```
 
-|                 |                         Score résiduel                          |
-| --------------- | :-------------------------------------------------------------: |
+|                 |                           Score résiduel                            |
+| --------------- | :-----------------------------------------------------------------: |
 | **Probabilité** | 1 (cert éphémère + source-address + allowlist + restriction réseau) |
-| **Impact**      |                               3                                 |
+| **Impact**      |                                  3                                  |
 
 ---
 
@@ -672,14 +672,14 @@ pamAccessBastionCertTtl: 60 # 1 minute au lieu de 2 (si politique plus stricte)
 
 ```yaml
 # LLNG Manager - Ajuster le plafond TTL du voucher
-pamAccessBastionVoucherTtl: 43200   # 12 h (défaut)
-pamAccessBastionCertTtl: 120        # 2 min (défaut)
+pamAccessBastionVoucherTtl: 43200 # 12 h (défaut)
+pamAccessBastionCertTtl: 120 # 2 min (défaut)
 ```
 
-|                 |                           Score résiduel                            |
-| --------------- | :-----------------------------------------------------------------: |
-| **Probabilité** |          1 (fail-closed, TTL court du cert, lié à SSO cert)         |
-| **Impact**      | 1 (expiration propagée ; cert ~120 s limite l'exposition en cas b)  |
+|                 |                           Score résiduel                           |
+| --------------- | :----------------------------------------------------------------: |
+| **Probabilité** |         1 (fail-closed, TTL court du cert, lié à SSO cert)         |
+| **Impact**      | 1 (expiration propagée ; cert ~120 s limite l'exposition en cas b) |
 
 ---
 
@@ -1273,10 +1273,10 @@ Contrairement à R-S19 (recorder tué) et R-S20 (action différée), ici le reco
 
 **Piste non implémentée :** faire vérifier `target=<hôte>` par `ob-ssh-principals` contre le FQDN local (`%h`/`hostname -f`). Voir [99-risk-reduce.md](99-risk-reduce.md#r-s22-p1-i2---certificat-vouché-réutilisé-vers-un-autre-backend).
 
-|                 |                              Score résiduel                               |
-| --------------- | :-----------------------------------------------------------------------: |
+|                 |                                Score résiduel                                 |
+| --------------- | :---------------------------------------------------------------------------: |
 | **Probabilité** | 1 (suppose le contrôle du bastion ; `source-address` + TTL court + allowlist) |
-| **Impact**      |          2 (réutilisation limitée aux backends de la même zone)           |
+| **Impact**      |            2 (réutilisation limitée aux backends de la même zone)             |
 
 ---
 
@@ -1304,10 +1304,10 @@ Contrairement à R-S19 (recorder tué) et R-S20 (action différée), ici le reco
 
 **Piste non implémentée :** faire écrire au paquet (postinst) un `allowed_bastions` vide par défaut pour que l'« absent » n'arrive jamais, ou un mode strict où l'absence du fichier = refus. Voir [99-risk-reduce.md](99-risk-reduce.md#r-s23-p1-i3---backend-en-mode-hérité-fail-open).
 
-|                 |                              Score résiduel                               |
-| --------------- | :-----------------------------------------------------------------------: |
+|                 |                               Score résiduel                                |
+| --------------- | :-------------------------------------------------------------------------: |
 | **Probabilité** | 1 (`ob-backend-setup` écrit toujours le fichier ; fail-closed si illisible) |
-| **Impact**      |        3 (contournement complet du vouching sur un backend hérité)        |
+| **Impact**      |         3 (contournement complet du vouching sur un backend hérité)         |
 
 ---
 
@@ -1315,23 +1315,23 @@ Contrairement à R-S19 (recorder tué) et R-S20 (action différée), ici le reco
 
 ### Avant remédiation
 
-| Impact ↓ / Probabilité → | 1 - Très improbable | 2 - Peu probable                                    | 3 - Probable | 4 - Très probable |
-| ------------------------ | ------------------- | --------------------------------------------------- | ------------ | ----------------- |
-| **4 - Critique**         | R-S4                | R-S6 R-S17                                          |              |                   |
-| **3 - Important**        |                     | R-S3 R-S7 R-S11 R-S15 R-S13 R-S14 R-S18 R-S20 R-S21 R-S23 | R-S19   |                   |
-| **2 - Limité**           | R-S16 R-S22         | R-S9 R-S10 R-S12                                    | R-S8         |                   |
-| **1 - Négligeable**      |                     |                                                     |              |                   |
+| Impact ↓ / Probabilité → | 1 - Très improbable | 2 - Peu probable                                          | 3 - Probable | 4 - Très probable |
+| ------------------------ | ------------------- | --------------------------------------------------------- | ------------ | ----------------- |
+| **4 - Critique**         | R-S4                | R-S6 R-S17                                                |              |                   |
+| **3 - Important**        |                     | R-S3 R-S7 R-S11 R-S15 R-S13 R-S14 R-S18 R-S20 R-S21 R-S23 | R-S19        |                   |
+| **2 - Limité**           | R-S16 R-S22         | R-S9 R-S10 R-S12                                          | R-S8         |                   |
+| **1 - Négligeable**      |                     |                                                           |              |                   |
 
 > **Note :** R-S1 (brute-force mot de passe) et R-S2 (vol de clé SSH simple) sont **éliminés** par la cible de sécurité maximale (`AuthorizedKeysFile none` + certificat CA requis). R-S5 démarre à P=1 grâce aux certificats CA obligatoires. R-S18 est ici à P=2 (et non P=3) car le wrapper setgid empêche l'accès aux recordings d'autres utilisateurs, ce qui réduit la probabilité d'un effacement « croisé » même avant remédiation complète ; l'effacement de ses propres recordings reste possible (cf. fiche R-S18).
 
 ### Après remédiation complète
 
-| Impact ↓ / Probabilité → | 1 - Très improbable                                             | 2 - Peu probable | 3 - Probable | 4 - Très probable |
-| ------------------------ | --------------------------------------------------------------- | ---------------- | ------------ | ----------------- |
-| **4 - Critique**         | R-S4                                                            |                  |              |                   |
-| **3 - Important**        | R-S5 R-S23                                                      | R-S6             |              |                   |
-| **2 - Limité**           | R-S7 R-S9 R-S10 R-S11 R-S12 R-S13 R-S14 R-S16 R-S17 R-S20 R-S21 R-S22 | R-S8       |              |                   |
-| **1 - Négligeable**      | R-S15 R-S19                                                     | R-S3 R-S18       |              |                   |
+| Impact ↓ / Probabilité → | 1 - Très improbable                                                   | 2 - Peu probable | 3 - Probable | 4 - Très probable |
+| ------------------------ | --------------------------------------------------------------------- | ---------------- | ------------ | ----------------- |
+| **4 - Critique**         | R-S4                                                                  |                  |              |                   |
+| **3 - Important**        | R-S5 R-S23                                                            | R-S6             |              |                   |
+| **2 - Limité**           | R-S7 R-S9 R-S10 R-S11 R-S12 R-S13 R-S14 R-S16 R-S17 R-S20 R-S21 R-S22 | R-S8             |              |                   |
+| **1 - Négligeable**      | R-S15 R-S19                                                           | R-S3 R-S18       |              |                   |
 
 **Profil de risque de la cible maximale :**
 
@@ -1629,35 +1629,35 @@ sequenceDiagram
 
 ### Mesures critiques (non négociables)
 
-| Mesure                        | Justification                                               |
-| ----------------------------- | ----------------------------------------------------------- |
-| `AuthorizedKeysFile none`     | Élimine R-S1 et R-S2 ; certificat CA obligatoire            |
-| KRL avec cron 30 min          | Contrôle compensatoire pour les certificats 1 an            |
+| Mesure                                                           | Justification                                               |
+| ---------------------------------------------------------------- | ----------------------------------------------------------- |
+| `AuthorizedKeysFile none`                                        | Élimine R-S1 et R-S2 ; certificat CA obligatoire            |
+| KRL avec cron 30 min                                             | Contrôle compensatoire pour les certificats 1 an            |
 | Cert éphémère + `source-address` + `AuthorizedPrincipalsCommand` | Réduit R-S5 à P=1 même si restrictions réseau insuffisantes |
-| PAM sudo avec token LLNG      | Bloque toute escalade sans réauthentification SSO           |
-| Restriction réseau backends   | Défense en profondeur contre le contournement bastion       |
+| PAM sudo avec token LLNG                                         | Bloque toute escalade sans réauthentification SSO           |
+| Restriction réseau backends                                      | Défense en profondeur contre le contournement bastion       |
 
 ### Mesures recommandées
 
-| Mesure                                                  | Justification                                                 |
-| ------------------------------------------------------- | ------------------------------------------------------------- |
-| CA sur HSM ou machine air-gap                           | Réduit l'impact catastrophique de R-S4                        |
-| LLNG en haute disponibilité                             | Réduit R-S7 à P=1                                             |
-| Monitoring KRL + alertes                                | Détection rapide de R-S15                                     |
-| `AllowAgentForwarding no`                               | Réduit l'impact de R-S6 en cas de compromission bastion       |
-| `ssh_key_allowed_types = ed25519, sk-ed25519, sk-ecdsa` | Élimine les clés faibles (R-S11)                              |
+| Mesure                                                  | Justification                                                          |
+| ------------------------------------------------------- | ---------------------------------------------------------------------- |
+| CA sur HSM ou machine air-gap                           | Réduit l'impact catastrophique de R-S4                                 |
+| LLNG en haute disponibilité                             | Réduit R-S7 à P=1                                                      |
+| Monitoring KRL + alertes                                | Détection rapide de R-S15                                              |
+| `AllowAgentForwarding no`                               | Réduit l'impact de R-S6 en cas de compromission bastion                |
+| `ssh_key_allowed_types = ed25519, sk-ed25519, sk-ecdsa` | Élimine les clés faibles (R-S11)                                       |
 | `ob-ssh-proxy` (pas ProxyJump natif)                    | Vouching par certificat éphémère + clé privée ne quitte pas le bastion |
-| `ClientAliveInterval 300`                               | Limite l'exposition des sessions actives après révocation     |
-| 2FA sur LLNG pour les tokens sudo                       | Renforce la protection contre R-S16                           |
+| `ClientAliveInterval 300`                               | Limite l'exposition des sessions actives après révocation              |
+| 2FA sur LLNG pour les tokens sudo                       | Renforce la protection contre R-S16                                    |
 
 ### Points de surveillance (SIEM / monitoring)
 
-| Événement                                 | Criticité | Action recommandée       |
-| ----------------------------------------- | --------- | ------------------------ |
-| Connexion SSH sans certificat rejetée     | Medium    | Log + alerte récurrente  |
-| Connexion avec certificat révoqué (KRL)   | High      | Alerte immédiate         |
+| Événement                                                                                                | Criticité | Action recommandée       |
+| -------------------------------------------------------------------------------------------------------- | --------- | ------------------------ |
+| Connexion SSH sans certificat rejetée                                                                    | Medium    | Log + alerte récurrente  |
+| Connexion avec certificat révoqué (KRL)                                                                  | High      | Alerte immédiate         |
 | Connexion backend sans certificat éphémère bastion (rejet source-address ou AuthorizedPrincipalsCommand) | High      | Alerte immédiate         |
-| KRL non mise à jour depuis > 1h           | High      | Alerte immédiate         |
-| Sudo refusé (token absent/invalide)       | Medium    | Log                      |
-| Même certificat depuis 2+ IPs différentes | High      | Alerte + investigation   |
-| Modification `service-accounts.conf`      | Critical  | Alerte immédiate + audit |
+| KRL non mise à jour depuis > 1h                                                                          | High      | Alerte immédiate         |
+| Sudo refusé (token absent/invalide)                                                                      | Medium    | Log                      |
+| Même certificat depuis 2+ IPs différentes                                                                | High      | Alerte + investigation   |
+| Modification `service-accounts.conf`                                                                     | Critical  | Alerte immédiate + audit |

--- a/doc/security/02-ssh-connection.md
+++ b/doc/security/02-ssh-connection.md
@@ -1257,7 +1257,7 @@ Contrairement à R-S19 (recorder tué) et R-S20 (action différée), ici le reco
 | **Probabilité** |   1   |
 | **Impact**      |   2   |
 
-**Description :** Le key-id du certificat éphémère porte `bastion=<id>;user=<u>;target=<hôte>`, mais `ob-ssh-principals` n'enforce que `bastion=<id>` (allowlist) et `user=<u>` — il **ne vérifie pas** `target=`. Un certificat émis pour `backendA` est donc techniquement accepté par `backendB` si `backendB` fait confiance à la même CA et liste le même bastion dans son `allowed_bastions`, pendant la fenêtre de validité (~120 s).
+**Description :** Le key-id du certificat éphémère porte `bastion=<id>;user=<u>;target=<hôte>`, mais `ob-ssh-principals` ne fait respecter que `bastion=<id>` (allowlist) et `user=<u>` — il **ne vérifie pas** `target=`. Un certificat émis pour `backendA` est donc techniquement accepté par `backendB` si `backendB` fait confiance à la même CA et liste le même bastion dans son `allowed_bastions`, pendant la fenêtre de validité (~120 s).
 
 **Vecteurs d'attaque :**
 

--- a/doc/security/02-ssh-connection.md
+++ b/doc/security/02-ssh-connection.md
@@ -1250,6 +1250,67 @@ Contrairement à R-S19 (recorder tué) et R-S20 (action différée), ici le reco
 
 ---
 
+### R-S22 - Réutilisation d'un certificat vouché vers un autre backend (`target` non vérifié)
+
+|                 | Score |
+| --------------- | :---: |
+| **Probabilité** |   1   |
+| **Impact**      |   2   |
+
+**Description :** Le key-id du certificat éphémère porte `bastion=<id>;user=<u>;target=<hôte>`, mais `ob-ssh-principals` n'enforce que `bastion=<id>` (allowlist) et `user=<u>` — il **ne vérifie pas** `target=`. Un certificat émis pour `backendA` est donc techniquement accepté par `backendB` si `backendB` fait confiance à la même CA et liste le même bastion dans son `allowed_bastions`, pendant la fenêtre de validité (~120 s).
+
+**Vecteurs d'attaque :**
+
+- root sur le bastion réutilisant un certificat fraîchement émis (dans le tmpfs, avant effacement) pour rebondir vers un autre backend de la même zone
+- Le processus bastion lui-même, détourné, présentant le certificat à un backend non visé
+
+**Facteurs atténuants :**
+
+- **`source-address` critique** : le certificat n'est présentable que depuis l'IP du bastion émetteur — la réutilisation suppose donc déjà un contrôle du bastion (cf. R-S6), pas un attaquant réseau arbitraire
+- **TTL ~120 s** : fenêtre très courte
+- **Allowlist par backend** : un backend d'une autre zone de sécurité qui ne liste pas ce bastion dans son `allowed_bastions` refuse le certificat
+- **Modèle de confiance** : à l'intérieur d'une même zone, le bastion est déjà l'autorité de vouching pour tous ses backends ; la distinction inter-zones se fait en donnant à chaque bastion un `client_id` (= `bastion_id`) distinct et en restreignant `allowed_bastions` par zone
+
+**Piste non implémentée :** faire vérifier `target=<hôte>` par `ob-ssh-principals` contre le FQDN local (`%h`/`hostname -f`). Voir [99-risk-reduce.md](99-risk-reduce.md#r-s22-p1-i2---certificat-vouché-réutilisé-vers-un-autre-backend).
+
+|                 |                              Score résiduel                               |
+| --------------- | :-----------------------------------------------------------------------: |
+| **Probabilité** | 1 (suppose le contrôle du bastion ; `source-address` + TTL court + allowlist) |
+| **Impact**      |          2 (réutilisation limitée aux backends de la même zone)           |
+
+---
+
+### R-S23 - Backend en mode hérité : `allowed_bastions` absent (fail-open)
+
+|                 | Score |
+| --------------- | :---: |
+| **Probabilité** |   1   |
+| **Impact**      |   3   |
+
+**Description :** Si le fichier `/etc/open-bastion/allowed_bastions` est **absent**, `ob-ssh-principals` retombe dans un mode hérité non contraignant et émet le principal pour tout certificat signé par la CA dont le principal correspond au login — **y compris un certificat SSO direct** (key-id sans `bastion=`). Le vouching est alors contourné : accès direct au backend possible. Ce mode existe pour la rétro-compatibilité avec des backends antérieurs au vouching par certificat.
+
+**Vecteurs d'attaque :**
+
+- Backend déployé sans jamais exécuter `ob-backend-setup` (qui écrit toujours le fichier)
+- Suppression manuelle du fichier `allowed_bastions`
+
+**Facteurs atténuants (implémentés) :**
+
+- `ob-backend-setup` écrit **toujours** `/etc/open-bastion/allowed_bastions` (0644 dans un répertoire 0711) lors de la configuration backend — sur un déploiement nominal, le fichier est donc toujours présent
+- **Fail-closed sur ambiguïté** : si le fichier est présent mais illisible (ou le répertoire non traversable par `nobody`), `ob-ssh-principals` **refuse** (n'émet aucun principal) au lieu de retomber en mode ouvert — c'est le correctif du bug où un répertoire `/etc/open-bastion` en 0700 faisait silencieusement accepter un certificat SSO direct
+- Le test `tests/test_backend_cert_acceptance.sh` vérifie les deux comportements (présent → enforce ; présent-mais-illisible → deny)
+
+> ⚠️ Contrairement à un certificat vouché, un certificat SSO direct n'a **pas** d'option `source-address` : en mode hérité, il serait donc accepté depuis n'importe quelle IP, d'où l'impact I=3 (contournement complet du bastion sur ce backend).
+
+**Piste non implémentée :** faire écrire au paquet (postinst) un `allowed_bastions` vide par défaut pour que l'« absent » n'arrive jamais, ou un mode strict où l'absence du fichier = refus. Voir [99-risk-reduce.md](99-risk-reduce.md#r-s23-p1-i3---backend-en-mode-hérité-fail-open).
+
+|                 |                              Score résiduel                               |
+| --------------- | :-----------------------------------------------------------------------: |
+| **Probabilité** | 1 (`ob-backend-setup` écrit toujours le fichier ; fail-closed si illisible) |
+| **Impact**      |        3 (contournement complet du vouching sur un backend hérité)        |
+
+---
+
 ## 4. Matrice des Risques
 
 ### Avant remédiation
@@ -1257,8 +1318,8 @@ Contrairement à R-S19 (recorder tué) et R-S20 (action différée), ici le reco
 | Impact ↓ / Probabilité → | 1 - Très improbable | 2 - Peu probable                                    | 3 - Probable | 4 - Très probable |
 | ------------------------ | ------------------- | --------------------------------------------------- | ------------ | ----------------- |
 | **4 - Critique**         | R-S4                | R-S6 R-S17                                          |              |                   |
-| **3 - Important**        |                     | R-S3 R-S7 R-S11 R-S15 R-S13 R-S14 R-S18 R-S20 R-S21 | R-S19        |                   |
-| **2 - Limité**           | R-S16               | R-S9 R-S10 R-S12                                    | R-S8         |                   |
+| **3 - Important**        |                     | R-S3 R-S7 R-S11 R-S15 R-S13 R-S14 R-S18 R-S20 R-S21 R-S23 | R-S19   |                   |
+| **2 - Limité**           | R-S16 R-S22         | R-S9 R-S10 R-S12                                    | R-S8         |                   |
 | **1 - Négligeable**      |                     |                                                     |              |                   |
 
 > **Note :** R-S1 (brute-force mot de passe) et R-S2 (vol de clé SSH simple) sont **éliminés** par la cible de sécurité maximale (`AuthorizedKeysFile none` + certificat CA requis). R-S5 démarre à P=1 grâce aux certificats CA obligatoires. R-S18 est ici à P=2 (et non P=3) car le wrapper setgid empêche l'accès aux recordings d'autres utilisateurs, ce qui réduit la probabilité d'un effacement « croisé » même avant remédiation complète ; l'effacement de ses propres recordings reste possible (cf. fiche R-S18).
@@ -1268,8 +1329,8 @@ Contrairement à R-S19 (recorder tué) et R-S20 (action différée), ici le reco
 | Impact ↓ / Probabilité → | 1 - Très improbable                                             | 2 - Peu probable | 3 - Probable | 4 - Très probable |
 | ------------------------ | --------------------------------------------------------------- | ---------------- | ------------ | ----------------- |
 | **4 - Critique**         | R-S4                                                            |                  |              |                   |
-| **3 - Important**        | R-S5                                                            | R-S6             |              |                   |
-| **2 - Limité**           | R-S7 R-S9 R-S10 R-S11 R-S12 R-S13 R-S14 R-S16 R-S17 R-S20 R-S21 | R-S8             |              |                   |
+| **3 - Important**        | R-S5 R-S23                                                      | R-S6             |              |                   |
+| **2 - Limité**           | R-S7 R-S9 R-S10 R-S11 R-S12 R-S13 R-S14 R-S16 R-S17 R-S20 R-S21 R-S22 | R-S8       |              |                   |
 | **1 - Négligeable**      | R-S15 R-S19                                                     | R-S3 R-S18       |              |                   |
 
 **Profil de risque de la cible maximale :**
@@ -1284,6 +1345,8 @@ Contrairement à R-S19 (recorder tué) et R-S20 (action différée), ici le reco
 - R-S18 (effacement sessions) : **traçable mais reste effaçable techniquement** ; l'imputation tient grâce à syslog `auth.info` (start/end de session) et, si PR2 (#113) est activée, grâce au watch auditd `-w /var/lib/open-bastion/sessions/` qui trace l'événement d'effacement lui-même
 - R-S19 (évasion containment via `setsid`/`nohup`), R-S20 (action différée via `at`/`cron`/`systemd-run`), R-S21 (action non capturée par le pty) : **nouvellement identifiés** et mitigés par PR1 (#112) et PR2 (#113) sous condition d'activation opt-in
 - **Conditions d'activation :** ces nouveaux risques (R-S19, R-S20, R-S21) ne sont mitigés à leur niveau résiduel **que si** le hardening (PR1) ET la trace auditd (PR2) sont activés via `ob-bastion-setup --enable-hardening --enable-audit-trace`. En l'absence d'activation, ces risques restent en zone jaune (P=3, I=3 pour R-S19 ; P=2, I=3 pour R-S20 et R-S21). Voir [doc/hardening.md](../hardening.md) et [doc/audit.md](../audit.md) (documentations techniques en anglais) pour les détails opérationnels.
+- R-S22 (certificat vouché réutilisé vers un autre backend) : **P=1, I=2** — `target=` non vérifié par `ob-ssh-principals`, mais `source-address` impose le contrôle du bastion et l'allowlist par backend cloisonne les zones (piste : vérifier `target=` contre le FQDN local)
+- R-S23 (backend en mode hérité, `allowed_bastions` absent) : **P=1, I=3** — `ob-backend-setup` écrit toujours le fichier et `ob-ssh-principals` est fail-closed si illisible ; le risque résiduel ne concerne qu'un backend jamais configuré par le setup (piste : postinst écrivant un fichier vide par défaut)
 - Seuls risques résiduels significatifs en zone jaune (PR1 et PR2 activées) : R-S4 (CA compromise) et R-S6 (bastion compromis)
 
 ---

--- a/doc/security/99-risk-reduce.md
+++ b/doc/security/99-risk-reduce.md
@@ -5,8 +5,8 @@
 | Impact ↓ / Probabilité → | 1 - Très improbable                                  | 2 - Peu probable | 3 - Probable | 4 - Très probable |
 | ------------------------ | ---------------------------------------------------- | ---------------- | ------------ | ----------------- |
 | **4 - Critique**         | R-S4, R-SA2                                          | R-SA1            |              |                   |
-| **3 - Important**        | R5, R-S5, R-S11                                      | R-S6             |              |                   |
-| **2 - Limité**           | R-S7, R-S9, R-S10, R-S12, R-S16, R-S17, R-S20, R-S21 | R6, R-S8         |              |                   |
+| **3 - Important**        | R5, R-S5, R-S11, R-S23                               | R-S6             |              |                   |
+| **2 - Limité**           | R-S7, R-S9, R-S10, R-S12, R-S16, R-S17, R-S20, R-S21, R-S22 | R6, R-S8   |              |                   |
 | **1 - Négligeable**      | R0, R13, R-S14, R-S15, R-S19                         | R-S3, R-S18      |              |                   |
 
 > **Note :** R-S3 et R-S15 ont été descendus d'un cran sur l'axe Impact grâce au **binding fingerprint SSH** introduit dans le plugin PamAccess ≥ 0.1.16. La vérification est effectuée côté LLNG à la fois sur `/pam/authorize` (à chaque ouverture de session SSH, phase PAM `account`) et sur `/pam/verify` (à chaque utilisation d'un token PAM pour sudo ou ré-authentification) : tant que l'empreinte de la clef SSH n'est pas présente, active et non révoquée dans la session persistante LLNG, ni la session SSH ni l'escalade sudo ne sont autorisées, indépendamment de la fraîcheur de la KRL locale. Voir [02-ssh-connection.md](02-ssh-connection.md) pour les détails.
@@ -87,8 +87,9 @@ Pistes pour réduire P à 1 :
 
 Pistes pour réduire I à 2 :
 
-1. **Segmentation fine** : Plusieurs bastions par zone de sécurité
+1. **Segmentation fine** : Plusieurs bastions par zone de sécurité, **chacun avec son propre `client_id` (= `bastion_id`)** et un `allowed_bastions` distinct par backend → un bastion compromis ne peut voucher que pour les backends de sa zone
 2. **Session recording** : Enregistrement de toutes les sessions transitant par le bastion
+3. **Réduire `pamAccessBastionVoucherTtl`** (défaut 43200 s = 12 h) : borne la durée pendant laquelle un bastion compromis peut continuer à obtenir des certificats pour les utilisateurs récemment vouchés sans nouvelle connexion de leur part. Compromis ergonomie (les admins doivent se reconnecter plus souvent) vs exposition.
 
 ### R-S8 _(P=2, I=2)_ - Session persistante après révocation
 
@@ -107,20 +108,49 @@ Pistes pour réduire P à 1 :
 
 ---
 
-## Pistes d'Amélioration - JWT Bastion
+## Pistes d'Amélioration - Vouching par certificat (Bastion→Backend)
 
-### R-S9 _(P=1, I=2)_ - Replay JWT bastion
+> Le transport `LLNG_BASTION_JWT` via `SendEnv`/`AcceptEnv` (anciens R-S9 « replay JWT » et R-S10 « rotation JWKS ») a été **remplacé** par le vouching par certificat éphémère : un voucher `(bastion_id, user)` émis par `/pam/authorize`, transporté localement via `pam_putenv`, échangé par `ob-ssh-proxy` (via `ob-bastion-cert-helper`) contre un certificat ~120 s signé par la CA `ssh-ca` (`/pam/bastion-cert`), épinglé à l'IP du bastion par `source-address`. Voir [02-ssh-connection.md](02-ssh-connection.md) et [doc/design/bastion-cert-vouching.md](../design/bastion-cert-vouching.md).
+
+### R-S9 _(P=1, I=2)_ - Interception ou vol du certificat éphémère bastion
 
 Pistes supplémentaires (non implémentées) :
 
-1. **Vérification stricte IP** : Rejeter si `bastion_ip` != IP source SSH
-2. **Nonce challenge** : Le backend génère un nonce (complexifie le protocole)
+1. **Réduire `pamAccessBastionCertTtl`** (défaut 120 s → 30-60 s) pour les zones les plus sensibles : raccourcit encore la fenêtre d'exploitation d'un certificat volé dans le tmpfs.
+2. **Émission KRL pour les certificats éphémères** : aujourd'hui leur TTL très court remplace la révocation ; en cas de besoin de révocation immédiate sub-120 s, pousser le serial sur la KRL des backends (utile uniquement en réponse à incident).
 
-### R-S10 _(P=1, I=1)_ - Rotation JWKS non propagée
+### R-S10 _(P=1, I=1)_ - Voucher expiré ou rotation/compromission de la CA `ssh-ca`
 
-Piste supplémentaire (optionnelle) :
+Pistes supplémentaires (optionnelles) :
 
-1. **Push de notification** : LLNG notifie les backends via webhook pour refresh immédiat (utile uniquement en cas de compromission)
+1. **Push de notification rotation CA** : lors d'une rotation (ou compromission) de la CA `ssh-ca`, LLNG notifie les backends via webhook pour rafraîchir `TrustedUserCAKeys` immédiatement, au lieu d'attendre le redéploiement.
+2. **Monitoring de fraîcheur de `TrustedUserCAKeys`** : alerter si l'empreinte de la CA déployée sur un backend diverge de la CA active côté LLNG.
+
+### R-S22 _(P=1, I=2)_ - Certificat vouché réutilisé vers un autre backend
+
+Le key-id porte `target=<hôte>` mais `ob-ssh-principals` ne vérifie que `bastion=<id>` et `user=<u>`. Pistes (non implémentées) pour épingler le certificat à son backend :
+
+1. **Vérification de `target=` dans `ob-ssh-principals`** : comparer `target=<hôte>` au FQDN local (`hostname -f` ou le token sshd `%h`) et refuser le principal si divergence. C'est la mitigation directe ; coût : robustesse du matching FQDN (alias, CNAME, IP vs nom) à valider.
+2. **`target` côté LLNG dans `source-address`** : impossible (source-address épingle l'origine, pas la destination) — c'est bien `ob-ssh-principals` qui doit porter ce contrôle.
+
+### R-S23 _(P=1, I=3)_ - Backend en mode hérité fail-open
+
+`ob-backend-setup` écrit toujours le fichier et `ob-ssh-principals` est fail-closed si le fichier est présent mais illisible. Le résidu ne concerne qu'un backend jamais passé par le setup. Pistes (non implémentées) pour fermer ce mode :
+
+1. **Fichier vide par défaut (postinst)** : faire écrire `/etc/open-bastion/allowed_bastions` vide par le paquet à l'installation, pour que l'« absent » n'arrive jamais (vide = « tout bastion vouché », ce qui reste contraignant : un cert SSO direct sans `bastion=` est refusé).
+2. **Mode strict** : option (`ob-backend-setup --strict-vouching` ou clé de conf) où l'absence du fichier = **refus** au lieu du mode hérité, à activer sur les déploiements neufs sans backend legacy.
+
+---
+
+## Pistes d'Amélioration - Cycle de vie des tokens (heartbeat)
+
+### Supervision du rafraîchissement (suite au fix #121)
+
+Le timer `ob-heartbeat` rafraîchit l'access_token (TTL 3600 s) toutes les 5 min ; un échec silencieux du timer fait expirer le token (NSS + `/pam/authorize` cassés ~1 h après — c'était le cas avant #121 à cause du sandbox `ProtectSystem=strict` rendant le token en lecture seule). Pistes (non implémentées) pour détecter une régression future :
+
+1. **Alerte sur échec de `ob-heartbeat.service`** : `OnFailure=` systemd → notification (mail/webhook/SIEM) dès qu'un run du timer échoue, plutôt que de découvrir l'expiration par la perte d'accès.
+2. **Monitoring de l'âge du token** : exporter `expires_at - now` (node_exporter textfile, ou un check Nagios/Prometheus) et alerter quand il descend sous ~2× l'intervalle du timer.
+3. **Test d'intégration sur fenêtre > TTL** : ajouter un test (CI longue ou lab) qui vérifie le refresh **via le chemin du timer** (`systemctl start ob-heartbeat.service`, donc avec le sandbox) sur une fenêtre dépassant 3600 s — un `sudo ob-heartbeat` manuel masque les régressions du sandbox. Recoupe R-S17 (lockout).
 
 ---
 

--- a/doc/security/99-risk-reduce.md
+++ b/doc/security/99-risk-reduce.md
@@ -2,12 +2,12 @@
 
 ## Matrice des Risques Résiduels (Mode E)
 
-| Impact ↓ / Probabilité → | 1 - Très improbable                                  | 2 - Peu probable | 3 - Probable | 4 - Très probable |
-| ------------------------ | ---------------------------------------------------- | ---------------- | ------------ | ----------------- |
-| **4 - Critique**         | R-S4, R-SA2                                          | R-SA1            |              |                   |
-| **3 - Important**        | R5, R-S5, R-S11, R-S23                               | R-S6             |              |                   |
-| **2 - Limité**           | R-S7, R-S9, R-S10, R-S12, R-S16, R-S17, R-S20, R-S21, R-S22 | R6, R-S8   |              |                   |
-| **1 - Négligeable**      | R0, R13, R-S14, R-S15, R-S19                         | R-S3, R-S18      |              |                   |
+| Impact ↓ / Probabilité → | 1 - Très improbable                                         | 2 - Peu probable | 3 - Probable | 4 - Très probable |
+| ------------------------ | ----------------------------------------------------------- | ---------------- | ------------ | ----------------- |
+| **4 - Critique**         | R-S4, R-SA2                                                 | R-SA1            |              |                   |
+| **3 - Important**        | R5, R-S5, R-S11, R-S23                                      | R-S6             |              |                   |
+| **2 - Limité**           | R-S7, R-S9, R-S10, R-S12, R-S16, R-S17, R-S20, R-S21, R-S22 | R6, R-S8         |              |                   |
+| **1 - Négligeable**      | R0, R13, R-S14, R-S15, R-S19                                | R-S3, R-S18      |              |                   |
 
 > **Note :** R-S3 et R-S15 ont été descendus d'un cran sur l'axe Impact grâce au **binding fingerprint SSH** introduit dans le plugin PamAccess ≥ 0.1.16. La vérification est effectuée côté LLNG à la fois sur `/pam/authorize` (à chaque ouverture de session SSH, phase PAM `account`) et sur `/pam/verify` (à chaque utilisation d'un token PAM pour sudo ou ré-authentification) : tant que l'empreinte de la clef SSH n'est pas présente, active et non révoquée dans la session persistante LLNG, ni la session SSH ni l'escalade sudo ne sont autorisées, indépendamment de la fraîcheur de la KRL locale. Voir [02-ssh-connection.md](02-ssh-connection.md) pour les détails.
 

--- a/doc/security/99-risk-reduce.md
+++ b/doc/security/99-risk-reduce.md
@@ -150,7 +150,7 @@ Le timer `ob-heartbeat` rafraîchit l'access_token (TTL 3600 s) toutes les 5 min
 
 1. **Alerte sur échec de `ob-heartbeat.service`** : `OnFailure=` systemd → notification (mail/webhook/SIEM) dès qu'un run du timer échoue, plutôt que de découvrir l'expiration par la perte d'accès.
 2. **Monitoring de l'âge du token** : exporter `expires_at - now` (node_exporter textfile, ou un check Nagios/Prometheus) et alerter quand il descend sous ~2× l'intervalle du timer.
-3. **Test d'intégration sur fenêtre > TTL** : ajouter un test (CI longue ou lab) qui vérifie le refresh **via le chemin du timer** (`systemctl start ob-heartbeat.service`, donc avec le sandbox) sur une fenêtre dépassant 3600 s — un `sudo ob-heartbeat` manuel masque les régressions du sandbox. Recoupe R-S17 (lockout).
+3. **Test d'intégration sur fenêtre > TTL** : ajouter un test (CI longue ou lab) qui vérifie le rafraîchissement **via le chemin du timer** (`systemctl start ob-heartbeat.service`, donc avec le sandbox) sur une fenêtre dépassant 3600 s — un `sudo ob-heartbeat` manuel masque les régressions du sandbox. Recoupe R-S17 (lockout).
 
 ---
 

--- a/presentation.md
+++ b/presentation.md
@@ -477,12 +477,12 @@ sudo ob-enroll
 
 ## Components
 
-| Component            | Function                           |
-| -------------------- | ---------------------------------- |
-| `pam_openbastion.so`        | PAM authentication & authorization |
-| `libnss_openbastion.so`     | User resolution before PAM         |
-| `ob-enroll`          | Server enrollment                  |
-| `ob-heartbeat`       | Server monitoring                  |
+| Component               | Function                           |
+| ----------------------- | ---------------------------------- |
+| `pam_openbastion.so`    | PAM authentication & authorization |
+| `libnss_openbastion.so` | User resolution before PAM         |
+| `ob-enroll`             | Server enrollment                  |
+| `ob-heartbeat`          | Server monitoring                  |
 
 <!-- end_slide -->
 


### PR DESCRIPTION
Re-runs the security threat analysis (`doc/security/`) against what is now actually implemented, and parks the remaining non-implemented mitigations in `99-risk-reduce.md`.

## `02-ssh-connection.md` — two newly identified residual risks

| ID | P×I | Risk | Implemented mitigation | Non-implemented piste |
|----|-----|------|------------------------|-----------------------|
| **R-S22** | 1×2 | A vouched cert reused against another backend — `ob-ssh-principals` enforces `bastion=`/`user=` but **not** `target=` | `source-address` (requires bastion control), ~120 s TTL, per-backend allowlist, distinct `bastion_id` per zone | Enforce `target=<FQDN>` in `ob-ssh-principals` |
| **R-S23** | 1×3 | A backend whose `allowed_bastions` is **absent** falls back to the legacy non-enforcing path and accepts a direct SSO cert (bastion bypass) | `ob-backend-setup` always writes the file; `ob-ssh-principals` **fails closed** when it is present-but-unreadable (the dir-perm bug we fixed) | postinst writes an empty allowlist by default / `--strict-vouching` mode |

Both added to the before/after risk matrices and the risk profile.

## `99-risk-reduce.md` — parking lot updated

- Replaced the obsolete **JWT Bastion** section (R-S9 *replay JWT*, R-S10 *JWKS rotation*) with the cert-vouching equivalents (R-S9 *ephemeral-cert theft*, R-S10 *voucher expiry / CA rotation*) and the matching residual-matrix entries.
- New pistes: enforce `target=` (R-S22); default/strict allowlist (R-S23); reduce `pamAccessBastionVoucherTtl` to bound a compromised bastion's minting window (R-S6).
- New **token lifecycle (heartbeat)** section: alert on `ob-heartbeat.service` failures, monitor token age, and test the refresh **via the timer path** over a >TTL window — the exact gap that hid the #121 sandbox bug (a manual `ob-heartbeat` runs without the sandbox and masked it).

Docs only; the implemented fiches in `00`/`02` were already migrated to cert vouching in #120.