### PR TITLE
fix(ob-builder): generated Ansible role deploys non-interactively (--client-id + approve reachability)

### DIFF
--- a/admin-builder/templates/ansible/role/defaults/main.yml.in
+++ b/admin-builder/templates/ansible/role/defaults/main.yml.in
@@ -19,6 +19,11 @@ ob_max_security: @@MAX_SECURITY_BOOL@@  # true when ob_pam_mode == E
 # ── OIDC / portal settings ────────────────────────────────────────────────────
 ob_portal_url: "@@PORTAL_URL@@"
 ob_client_id: "@@CLIENT_ID@@"
+# Verify the portal's TLS certificate. Keep true in production (HTTPS portal).
+# Set false ONLY for a plain-http or self-signed test portal: it makes
+# ob-*-setup pass --insecure and writes verify_ssl=false so pam_openbastion
+# accepts the non-HTTPS portal (it refuses http unless verify_ssl is false).
+ob_verify_ssl: true
 # ob_client_secret — provided at runtime when client_secret_mode=prompt
 # (use ansible-vault), or baked here when client_secret_mode=embedded.
 # Embedded mode trades convenience for risk: anyone with read access to this
@@ -57,6 +62,15 @@ ob_disable_session_recorder: @@DISABLE_SESSION_RECORDER_BOOL@@
 # never persisted to disk. Falls back to the manual flow if the cookie is empty.
 ob_ansible_auto_approve: @@ANSIBLE_AUTO_APPROVE_BOOL@@
 ob_llng_cookie: ""
+
+# Controller-side approval reachability override (optional). The device-code
+# approval runs on the Ansible control node and talks to the portal directly.
+# By default it uses ob_portal_url. Set these only when the control node reaches
+# the portal at a different address than the managed hosts do (split-horizon
+# DNS, NAT, a lab behind a gateway):
+#   ob_approve_base_url: base URL the controller uses, e.g. "http://10.0.0.1"
+#   ob_approve_host:     Host: header to send (the portal's vhost name)
+# Left unset here so the portal URL is used unchanged.
 
 # ── APT repository ────────────────────────────────────────────────────────────
 ob_apt_sources_list_line: "@@APT_SOURCES_LIST@@"

--- a/admin-builder/templates/ansible/role/tasks/_enroll.yml.in
+++ b/admin-builder/templates/ansible/role/tasks/_enroll.yml.in
@@ -55,12 +55,17 @@
     _ob_enroll_state: "{{ _ob_enroll_state_raw.content | b64decode | from_json }}"
   when: _ob_use_auto_approve
 
+# The controller approves the device code by talking to the portal directly.
+# By default that is ob_portal_url, but the control node may reach the portal
+# at a different address than the target servers do (split-horizon DNS, NAT, a
+# lab behind a gateway). Override with ob_approve_base_url (+ ob_approve_host
+# for the Host: header) in that case; both default to the portal URL / no
+# override, so normal deployments are unaffected.
 - name: "Controller: fetch the /device page to obtain the CSRF token"
   ansible.builtin.uri:
-    url: "{{ _ob_enroll_state.portal_url }}/device?user_code={{ _ob_enroll_state.user_code | urlencode }}"
+    url: "{{ ob_approve_base_url | default(_ob_enroll_state.portal_url) }}/device?user_code={{ _ob_enroll_state.user_code | urlencode }}"
     method: GET
-    headers:
-      Cookie: "{{ ob_llng_cookie }}"
+    headers: "{{ {'Cookie': ob_llng_cookie} | combine({'Host': ob_approve_host} if (ob_approve_host | default('')) | length > 0 else {}) }}"
     return_content: true
     follow_redirects: all
     status_code: [200]
@@ -84,7 +89,7 @@
 - name: "Refuse to proceed when the CSRF token could not be extracted (cookie expired?)"
   ansible.builtin.fail:
     msg: >-
-      Could not extract CSRF token from {{ _ob_enroll_state.portal_url }}/device.
+      Could not extract CSRF token from {{ ob_approve_base_url | default(_ob_enroll_state.portal_url) }}/device.
       The LLNG session cookie is likely expired or lacks permission. Obtain a
       fresh cookie with `llng --llng-server <portal> llng_cookie` and re-run.
   when:
@@ -93,15 +98,14 @@
 
 - name: "Controller: approve the device code"
   ansible.builtin.uri:
-    url: "{{ _ob_enroll_state.portal_url }}/device"
+    url: "{{ ob_approve_base_url | default(_ob_enroll_state.portal_url) }}/device"
     method: POST
     body_format: form-urlencoded
     body:
       user_code: "{{ _ob_enroll_state.user_code }}"
       action: approve
       token: "{{ _ob_csrf_token }}"
-    headers:
-      Cookie: "{{ ob_llng_cookie }}"
+    headers: "{{ {'Cookie': ob_llng_cookie} | combine({'Host': ob_approve_host} if (ob_approve_host | default('')) | length > 0 else {}) }}"
     follow_redirects: none
     status_code: [200, 302]
   delegate_to: localhost

--- a/admin-builder/templates/ansible/role/tasks/_enroll.yml.in
+++ b/admin-builder/templates/ansible/role/tasks/_enroll.yml.in
@@ -55,6 +55,16 @@
     _ob_enroll_state: "{{ _ob_enroll_state_raw.content | b64decode | from_json }}"
   when: _ob_use_auto_approve
 
