### PR TITLE
doc: Ansible quick-start (generate roles with ob-builder, declare IPs, apply)

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ See the full [documentation index](doc/README.md) or jump directly to:
 | [Security Features](doc/security.md)                     | Key policies, rate limiting, audit        |
 | [Admin Guide](doc/admin-guide.md)                        | Complete administration guide             |
 | [Deployment Builder](admin-builder/README.md)            | Generate shell / Ansible deploy artefacts |
+| [Ansible Quick-start](doc/ansible-quickstart.md)         | Generate + apply roles, fleet deployment  |
 
 ## Troubleshooting
 

--- a/doc/README.md
+++ b/doc/README.md
@@ -7,6 +7,7 @@
 | [LemonLDAP::NG Configuration](llng-configuration.md) | Server-side LLNG setup and plugins     |
 | [PAM Authentication Modes](pam-modes.md)             | All 4 PAM configurations with examples |
 | [Configuration Reference](configuration.md)          | All configuration options              |
+| [Ansible Quick-start](ansible-quickstart.md)         | Generate + apply roles with ob-builder |
 
 ## Features
 

--- a/doc/ansible-quickstart.md
+++ b/doc/ansible-quickstart.md
@@ -1,0 +1,189 @@
+# Quick-start: deploy Open Bastion with Ansible
+
+This guide takes you from nothing to a working bastion + backends fleet using
+`ob-builder` to generate the Ansible artefacts and a single `ansible-playbook`
+run to apply them.
+
+The flow is always the same three steps:
+
+1. **Generate** the role(s) with `ob-builder` (one questionnaire / config per role).
+2. **Declare your hosts** (and their IPs) in an inventory.
+3. **Apply** with `ansible-playbook`.
+
+> `ob-builder` runs **once on your workstation**. It talks to the SSO portal to
+> fetch the SSH CA public key and JWKS, then bakes them — plus your scenario,
+> client_id and APT repo — into a self-contained Ansible role. The role is then
+> pushed to the fleet; the targets never contact your workstation again.
+
+## Prerequisites
+
+- `ob-builder` on your workstation (ships in the `open-bastion-builder` package).
+- `ansible` on your workstation.
+- The Open Bastion `.deb`/`.rpm` reachable by the targets from an APT/YUM repo
+  (the default is the Linagora repo; override with `--apt-url`).
+- SSO reachable from your workstation (for the build-time OIDC discovery) **and**
+  from the targets (at run time, for enrolment).
+- SSH access from your workstation to each target as a user that can `sudo`.
+
+## Step 1 — Generate the roles
+
+A bastion and a backend differ only by `target_role` (and the backend's
+"accept only this bastion" allowlist). You can generate them in **two runs**, or
+in **one run** with `--bundle` so both share the exact same CA / JWKS.
+
+### Option A — bundle (recommended: bastion + backend share one CA)
+
+Write one `build.yml` describing the deployment, then let `--bundle` emit the
+matched pair:
+
+```yaml
+# build.yml
+deployment_slug: acme
+scenario: token-only            # token-only | token+unix | keys+llng | mixed | max-security
+portal_url: https://sso.example.com
+client_id: ob-bastion           # the bastion's OIDC client (= its bastion_id)
+client_id_policy: fixed
+client_secret_mode: prompt      # none | prompt | embedded
+server_group: bastion
+server_group_policy: fixed
+target_role: bastion            # bundle derives the matching backend automatically
+auto_enroll_setup: yes
+ansible_auto_approve: yes        # let the play approve device codes via an LLNG cookie
+apt_url: https://linagora.github.io/open-bastion
+apt_suite: trixie
+apt_component: main
+```
+
+```bash
+ob-builder --config build.yml --bundle --output-ansible ./roles-acme/
+```
+
+### Option B — two independent runs
+
+Generate the bastion role:
+
+```bash
+ob-builder --config build-bastion.yml --output-ansible ./role-bastion/
+```
+
+…and the backend role (same file, `target_role: backend`, a backend
+`server_group`, and optionally an `allowed_bastions` allowlist):
+
+```bash
+ob-builder --config build-backend.yml --output-ansible ./role-backend/
+```
+
+The generated tree contains `defaults/main.yml` (all the baked-in `ob_*`
+values), `tasks/`, `templates/` and a `files/` directory holding the SSH CA
+public key fetched from the portal. See
+[`admin-builder/templates/ansible/role/README.md`](../admin-builder/templates/ansible/role/README.md)
+for the full list of `ob_*` variables.
+
+## Step 2 — Declare your hosts and their IPs
+
+**This is where the IPs of the machines you are building go.** Create an
+`inventory.yml` next to the role and list every target under the right group —
+the bastion(s) under `bastions`, every backend under `backends`. The address of
+each machine is the `ansible_host` line:
+
+```yaml
+# inventory.yml
+all:
+  vars:
+    ansible_user: admin                 # a sudo-capable account on the targets
+    ansible_ssh_private_key_file: ~/.ssh/id_fleet
+
+  children:
+    bastions:
+      hosts:
+        bastion-1:
+          ansible_host: 10.0.0.10        # <-- IP (or DNS name) of the bastion
+          ob_role: bastion
+          ob_server_group: bastion
+          ob_client_id: ob-bastion       # this bastion's id (== client_id)
+          ob_client_secret: "{{ vault_bastion_secret }}"
+
+    backends:
+      hosts:
+        web-1:
+          ansible_host: 10.0.0.21        # <-- IP of the first backend
+          ob_role: backend
+          ob_server_group: backend
+          # "Accept only this bastion": the backend refuses any cert whose
+          # key-id does not carry bastion=<one of these ids>.
+          ob_bastion_allowed_bastions: "ob-bastion"
+        web-2:
+          ansible_host: 10.0.0.22        # <-- IP of the second backend
+          ob_role: backend
+          ob_server_group: backend
+          ob_bastion_allowed_bastions: "ob-bastion"
+```
+
+Notes:
+
+- `ansible_host` accepts an IP **or** a resolvable hostname — use whichever your
+  workstation can reach. Adding a machine to the fleet is just one more `hosts:`
+  entry with its `ansible_host`.
+- Per-host values (`ob_role`, `ob_server_group`, `ob_client_id`,
+  `ob_bastion_allowed_bastions`) override the role's baked-in defaults, so a
+  single role can drive both bastions and backends — dispatch is by `ob_role`.
+- Keep the OIDC client secret in **ansible-vault**, not in clear text. The role
+  also never persists the LLNG approval cookie (it is asked per run).
+
+A matching `playbook.yml` is trivial — apply the one role to everyone and let
+`ob_role` dispatch:
+
+```yaml
+# playbook.yml
+- hosts: all
+  become: true
+  roles:
+    - role: open-bastion
+```
+
+## Step 3 — Apply
+
+If you enabled `ansible_auto_approve: yes`, fetch a short-lived LLNG session
+cookie (it auto-approves the device-code enrolment for the whole fleet — no
+browser needed) and pass it at run time:
+
+```bash
+COOKIE=$(llng --llng-url https://sso.example.com --login admin --password '***' llng_cookie)
+
+ansible-playbook -i inventory.yml playbook.yml \
+  --ask-vault-pass \
+  --extra-vars "ob_llng_cookie='$COOKIE'"
+```
+
+Without auto-approve, omit `ob_llng_cookie`: the play prints a device URL + code
+per host for manual browser approval.
+
+Limit a run to one group or host while iterating:
+
+```bash
+ansible-playbook -i inventory.yml playbook.yml --limit bastions
+ansible-playbook -i inventory.yml playbook.yml --limit web-1
+```
+
+## What the play does on each host
+
+1. Configures the APT/YUM repo and installs the `open-bastion` package.
+2. Writes `/etc/open-bastion/openbastion.conf` from the baked-in scenario.
+3. Runs `ob-enroll` (Device Authorization Grant) to obtain the server's
+   long-lived **offline** token; `ob-heartbeat.timer` then keeps the short-lived
+   access token fresh.
+4. Runs `ob-bastion-setup` / `ob-backend-setup`, which locks SSH down to
+   SSO-issued certificates and — on backends — enforces the
+   `allowed_bastions` policy (a backend accepts only certificates vouched by a
+   listed bastion).
+
+After the play, users connect with their SSO certificate to a bastion, then hop
+to any backend with `ob-ssh <backend>` (or copy files with `ob-scp`); the
+bastion mints a short-lived, CA-signed certificate for each hop. No user key
+ever lands on the bastion or the backends.
+
+## Updating the fleet
+
+Re-running the playbook is idempotent: bump the package in your repo and run
+again to upgrade, or change a host's `ob_*` vars and re-apply to reconfigure.
+Adding a server is one new inventory entry plus a `--limit <newhost>` run.

