### PR TITLE
fix(setup): sshd drop-in must outrank cloud-init (password auth stayed enabled)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **sshd hardening drop-in could be silently overridden by cloud-init.** Cloud
+  images ship `/etc/ssh/sshd_config.d/50-cloud-init.conf` with
+  `PasswordAuthentication yes`, and sshd keeps the *first* value seen while
+  `Include` expands the drop-in directory alphabetically. The open-bastion
+  drop-in was written as `50-open-bastion-{bastion,backend}.conf`, which sorts
+  *after* `50-cloud-init.conf`, so password authentication stayed enabled on
+  freshly provisioned bastions and backends. `ob-bastion-setup` /
+  `ob-backend-setup` now write `00-open-bastion-{bastion,backend}.conf` (and
+  remove the legacy `50-` file on rerun) so the cert-only lockdown wins.
+
 ### Changed
 
 - **Server token relocated from `/etc/open-bastion/token` to

--- a/doc/admin-guide.md
+++ b/doc/admin-guide.md
@@ -248,7 +248,7 @@ EOF
 ### Step 6: Configure SSH with Recording
 
 ```bash
-cat > /etc/ssh/sshd_config.d/50-open-bastion-bastion.conf << 'EOF'
+cat > /etc/ssh/sshd_config.d/00-open-bastion-bastion.conf << 'EOF'
 # LLNG PAM Authentication
 UsePAM yes
 PasswordAuthentication yes
@@ -463,7 +463,7 @@ EOF
 ### Step 7: Configure SSH
 
 ```bash
-cat > /etc/ssh/sshd_config.d/50-open-bastion-backend.conf << 'EOF'
+cat > /etc/ssh/sshd_config.d/00-open-bastion-backend.conf << 'EOF'
 # PAM required for authorization and user creation
 UsePAM yes
 

--- a/doc/bastion-architecture.md
+++ b/doc/bastion-architecture.md
@@ -567,7 +567,7 @@ directory so the helper, running as nobody, can read it) and wires
 `AuthorizedPrincipalsCommand`. Ansible variable: `ob_bastion_allowed_bastions`.
 
 ```ini
-# /etc/ssh/sshd_config.d/50-open-bastion.conf  (managed by ob-backend-setup)
+# /etc/ssh/sshd_config.d/00-open-bastion-backend.conf  (managed by ob-backend-setup)
 TrustedUserCAKeys /etc/open-bastion/llng_ca.pub
 AuthorizedPrincipalsCommand /usr/local/sbin/ob-ssh-principals %u %f %i
 AuthorizedPrincipalsCommandUser nobody

--- a/docker-demo-cert/backend/entrypoint.sh
+++ b/docker-demo-cert/backend/entrypoint.sh
@@ -45,7 +45,7 @@ if [ ! -f "$SSH_CA_FILE" ]; then
 fi
 
 # Configure sshd for certificate authentication
-cat > /etc/ssh/sshd_config.d/50-open-bastion-backend.conf << EOF
+cat > /etc/ssh/sshd_config.d/00-open-bastion-backend.conf << EOF
 # LemonLDAP::NG Backend Configuration
 
 # Trust LLNG SSH CA

--- a/docker-demo-cert/bastion/entrypoint.sh
+++ b/docker-demo-cert/bastion/entrypoint.sh
@@ -131,7 +131,7 @@ SCRIPT
 chmod 755 /usr/local/bin/ob-principals
 
 # Configure sshd for certificate authentication
-cat > /etc/ssh/sshd_config.d/50-open-bastion-bastion.conf << EOF
+cat > /etc/ssh/sshd_config.d/00-open-bastion-bastion.conf << EOF
 # LemonLDAP::NG Bastion Configuration
 
 # Trust LLNG SSH CA

--- a/docker-demo-maxsec/README.md
+++ b/docker-demo-maxsec/README.md
@@ -161,10 +161,10 @@ docker logs ob-maxsec-backend
 
 ```bash
 # Check AuthorizedKeysFile is none