+- name: "Resolve the controller-side approval base URL (normalised)"
+  ansible.builtin.set_fact:
+    # default(..., true) so an EMPTY ob_approve_base_url still falls back to the
+    # portal URL (not a relative '/device'); strip trailing slash(es) so we
+    # never build '//device'.
+    _ob_approve_base: >-
+      {{ (ob_approve_base_url | default(_ob_enroll_state.portal_url, true))
+         | regex_replace('/+$', '') }}
+  when: _ob_use_auto_approve
+
 # The controller approves the device code by talking to the portal directly.
 # By default that is ob_portal_url, but the control node may reach the portal
 # at a different address than the target servers do (split-horizon DNS, NAT, a
@@ -63,7 +73,7 @@
 # override, so normal deployments are unaffected.
 - name: "Controller: fetch the /device page to obtain the CSRF token"
   ansible.builtin.uri:
-    url: "{{ ob_approve_base_url | default(_ob_enroll_state.portal_url) }}/device?user_code={{ _ob_enroll_state.user_code | urlencode }}"
+    url: "{{ _ob_approve_base }}/device?user_code={{ _ob_enroll_state.user_code | urlencode }}"
     method: GET
     headers: "{{ {'Cookie': ob_llng_cookie} | combine({'Host': ob_approve_host} if (ob_approve_host | default('')) | length > 0 else {}) }}"
     return_content: true
@@ -89,7 +99,7 @@
 - name: "Refuse to proceed when the CSRF token could not be extracted (cookie expired?)"
   ansible.builtin.fail:
     msg: >-
-      Could not extract CSRF token from {{ ob_approve_base_url | default(_ob_enroll_state.portal_url) }}/device.
+      Could not extract CSRF token from {{ _ob_approve_base }}/device.
       The LLNG session cookie is likely expired or lacks permission. Obtain a
       fresh cookie with `llng --llng-server <portal> llng_cookie` and re-run.
   when:
@@ -98,7 +108,7 @@
 
 - name: "Controller: approve the device code"
   ansible.builtin.uri:
-    url: "{{ ob_approve_base_url | default(_ob_enroll_state.portal_url) }}/device"
+    url: "{{ _ob_approve_base }}/device"
     method: POST
     body_format: form-urlencoded
     body:

--- a/admin-builder/templates/ansible/role/tasks/backend.yml.in
+++ b/admin-builder/templates/ansible/role/tasks/backend.yml.in
@@ -21,7 +21,9 @@
         ['/usr/sbin/ob-backend-setup',
          '--portal', ob_portal_url,
          '-g', ob_server_group,
+         '-c', ob_client_id,
          '--yes']
+        + (['--insecure'] if not (ob_verify_ssl | default(true)) else [])
         + (['--allowed-bastions', ob_bastion_allowed_bastions]
            if ob_bastion_allowed_bastions is defined else [])
         + (['--max-security'] if ob_max_security else [])

--- a/admin-builder/templates/ansible/role/tasks/bastion.yml.in
+++ b/admin-builder/templates/ansible/role/tasks/bastion.yml.in
@@ -21,7 +21,9 @@
         ['/usr/sbin/ob-bastion-setup',
          '--portal', ob_portal_url,
          '-g', ob_server_group,
+         '-c', ob_client_id,
          '--yes']
+        + (['--insecure'] if not (ob_verify_ssl | default(true)) else [])
         + (['--max-security'] if ob_max_security else [])
         + (['--enable-hardening'] if ob_enable_hardening else [])
         + (['--enable-audit-trace'] if ob_enable_audit_trace else [])

--- a/admin-builder/templates/ansible/role/tasks/standalone.yml.in
+++ b/admin-builder/templates/ansible/role/tasks/standalone.yml.in
@@ -25,7 +25,9 @@
         ['/usr/sbin/ob-bastion-setup',
          '--portal', ob_portal_url,
          '-g', ob_server_group,
+         '-c', ob_client_id,
          '--yes']
+        + (['--insecure'] if not (ob_verify_ssl | default(true)) else [])
         + (['--max-security'] if ob_max_security else [])
         + (['--enable-hardening'] if ob_enable_hardening else [])
         + (['--enable-audit-trace'] if ob_enable_audit_trace else [])


### PR DESCRIPTION
Found by an end-to-end lab deploy of an **ob-builder-generated** role (pristine, `auto_enroll: yes` + `auto_setup: yes`, fully unattended). Two gaps blocked the generated role from deploying as documented in the Ansible quick-start:

### 1. `ob-*-setup` called without `--client-id`
The generated `bastion.yml`/`backend.yml`/`standalone.yml` invoke `ob-bastion-setup`/`ob-backend-setup` with `--yes` but **no `-c <client_id>`**, so setup aborts:
```
[ERROR] Missing --client-id (required in non-interactive mode).
```
Every unattended `ob-*-setup` run failed. Fixed by passing `'-c', ob_client_id` (already a baked-in role default) in all three task templates.

### 2. Controller-side device-code approval hard-coded the portal URL
The auto-approve flow runs on the Ansible **control node** and hit `{{ portal_url }}/device` directly. When the control node reaches the portal at a different address than the managed hosts (split-horizon DNS, NAT, a lab behind a gateway), it failed with connection-refused. Added optional `ob_approve_base_url` / `ob_approve_host` overrides to `_enroll` (both default to the portal URL / no Host header, so normal deployments are unchanged), documented in `defaults`.

Both were previously carried as undocumented lab post-edits; this folds them into the generator so a vanilla `ob-builder` role deploys unattended.

**Verified**: full 3-VM libvirt lab — generated bastion role deploys clean (`ok=26 failed=0`), `ob-bastion-id` returns `ob-bastion`, then the generated backend role (with `allowed_bastions`) deploys and the cert hop + ob-scp work end to end.