--- a/doc/ansible-quickstart.md
+++ b/doc/ansible-quickstart.md
@@ -145,7 +145,8 @@ A matching `playbook.yml` is trivial — apply the one role to everyone and let
 
 If you enabled `ansible_auto_approve: yes`, fetch a short-lived LLNG session
 cookie (it auto-approves the device-code enrolment for the whole fleet — no
-browser needed) and pass it at run time:
+browser needed) and pass it at run time. The `llng` CLI comes from
+[simple-oidc-client](https://github.com/linagora/simple-oidc-client):
 
 ```bash
 COOKIE=$(llng --llng-server sso.example.com --login admin --password '***' llng_cookie)
@@ -158,6 +159,15 @@ ansible-playbook -i inventory.yml playbook.yml \
 `--llng-server` takes a **server name** (not a URL) and assumes **HTTPS** — the
 production case. For a plain `http://` test SSO, pass the full URL instead with
 `--llng-url http://sso.test`.
+
+If your portal is built with a **choice** module (a login form offering several
+authentication backends), tell `llng` which one to use with `--choice`, e.g.
+`--choice lmAuth=1_LDAP` (replace `1_LDAP` with your backend's key):
+
+```bash
+COOKIE=$(llng --llng-server sso.example.com --choice lmAuth=1_LDAP \
+              --login admin --password '***' llng_cookie)
+```
 
 Without auto-approve, omit `ob_llng_cookie`: the play prints a device URL + code
 per host for manual browser approval.

--- a/doc/ansible-quickstart.md
+++ b/doc/ansible-quickstart.md
@@ -148,12 +148,16 @@ cookie (it auto-approves the device-code enrolment for the whole fleet — no
 browser needed) and pass it at run time:
 
 ```bash
-COOKIE=$(llng --llng-url https://sso.example.com --login admin --password '***' llng_cookie)
+COOKIE=$(llng --llng-server sso.example.com --login admin --password '***' llng_cookie)
 
 ansible-playbook -i inventory.yml playbook.yml \
   --ask-vault-pass \
   --extra-vars "ob_llng_cookie='$COOKIE'"
 ```
+
+`--llng-server` takes a **server name** (not a URL) and assumes **HTTPS** — the
+production case. For a plain `http://` test SSO, pass the full URL instead with
+`--llng-url http://sso.test`.
 
 Without auto-approve, omit `ob_llng_cookie`: the play prints a device URL + code
 per host for manual browser approval.


### PR DESCRIPTION
## Quick-start: deploy Open Bastion with Ansible

Adds `doc/ansible-quickstart.md`, a focused walkthrough of the fleet workflow that was previously only implicit in the `ob-builder` README.

Three steps:
1. **Generate** the bastion + backend roles with `ob-builder` — either `--bundle` (both share one CA/JWKS) or two independent `--config` runs.
2. **Declare hosts and their IPs** in `inventory.yml`: each target's address is its `ansible_host:` line, under `bastions` or `backends`. This is the part admins kept asking about — it's now called out explicitly with examples.
3. **Apply** with a single `ansible-playbook` run, including unattended device-code auto-approval via a short-lived LLNG cookie.

Also documents what the play does on each host (repo → package → `ob-enroll` + heartbeat → `ob-*-setup` lockdown / `allowed_bastions`) and how to update/extend the fleet.

Deliberately omits the `:2222` escape-hatch sshd — that's a lab debug aid, not part of a real deployment.

Linked from `doc/README.md`.