-docker exec ob-maxsec-bastion grep AuthorizedKeysFile /etc/ssh/sshd_config.d/50-open-bastion-bastion.conf
+docker exec ob-maxsec-bastion grep AuthorizedKeysFile /etc/ssh/sshd_config.d/00-open-bastion-bastion.conf
 
 # Check KRL is configured
-docker exec ob-maxsec-bastion grep RevokedKeys /etc/ssh/sshd_config.d/50-open-bastion-bastion.conf
+docker exec ob-maxsec-bastion grep RevokedKeys /etc/ssh/sshd_config.d/00-open-bastion-bastion.conf
 
 # Check sudo PAM uses pam_openbastion (not NOPASSWD)
 docker exec ob-maxsec-backend cat /etc/pam.d/sudo

--- a/docker-demo-maxsec/backend/entrypoint.sh
+++ b/docker-demo-maxsec/backend/entrypoint.sh
@@ -72,7 +72,7 @@ chmod 644 /etc/cron.d/open-bastion-krl
 cron
 
 # Configure sshd for maximum security (Mode E)
-cat > /etc/ssh/sshd_config.d/50-open-bastion-backend.conf << EOF
+cat > /etc/ssh/sshd_config.d/00-open-bastion-backend.conf << EOF
 # Open Bastion Maximum Security Configuration (Mode E)
 
 # Trust LLNG SSH CA

--- a/docker-demo-maxsec/bastion/entrypoint.sh
+++ b/docker-demo-maxsec/bastion/entrypoint.sh
@@ -137,7 +137,7 @@ SCRIPT
 chmod 755 /usr/local/bin/ob-principals
 
 # Configure sshd for maximum security (Mode E)
-cat > /etc/ssh/sshd_config.d/50-open-bastion-bastion.conf << EOF
+cat > /etc/ssh/sshd_config.d/00-open-bastion-bastion.conf << EOF
 # Open Bastion Maximum Security Configuration (Mode E)
 
 # Trust LLNG SSH CA

--- a/docker-demo-token-svc/backend/entrypoint.sh
+++ b/docker-demo-token-svc/backend/entrypoint.sh
@@ -27,7 +27,7 @@ for i in {1..60}; do
 done
 
 # Configure sshd for password authentication via PAM
-cat > /etc/ssh/sshd_config.d/50-open-bastion-backend.conf << EOF
+cat > /etc/ssh/sshd_config.d/00-open-bastion-backend.conf << EOF
 # LemonLDAP::NG Backend Configuration (Token Auth Mode)
 
 # Disable public key authentication

--- a/docker-demo-token-svc/bastion/entrypoint.sh
+++ b/docker-demo-token-svc/bastion/entrypoint.sh
@@ -30,7 +30,7 @@ done
 # accounts) auth. AuthorizedKeysCommand yields a key only for usernames
 # declared in /etc/open-bastion/service-accounts.conf, so plain pubkey
 # auth is effectively restricted to those service accounts.
-cat > /etc/ssh/sshd_config.d/50-open-bastion-bastion.conf << EOF
+cat > /etc/ssh/sshd_config.d/00-open-bastion-bastion.conf << EOF
 # LemonLDAP::NG Bastion Configuration (Token Auth Mode + Service Accounts)
 
 # Enable public key authentication for service accounts. AuthorizedKeysFile

--- a/docker-demo-token/backend/entrypoint.sh
+++ b/docker-demo-token/backend/entrypoint.sh
@@ -27,7 +27,7 @@ for i in {1..60}; do
 done
 
 # Configure sshd for password authentication via PAM
-cat > /etc/ssh/sshd_config.d/50-open-bastion-backend.conf << EOF
+cat > /etc/ssh/sshd_config.d/00-open-bastion-backend.conf << EOF
 # LemonLDAP::NG Backend Configuration (Token Auth Mode)
 
 # Disable public key authentication

--- a/docker-demo-token/bastion/entrypoint.sh
+++ b/docker-demo-token/bastion/entrypoint.sh
@@ -27,7 +27,7 @@ for i in {1..60}; do
 done
 
 # Configure sshd for password authentication via PAM
