### PR TITLE
fix(nss): reload server token on rotation; don't negative-cache transient 401s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **NSS module kept serving a stale access token after rotation.**
+  `libnss_openbastion` loaded the server token once per process and never
+  re-read it, so once `ob-heartbeat` rotated the token the cached value
+  expired and the portal answered `401`. That was treated as
+  "user not found", poisoning the (nscd) negative cache and breaking
+  `getent passwd` / SSH logins roughly once per access-token lifetime until
+  the resolver was restarted. The module now reloads the token when its mtime
+  changes and distinguishes an authoritative "not found" from a transient
+  error (HTTP ≠ 200 / curl failure): transient errors trigger a reload+retry
+  and return `EAGAIN` / `NSS_STATUS_UNAVAIL` instead of being cached as a miss.
 - **sshd hardening drop-in could be silently overridden by cloud-init.** Cloud
   images ship `/etc/ssh/sshd_config.d/50-cloud-init.conf` with
   `PasswordAuthentication yes`, and sshd keeps the *first* value seen while

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,10 +21,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and return `EAGAIN` / `NSS_STATUS_UNAVAIL` instead of being cached as a miss.
 - **sshd hardening drop-in could be silently overridden by cloud-init.** Cloud
   images ship `/etc/ssh/sshd_config.d/50-cloud-init.conf` with
-  `PasswordAuthentication yes`, and sshd keeps the *first* value seen while
+  `PasswordAuthentication yes`, and sshd keeps the _first_ value seen while
   `Include` expands the drop-in directory alphabetically. The open-bastion
   drop-in was written as `50-open-bastion-{bastion,backend}.conf`, which sorts
-  *after* `50-cloud-init.conf`, so password authentication stayed enabled on
+  _after_ `50-cloud-init.conf`, so password authentication stayed enabled on
   freshly provisioned bastions and backends. `ob-bastion-setup` /
   `ob-backend-setup` now write `00-open-bastion-{bastion,backend}.conf` (and
   remove the legacy `50-` file on rerun) so the cert-only lockdown wins.

--- a/doc/admin-guide.md
+++ b/doc/admin-guide.md
@@ -819,16 +819,16 @@ journalctl -u sshd | grep "SSH key policy"
 
 ### File Locations
 
-| File                                      | Purpose                              |
-| ----------------------------------------- | ------------------------------------ |
-| `/etc/open-bastion/openbastion.conf`      | PAM module configuration             |
+| File                                      | Purpose                                                            |
+| ----------------------------------------- | ------------------------------------------------------------------ |
+| `/etc/open-bastion/openbastion.conf`      | PAM module configuration                                           |
 | `/var/lib/open-bastion/token`             | Server enrollment token (runtime state, refreshed by ob-heartbeat) |
-| `/etc/open-bastion/nss_openbastion.conf`  | NSS module configuration             |
-| `/etc/open-bastion/session-recorder.conf` | Session recorder configuration       |
-| `/etc/open-bastion/ssh-proxy.conf`        | SSH proxy configuration (bastion)    |
-| `/var/lib/open-bastion/sessions/`         | Session recordings                   |
-| `/etc/open-bastion/allowed_bastions`      | Allowed bastion client_ids (backend) |
-| `/var/log/open-bastion/audit.json`        | Audit log                            |
+| `/etc/open-bastion/nss_openbastion.conf`  | NSS module configuration                                           |
+| `/etc/open-bastion/session-recorder.conf` | Session recorder configuration                                     |
+| `/etc/open-bastion/ssh-proxy.conf`        | SSH proxy configuration (bastion)                                  |
+| `/var/lib/open-bastion/sessions/`         | Session recordings                                                 |
+| `/etc/open-bastion/allowed_bastions`      | Allowed bastion client_ids (backend)                               |
+| `/var/log/open-bastion/audit.json`        | Audit log                                                          |
 
 ### Commands
 

