### PR TITLE
fix(ob-builder): fail fast when no output target is given

### DIFF
--- a/admin-builder/ob-builder
+++ b/admin-builder/ob-builder
@@ -636,10 +636,7 @@ validate_inputs() {
         fi
     fi
     [ -f "$REPO_KEYRING" ] || die "Repo keyring not found: $REPO_KEYRING"
-
-    if [ -z "$OUTPUT_SHELL" ] && [ -z "$OUTPUT_ANSIBLE" ]; then
-        die "At least one of --output-shell or --output-ansible is required"
-    fi
+    # (output-target presence is checked fail-fast in main(), before this.)
 }
 
 # Print a recap before doing any work — last chance for the admin to bail.
@@ -1249,6 +1246,13 @@ main() {
     ob_init_tmpdir_trap
 
     parse_args "$@"
+
+    # Fail fast: ob-builder produces nothing without an output target. Check
+    # this BEFORE the interactive questionnaire / config load so the admin is
+    # not made to answer every question only to be rejected at the end.
+    if [ -z "$OUTPUT_SHELL" ] && [ -z "$OUTPUT_ANSIBLE" ]; then
+        die "At least one of --output-shell or --output-ansible is required (nothing to produce otherwise). See --help."
+    fi
 
     if [ -n "$CONFIG_FILE" ]; then
         load_config "$CONFIG_FILE"


### PR DESCRIPTION
Running `ob-builder` without `--output-shell` or `--output-ansible` produces nothing, but the guard lived in `validate_inputs` — *after* the interactive questionnaire. So the admin answered every prompt only to be rejected at the end (in interactive mode it looked like it just ran and did nothing).

Move the "at least one output is required" check to right after `parse_args` in `main()`, so it fails immediately with a clear, actionable message before any questionnaire/config work. Drop the now-redundant late check in `validate_inputs`.

Verified: `ob-builder` with no output target now exits 1 immediately (no questionnaire); a valid `--output-shell …` invocation passes the guard.