-cat > /etc/ssh/sshd_config.d/50-open-bastion-bastion.conf << EOF
+cat > /etc/ssh/sshd_config.d/00-open-bastion-bastion.conf << EOF
 # LemonLDAP::NG Bastion Configuration (Token Auth Mode)
 
 # Disable public key authentication

--- a/scripts/ob-backend-setup
+++ b/scripts/ob-backend-setup
@@ -417,7 +417,15 @@ PermitRootLogin no
             info "Added Include directive to $SSHD_CONFIG"
         fi
 
-        local ob_config="$SSHD_CONFIG_DIR/50-open-bastion-backend.conf"
+        # Sort BEFORE distro drop-ins such as 50-cloud-init.conf, which ships
+        # `PasswordAuthentication yes`. sshd uses the FIRST value seen for
+        # keywords like PasswordAuthentication / PermitRootLogin / KbdInteractive,
+        # so our cert-only hardening must be read first or it is silently
+        # overridden. The 00- prefix guarantees that.
+        local ob_config="$SSHD_CONFIG_DIR/00-open-bastion-backend.conf"
+        # Drop the legacy 50- name from earlier installs (it sorted AFTER
+        # 50-cloud-init.conf and therefore lost the PasswordAuthentication race).
+        rm -f "$SSHD_CONFIG_DIR/50-open-bastion-backend.conf"
         backup_file "$ob_config"
         echo "$config_content" > "$ob_config"
         chmod 644 "$ob_config"

--- a/scripts/ob-bastion-setup
+++ b/scripts/ob-bastion-setup
@@ -370,7 +370,15 @@ PermitRootLogin no
             info "Added Include directive to $SSHD_CONFIG"
         fi
 
-        local ob_config="$SSHD_CONFIG_DIR/50-open-bastion-bastion.conf"
+        # Sort BEFORE distro drop-ins such as 50-cloud-init.conf, which ships
+        # `PasswordAuthentication yes`. sshd uses the FIRST value seen for
+        # keywords like PasswordAuthentication / PermitRootLogin / KbdInteractive,
+        # so our cert-only hardening must be read first or it is silently
+        # overridden. The 00- prefix guarantees that.
+        local ob_config="$SSHD_CONFIG_DIR/00-open-bastion-bastion.conf"
+        # Drop the legacy 50- name from earlier installs (it sorted AFTER
+        # 50-cloud-init.conf and therefore lost the PasswordAuthentication race).
+        rm -f "$SSHD_CONFIG_DIR/50-open-bastion-bastion.conf"
         backup_file "$ob_config"
         echo "$config_content" > "$ob_config"
         chmod 644 "$ob_config"

--- a/tests/test_backend_cert_acceptance.sh
+++ b/tests/test_backend_cert_acceptance.sh
@@ -73,7 +73,7 @@ cp /helper /usr/local/sbin/ob-ssh-principals
 chmod 755 /usr/local/sbin/ob-ssh-principals
 
 mkdir -p /etc/ssh/sshd_config.d /run/sshd
-cat > /etc/ssh/sshd_config.d/50-open-bastion-backend.conf <<EOF
+cat > /etc/ssh/sshd_config.d/00-open-bastion-backend.conf <<EOF
 TrustedUserCAKeys /ca/ca.pub
 AuthorizedPrincipalsCommand /usr/local/sbin/ob-ssh-principals %u %f %i
 AuthorizedPrincipalsCommandUser nobody