--- a/nss/libnss_openbastion.c
+++ b/nss/libnss_openbastion.c
@@ -67,6 +67,7 @@ typedef struct {
     char *portal_url;
     char *server_token_file;
     char *server_token;
+    time_t server_token_mtime;    /* mtime of server_token_file at last load */
     int timeout;
     int verify_ssl;
     int cache_ttl;
@@ -374,29 +375,51 @@ static int load_server_token(nss_llng_config_t *config)
         buffer[--len] = '\0';
     }
 
-    /* Try to parse as JSON first (format: {"access_token": "..."}) */
+    /* Parse the NEW token into a local first; only swap it in on success so a
+     * reload that hits a transiently bad/partial file keeps the old token. */
+    char *new_token = NULL;
     struct json_object *json = json_tokener_parse(buffer);
     if (json) {
         struct json_object *token_obj;
         if (json_object_object_get_ex(json, "access_token", &token_obj)) {
             const char *token = json_object_get_string(token_obj);
-            if (token) {
-                free(config->server_token);
-                config->server_token = strdup(token);
-            }
+            if (token) new_token = strdup(token);
         }
         json_object_put(json);
     }
-
     /* If JSON parsing failed or no access_token found, treat as plain token */
-    if (!config->server_token && len > 0) {
-        config->server_token = strdup(buffer);
+    if (!new_token && len > 0) {
+        new_token = strdup(buffer);
     }
 
     /* Clear sensitive token from stack buffer */
     explicit_bzero(buffer, sizeof(buffer));
 
-    return config->server_token ? 0 : -1;
+    if (!new_token) return -1;          /* keep any previously loaded token */
+    free(config->server_token);
+    config->server_token = new_token;
+    /* Remember the file's mtime so callers can detect rotation by ob-heartbeat
+     * and reload, instead of caching a stale (soon-expired) access token for
+     * the whole process lifetime. */
+    config->server_token_mtime = st.st_mtime;
+    return 0;
+}
+
+/* Reload the server token if the token file changed on disk since last load
+ * (ob-heartbeat rotates it every few minutes). Long-running NSS consumers like
+ * nscd otherwise keep using the first token they loaded; once it expires the
+ * LLNG calls 401 and users stop resolving until the consumer is restarted. */
+static void maybe_reload_server_token(void)
+{
+    if (!g_config.server_token_file) return;
+    struct stat st;
+    if (stat(g_config.server_token_file, &st) != 0) return;
+    if (st.st_mtime == g_config.server_token_mtime) return;
+    pthread_mutex_lock(&g_init_lock);
+    if (st.st_mtime != g_config.server_token_mtime) {
+        load_server_token(&g_config);
+    }
+    pthread_mutex_unlock(&g_init_lock);
 }
 
 /* Load configuration */
@@ -1098,12 +1121,25 @@ static int query_llng_userinfo(const char *username, struct passwd *pw,
     }
 
     CURLcode res = curl_easy_perform(curl);
+    long http_code = 0;
+    curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &http_code);
 
     curl_slist_free_all(headers);
     json_object_put(req_json);
     curl_easy_cleanup(curl);
 
+    /* Return convention: 0 = found, 1 = authoritatively not found (HTTP 200
+     * with found=false), -1 = transient/unavailable (network error, 401/403
+     * from a stale token, 5xx, unparseable). Only an authoritative not-found
+     * may be negatively cached; -1 must NOT poison the cache and lets the
+     * caller reload the token and retry. */
     if (res != CURLE_OK || !response.data) {
+        free(response.data);
+        return -1;
+    }
+    if (http_code != 200) {
+        /* 401/403 = stale/invalid token, 5xx = server, 404/other = unexpected:
+         * all transient from NSS's point of view. */
         free(response.data);
         return -1;
     }
