### PR TITLE
fix(recorder): make sessions dir traversable (3771) in postinst/%post

### DIFF
--- a/debian/open-bastion.postinst
+++ b/debian/open-bastion.postinst
@@ -164,7 +164,14 @@ case "$1" in
         groupadd --system open-bastion-sudo 2>/dev/null || true
         mkdir -p /var/lib/open-bastion/sessions
         chgrp ob-sessions /var/lib/open-bastion/sessions
-        chmod 1770 /var/lib/open-bastion/sessions
+        # Mode 3771 (drwxrws--t root:ob-sessions): setgid so per-user subdirs
+        # inherit group ob-sessions; sticky so users only unlink their own
+        # entries; o+x (NO o+r) so a connecting user — who is NOT in ob-sessions
+        # and whose elevated gid the recorder wrapper deliberately drops before
+        # exec — can still traverse into its own subdir created by the wrapper.
+        # Without o+x the recorder fails with "session directory ... does not
+        # exist and could not be created" and the session is torn down.
+        chmod 3771 /var/lib/open-bastion/sessions
         # Set setgid on the session recorder wrapper so it runs with gid ob-sessions
         if [ -f /usr/sbin/ob-session-recorder-wrapper ]; then
             chgrp ob-sessions /usr/sbin/ob-session-recorder-wrapper

--- a/rpm/open-bastion.spec
+++ b/rpm/open-bastion.spec
@@ -157,7 +157,13 @@ mkdir -p /var/lib/open-bastion
 chmod 711 /var/lib/open-bastion
 mkdir -p /var/lib/open-bastion/sessions
 chgrp ob-sessions /var/lib/open-bastion/sessions
-chmod 1770 /var/lib/open-bastion/sessions
+# Mode 3771 (drwxrws--t root:ob-sessions): setgid so per-user subdirs inherit
+# group ob-sessions; sticky so users only unlink their own entries; o+x (NO
+# o+r) so a connecting user — who is NOT in ob-sessions and whose elevated gid
+# the recorder wrapper deliberately drops before exec — can still traverse into
+# its own subdir created by the wrapper. Without o+x the recorder fails with
+# "session directory ... does not exist and could not be created".
+chmod 3771 /var/lib/open-bastion/sessions
 # Migrate the server token out of /etc (config) into /var/lib (runtime state,
 # FHS) so the heartbeat sandbox can keep /etc read-only. Idempotent.
 if [ -f /etc/open-bastion/token ] && [ ! -e /var/lib/open-bastion/token ]; then


### PR DESCRIPTION
## Problem

The session-recorder directory `/var/lib/open-bastion/sessions` is created **mode 1770** (`drwxrwx--T`) by the Debian `postinst` and the RPM `%post`.

`ob-session-recorder-wrapper` (setgid `ob-sessions`) creates the per-user subdir, then **deliberately drops the elevated gid** (`setregid`) before exec'ing the recorder — so the recorder runs with the *connecting user's* gid, not `ob-sessions`. With the parent at 1770 (no `o+x` for others), that de-privileged process **cannot even traverse** `sessions/` to reach its own subdir. `ensure_sessions_dir()` then fails with:

```
User sessions directory /var/lib/open-bastion/sessions/<user> does not exist and could not be created
```

and the SSH session is torn down (`exit status 1`) — the user can authenticate but every session dies.

`ob-bastion-setup` already creates this directory **3771** with exactly this rationale, but the package maintainer scripts use 1770, so **reinstalling or upgrading the package re-runs the maintainer script and resets it to 1770**, silently breaking logins on any bastion that records sessions.

## Fix

Align `debian/open-bastion.postinst` and `rpm/open-bastion.spec` `%post` with `ob-bastion-setup`: **`chmod 3771`** (setgid + sticky + `o+x`, no `o+r`). The `o+x` exposes only *traversal*; per-user subdirs stay `2770` owned `user:ob-sessions`, so users still cannot list or enter each other's recordings.

## Validation

Reproduced and fixed on the 3-VM lab: with `sessions/` at 1770 the recorder tore down dwho's session; after `chmod 3771` dwho logs in cleanly **with the recorder active** and the per-user recording dir is created by the wrapper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)