--- a/tests/test_integration_maxsec.sh
+++ b/tests/test_integration_maxsec.sh
@@ -764,8 +764,8 @@ test_authorized_keys_disabled() {
     log "Testing AuthorizedKeysFile is disabled..."
 
     local bastion_conf backend_conf
-    bastion_conf=$(docker exec ob-maxsec-bastion grep "AuthorizedKeysFile" /etc/ssh/sshd_config.d/50-open-bastion-bastion.conf 2>&1) || true
-    backend_conf=$(docker exec ob-maxsec-backend grep "AuthorizedKeysFile" /etc/ssh/sshd_config.d/50-open-bastion-backend.conf 2>&1) || true
+    bastion_conf=$(docker exec ob-maxsec-bastion grep "AuthorizedKeysFile" /etc/ssh/sshd_config.d/00-open-bastion-bastion.conf 2>&1) || true
+    backend_conf=$(docker exec ob-maxsec-backend grep "AuthorizedKeysFile" /etc/ssh/sshd_config.d/00-open-bastion-backend.conf 2>&1) || true
 
     if echo "$bastion_conf" | grep -q "none" && echo "$backend_conf" | grep -q "none"; then
         pass "AuthorizedKeysFile none on both bastion and backend"
@@ -781,8 +781,8 @@ test_krl_configured() {
     log "Testing KRL (RevokedKeys) is configured..."
 
     local bastion_krl backend_krl
-    bastion_krl=$(docker exec ob-maxsec-bastion grep "RevokedKeys" /etc/ssh/sshd_config.d/50-open-bastion-bastion.conf 2>&1) || true
-    backend_krl=$(docker exec ob-maxsec-backend grep "RevokedKeys" /etc/ssh/sshd_config.d/50-open-bastion-backend.conf 2>&1) || true
+    bastion_krl=$(docker exec ob-maxsec-bastion grep "RevokedKeys" /etc/ssh/sshd_config.d/00-open-bastion-bastion.conf 2>&1) || true
+    backend_krl=$(docker exec ob-maxsec-backend grep "RevokedKeys" /etc/ssh/sshd_config.d/00-open-bastion-backend.conf 2>&1) || true
 
     if echo "$bastion_krl" | grep -q "revoked_keys" && echo "$backend_krl" | grep -q "revoked_keys"; then
         pass "RevokedKeys configured on both bastion and backend"
@@ -862,8 +862,8 @@ test_password_auth_disabled() {
     log "Testing password authentication is disabled..."
 
     local bastion_pw backend_pw
-    bastion_pw=$(docker exec ob-maxsec-bastion grep "^PasswordAuthentication" /etc/ssh/sshd_config.d/50-open-bastion-bastion.conf 2>&1) || true
-    backend_pw=$(docker exec ob-maxsec-backend grep "^PasswordAuthentication" /etc/ssh/sshd_config.d/50-open-bastion-backend.conf 2>&1) || true
+    bastion_pw=$(docker exec ob-maxsec-bastion grep "^PasswordAuthentication" /etc/ssh/sshd_config.d/00-open-bastion-bastion.conf 2>&1) || true
+    backend_pw=$(docker exec ob-maxsec-backend grep "^PasswordAuthentication" /etc/ssh/sshd_config.d/00-open-bastion-backend.conf 2>&1) || true
 
     if echo "$bastion_pw" | grep -q "no" && echo "$backend_pw" | grep -q "no"; then
         pass "PasswordAuthentication disabled on both servers"

--- a/tests/test_ob_sshd_dropin_precedence.sh
+++ b/tests/test_ob_sshd_dropin_precedence.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# test_sshd_dropin_precedence.sh
+# test_ob_sshd_dropin_precedence.sh
 #
 # Regression test for the cert-only lockdown being silently defeated by a
 # distro sshd drop-in. Cloud images ship /etc/ssh/sshd_config.d/50-cloud-init.conf
@@ -24,6 +24,13 @@ bastion_dropin=$(grep -oE '[0-9]+-open-bastion-bastion\.conf' "$SCRIPT_DIR/scrip
 backend_dropin=$(grep -oE '[0-9]+-open-bastion-backend\.conf' "$SCRIPT_DIR/scripts/ob-backend-setup" | head -1)
 echo "bastion drop-in: $bastion_dropin"
 echo "backend drop-in: $backend_dropin"
+
+# Fail fast: an empty name (grep matched nothing) would vacuously "sort first"
+# below and let a real regression slip through.
+if [ -z "$bastion_dropin" ] || [ -z "$backend_dropin" ]; then
+    echo "FAIL: could not extract the open-bastion sshd drop-in name from the setup scripts"
+    exit 1
+fi
 
 # Static check: must sort before 50-cloud-init.conf.
 for d in "$bastion_dropin" "$backend_dropin"; do
@@ -67,7 +74,7 @@ rm -f "/etc/ssh/sshd_config.d/$backend_dropin"
 printf 'PasswordAuthentication no\n' > /etc/ssh/sshd_config.d/50-open-bastion-backend.conf
 ctl=\$(sshd -T 2>/dev/null | awk '/^passwordauthentication /{print \$2}')
 echo "with legacy 50-open-bastion-backend.conf → passwordauthentication=\$ctl (expected yes: proves ordering matters)"
-[ "\$ctl" = "yes" ] || echo "NOTE: negative control unexpectedly \$ctl"
+[ "\$ctl" = "yes" ] || { echo "FAIL: negative control expected yes, got \$ctl — ordering is NOT what defeats cloud-init, test is not proving the regression"; exit 1; }
 echo "PRECEDENCE_OK"
 DRIVER
 

--- a/tests/test_sshd_dropin_precedence.sh
+++ b/tests/test_sshd_dropin_precedence.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+#
+# test_sshd_dropin_precedence.sh
+#
+# Regression test for the cert-only lockdown being silently defeated by a
+# distro sshd drop-in. Cloud images ship /etc/ssh/sshd_config.d/50-cloud-init.conf
+# with `PasswordAuthentication yes`. sshd uses the FIRST value seen for keywords
+# like PasswordAuthentication, and Include expands the drop-in dir alphabetically,
+# so the open-bastion drop-in MUST sort before 50-cloud-init.conf or its
+# `PasswordAuthentication no` loses and password auth stays enabled.
+#
+# This test extracts the drop-in file name the setup scripts actually write and
+# asserts, via a real `sshd -T`, that with a competing 50-cloud-init.conf the
+# resolved PasswordAuthentication is `no`. A negative control with the legacy
+# 50- name proves the ordering is what matters.
+#
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+fail=0
+
+# Drop-in names the setup scripts write (so a future rename back to 50- fails here).
+bastion_dropin=$(grep -oE '[0-9]+-open-bastion-bastion\.conf' "$SCRIPT_DIR/scripts/ob-bastion-setup" | head -1)
+backend_dropin=$(grep -oE '[0-9]+-open-bastion-backend\.conf' "$SCRIPT_DIR/scripts/ob-backend-setup" | head -1)
+echo "bastion drop-in: $bastion_dropin"
+echo "backend drop-in: $backend_dropin"
+
+# Static check: must sort before 50-cloud-init.conf.
+for d in "$bastion_dropin" "$backend_dropin"; do
+    first=$(printf '%s\n50-cloud-init.conf\n' "$d" | LC_ALL=C sort | head -1)
+    if [ "$first" = "$d" ] && [ "$d" != "50-cloud-init.conf" ]; then
+        echo "ok   $d sorts before 50-cloud-init.conf"
+    else
+        echo "FAIL $d does NOT sort before 50-cloud-init.conf (password auth would stay enabled)"
+        fail=1
+    fi
+done
+
+if ! command -v docker >/dev/null 2>&1; then
+    echo "SKIP: docker not available — static ordering check only"
+    exit $fail
+fi
+
+# Dynamic check: real sshd -T with both drop-ins present.
+RUNNER=$(mktemp)
+trap 'rm -f "$RUNNER"' EXIT
+cat > "$RUNNER" <<DRIVER
+set -e
+export DEBIAN_FRONTEND=noninteractive
+apt-get update -qq >/dev/null && apt-get install -y -qq openssh-server >/dev/null
+mkdir -p /etc/ssh/sshd_config.d /run/sshd
+grep -q "Include /etc/ssh/sshd_config.d" /etc/ssh/sshd_config || \
+    sed -i '1i Include /etc/ssh/sshd_config.d/*.conf' /etc/ssh/sshd_config
+
+# Distro drop-in enabling password auth (as cloud-init does).
+printf 'PasswordAuthentication yes\n' > /etc/ssh/sshd_config.d/50-cloud-init.conf
+
+# open-bastion drop-in at the REAL name, disabling it.
+printf 'PasswordAuthentication no\nKbdInteractiveAuthentication no\n' \
+    > "/etc/ssh/sshd_config.d/$backend_dropin"
+got=\$(sshd -T 2>/dev/null | awk '/^passwordauthentication /{print \$2}')
+echo "with $backend_dropin → passwordauthentication=\$got"
+[ "\$got" = "no" ] || { echo "FAIL: password auth not disabled"; exit 1; }
+
+# Negative control: legacy 50- name loses to 50-cloud-init.conf.
+rm -f "/etc/ssh/sshd_config.d/$backend_dropin"
+printf 'PasswordAuthentication no\n' > /etc/ssh/sshd_config.d/50-open-bastion-backend.conf
+ctl=\$(sshd -T 2>/dev/null | awk '/^passwordauthentication /{print \$2}')
+echo "with legacy 50-open-bastion-backend.conf → passwordauthentication=\$ctl (expected yes: proves ordering matters)"
+[ "\$ctl" = "yes" ] || echo "NOTE: negative control unexpectedly \$ctl"
+echo "PRECEDENCE_OK"
+DRIVER
+
+echo "=== sshd drop-in precedence e2e (docker) ==="
+out=$(docker run --rm -v "$RUNNER":/run.sh:ro debian:trixie bash /run.sh 2>&1)
+echo "$out"
+echo "$out" | grep -q "PRECEDENCE_OK" || fail=1
+
+[ "$fail" -eq 0 ] && echo "PASS: open-bastion sshd drop-in wins the PasswordAuthentication race" \
+                  || echo "FAIL: drop-in precedence regression"
+exit $fail


### PR DESCRIPTION
## Problem (found during lab validation)

`sshd -T` on a freshly-deployed bastion **and** backends showed `passwordauthentication yes` — the cert-only lockdown (R-S1) was silently defeated. A plain `ssh user@host` without a cert fell back to a **password prompt** instead of being refused.

Root cause: cloud images ship `/etc/ssh/sshd_config.d/50-cloud-init.conf` containing `PasswordAuthentication yes`. sshd uses the **first** value seen for keywords like `PasswordAuthentication` / `PermitRootLogin` / `KbdInteractiveAuthentication`, and the `Include` directory is read alphabetically. The setup scripts wrote `50-open-bastion-<role>.conf`, which sorts **after** `50-cloud-init.conf` (`c` < `o`), so cloud-init's `yes` won and our `no` was ignored.

## Fix

Write the drop-in as **`00-open-bastion-<role>.conf`** so it is read before any distro drop-in and the open-bastion hardening (`PasswordAuthentication no`, `PermitRootLogin no`, `KbdInteractiveAuthentication no`, …) wins. The legacy `50-` file is removed on re-run.

## Regression test — `tests/test_sshd_dropin_precedence.sh`

- Extracts the drop-in name the setup scripts actually write (so a future rename back to `50-` fails the test) and asserts it sorts before `50-cloud-init.conf`.
- In docker, with both drop-ins present, a real `sshd -T` confirms `passwordauthentication=no`; a negative control with the legacy `50-` name yields `yes`, proving the ordering is the cause.

## Lab validation (3 VMs, all carrying cloud-init's `50-cloud-init.conf`)

After deploy: `sshd -T` → `passwordauthentication no` on bastion + both backends; the `50-` drop-in is gone (replaced by `00-`); the cert hop bastion→backend still works; and `ssh dwho@host` **without** a cert is now refused (`Permission denied (publickey)`) with no password fallback.

Independent of the `/var` token MR (#123); this is a pre-existing hardening gap in `ob-bastion-setup` / `ob-backend-setup`.