@@ -1124,7 +1160,7 @@ static int query_llng_userinfo(const char *username, struct passwd *pw,
 
     if (!found) {
         json_object_put(json);
-        return -1;
+        return 1;    /* authoritative "no such user" → safe to negative-cache */
     }
 
     /* Extract user info with safe bounds checking */
@@ -1374,8 +1410,23 @@ NSS_VISIBLE enum nss_status _nss_openbastion_getpwnam_r(const char *name,
         return NSS_STATUS_SUCCESS;
     }
 
-    /* Query LLNG server */
-    if (query_llng_userinfo(name, result, buffer, buflen) == 0) {
+    /* Pick up a token rotated by ob-heartbeat before querying, so a long-lived
+     * consumer (nscd) never queries LLNG with a stale, soon-401 token. */
+    maybe_reload_server_token();
+
+    /* Query LLNG server. On a transient failure (-1) the likeliest cause is a
+     * token that rotated between the reload above and the call (or a brief
+     * server hiccup): force a reload and retry once. Never negative-cache a
+     * transient failure. */
+    int qr = query_llng_userinfo(name, result, buffer, buflen);
+    if (qr < 0) {
+        pthread_mutex_lock(&g_init_lock);
+        load_server_token(&g_config);
+        pthread_mutex_unlock(&g_init_lock);
+        qr = query_llng_userinfo(name, result, buffer, buflen);
+    }
+
+    if (qr == 0) {
         /* Add to memory cache */
         cache_add(name, result, 1);
         /* Also save to file cache for cross-process UID lookups */
@@ -1384,11 +1435,20 @@ NSS_VISIBLE enum nss_status _nss_openbastion_getpwnam_r(const char *name,
         return NSS_STATUS_SUCCESS;
     }
 
-    /* Not found - cache negative result */
-    cache_add(name, NULL, 0);
+    if (qr == 1) {
+        /* Authoritative "no such user" — safe to negative-cache. */
+        cache_add(name, NULL, 0);
+        g_in_nss_lookup = 0;
+        *errnop = ENOENT;
+        return NSS_STATUS_NOTFOUND;
+    }
+
+    /* qr < 0: transient/unavailable (network, persistent 401, 5xx). Do NOT
+     * cache, and return UNAVAIL so nscd does not store an authoritative
+     * negative that would lock the user out until nscd is restarted. */
     g_in_nss_lookup = 0;
-    *errnop = ENOENT;
-    return NSS_STATUS_NOTFOUND;
+    *errnop = EAGAIN;
+    return NSS_STATUS_UNAVAIL;
 }
 
 /* NSS entry point: getpwuid_r */

--- a/nss/libnss_openbastion.c
+++ b/nss/libnss_openbastion.c
@@ -411,13 +411,18 @@ static int load_server_token(nss_llng_config_t *config)
  * LLNG calls 401 and users stop resolving until the consumer is restarted. */
 static void maybe_reload_server_token(void)
 {
-    if (!g_config.server_token_file) return;
-    struct stat st;
-    if (stat(g_config.server_token_file, &st) != 0) return;
-    if (st.st_mtime == g_config.server_token_mtime) return;
+    /* The whole stat() + mtime comparison + reload runs under g_init_lock:
+     * server_token_mtime is written under that lock by load_server_token(), so
+     * reading it (or the token pointer) outside the lock would be a data race,
+     * and a pre-lock stat() could also miss a rotation that lands between the
+     * stat() and acquiring the lock. stat() is cheap enough to hold the lock. */
     pthread_mutex_lock(&g_init_lock);
-    if (st.st_mtime != g_config.server_token_mtime) {
-        load_server_token(&g_config);
+    if (g_config.server_token_file) {
+        struct stat st;
+        if (stat(g_config.server_token_file, &st) == 0 &&
+            st.st_mtime != g_config.server_token_mtime) {
+            load_server_token(&g_config);
+        }
     }
     pthread_mutex_unlock(&g_init_lock);
 }
@@ -1073,12 +1078,29 @@ static int query_service_account(const char *username, struct passwd *pw,
 static int query_llng_userinfo(const char *username, struct passwd *pw,
                                 char *buffer, size_t buflen)
 {
-    if (!g_config.portal_url || !g_config.server_token) {
+    if (!g_config.portal_url) {
+        return -1;
+    }
+
+    /* Snapshot the server token under g_init_lock. A concurrent
+     * maybe_reload_server_token() can free and replace g_config.server_token at
+     * any time (rotation by ob-heartbeat), so reading it directly across the
+     * curl network I/O below would be a use-after-free in multi-threaded NSS
+     * consumers such as nscd. Copy it under the lock, release the lock before
+     * any I/O, and free the copy as soon as the header is built. portal_url is
+     * set once at init and never reloaded, so it needs no such guard. */
+    pthread_mutex_lock(&g_init_lock);
+    char *server_token = g_config.server_token ? strdup(g_config.server_token) : NULL;
+    pthread_mutex_unlock(&g_init_lock);
+    if (!server_token) {
         return -1;
     }
 
     CURL *curl = curl_easy_init();
-    if (!curl) return -1;
+    if (!curl) {
+        free(server_token);
+        return -1;
+    }
 
     /* Build URL */
     char url[512];
@@ -1089,9 +1111,13 @@ static int query_llng_userinfo(const char *username, struct passwd *pw,
     json_object_object_add(req_json, "user", json_object_new_string(username));
     const char *req_body = json_object_to_json_string(req_json);
 
-    /* Build Authorization header */
+    /* Build Authorization header from the snapshot, then drop the token copy:
+     * auth_header now holds its own bytes and server_token is no longer needed. */
     char auth_header[512];
-    snprintf(auth_header, sizeof(auth_header), "Authorization: Bearer %s", g_config.server_token);
+    snprintf(auth_header, sizeof(auth_header), "Authorization: Bearer %s", server_token);
+    explicit_bzero(server_token, strlen(server_token));
+    free(server_token);
+    server_token = NULL;
 
     struct curl_slist *headers = NULL;
     headers = curl_slist_append(headers, "Content-Type: application/json");


### PR DESCRIPTION
## Problem (root cause of the nscd flushes during the accelerated test)

The NSS module loaded the server access token **once per process** (`ensure_initialized` sets `g_initialized` and never resets) and reused the cached `g_config.server_token` for every lookup. `ob-heartbeat` rotates that token on disk every few minutes; a long-running consumer — **nscd, the common case** — kept using the first token it loaded.

Once that token expired, every `/pam/userinfo` call returned HTTP **401**, which the module (with **no HTTP-status handling**) treated like "user not found" → `NSS_STATUS_NOTFOUND`, and negative-cached. Net effect: `getent` and SSH logins for SSO users broke **roughly once per access-token lifetime** until nscd was restarted. The short-TTL lab test made it obvious (we had to flush nscd repeatedly); on a real host with a 1 h access token it would lock users out about hourly.

## Fix (`nss/libnss_openbastion.c`)

- **Reload on rotation**: track the token file mtime; `maybe_reload_server_token()` reloads it when it changes, called before each LLNG query, so nscd always uses the current token.
- **Safe reload**: `load_server_token()` parses the new token into a local and only swaps it in on success (a transiently bad/partial file keeps the old token), and records the mtime.
- **HTTP-status aware**: `query_llng_userinfo()` captures `CURLINFO_RESPONSE_CODE` and returns 3 states — `0` found, `1` authoritative not-found (200 + `found=false`), `-1` transient (network, 401/403 stale token, 5xx, unparseable).
- **No negative cache on transient**: `getpwnam` forces a token reload + one retry on `-1`; only an authoritative not-found is negative-cached; a persistent transient failure returns `NSS_STATUS_UNAVAIL` (not `NOTFOUND`), so nscd never stores an authoritative negative that locks the user out until restart.

Builds with `-Werror`. Validated on the 3-VM lab under accelerated TTLs (access 10 min): after token rotations, `getent` keeps resolving with **no nscd flush** required.

> An automated regression needs the full LLNG + nscd stack (token rotation + delayed lookup); can be added to `test_integration_docker.sh` as a follow-up.