### PR TITLE
fix(ob-builder): shell installer deploys unattended (--yes + allowlist + hardening)

### DIFF
--- a/admin-builder/ob-builder
+++ b/admin-builder/ob-builder
@@ -605,6 +605,15 @@ validate_inputs() {
     [ -n "$TARGET_ROLE" ]        || die "target_role is required"
     is_valid_target_role "$TARGET_ROLE" || die "Invalid target_role: $TARGET_ROLE"
 
+    # allowed_bastions is embedded verbatim into the generated artefacts (the
+    # self-extracting shell installer and the Ansible vars). Restrict it to safe
+    # identifier characters so a malicious or typo'd value cannot inject shell
+    # metacharacters ($(), backticks, quotes, newlines) into the installer that
+    # runs as root. bastion_ids are [A-Za-z0-9._-], separated by comma/space.
+    if [ -n "${ALLOWED_BASTIONS:-}" ] && ! [[ "$ALLOWED_BASTIONS" =~ ^[A-Za-z0-9._,\ -]+$ ]]; then
+        die "Invalid allowed_bastions (only letters, digits, '.', '_', '-', ',' and spaces allowed): $ALLOWED_BASTIONS"
+    fi
+
     : "${AUTO_ENROLL_SETUP:=prompt}"
     case "$AUTO_ENROLL_SETUP" in yes|no|prompt) ;; *) die "Invalid auto_enroll_setup: $AUTO_ENROLL_SETUP" ;; esac
 
@@ -880,7 +889,12 @@ build_placeholder_map() {
     # source-address. So the conf block is empty; we only pass the allowlist to
     # the Ansible role (which forwards it as ob-backend-setup --allowed-bastions).
     bastion_backend_block=""
+    # Role-scoped: the allowlist is meaningful only for a backend. Keep it empty
+    # for bastion/standalone artefacts (matters in --bundle, where one config
+    # produces both roles — the bastion installer must NOT embed the allowlist).
+    local allowlist_for_role=""
     if [ "$role" = "backend" ] && [ -n "${ALLOWED_BASTIONS:-}" ]; then
+        allowlist_for_role="$ALLOWED_BASTIONS"
         bastion_allowlist_yaml="ob_bastion_allowed_bastions: \"${ALLOWED_BASTIONS}\""
     else
         bastion_allowlist_yaml=""
@@ -933,6 +947,7 @@ build_placeholder_map() {
     ph_set EMBEDDED_CLIENT_SECRET "$EMBEDDED_CLIENT_SECRET"
     ph_set SERVER_GROUP         "$SERVER_GROUP"
     ph_set SERVER_GROUP_POLICY  "$SERVER_GROUP_POLICY"
+    ph_set ALLOWED_BASTIONS     "$allowlist_for_role"
     ph_set AUTO_ENROLL_SETUP    "$AUTO_ENROLL_SETUP"
     ph_set SELF_DELETE          "$SELF_DELETE"
     ph_set CA_SSH_PUB_B64       "$ca_b64"

--- a/admin-builder/templates/shell/installer.sh.in
+++ b/admin-builder/templates/shell/installer.sh.in
@@ -57,6 +57,9 @@ SELF_DELETE_DEFAULT="@@SELF_DELETE@@"
 ENABLE_HARDENING="@@ENABLE_HARDENING@@"
 ENABLE_AUDIT_TRACE="@@ENABLE_AUDIT_TRACE@@"
 DISABLE_SESSION_RECORDER="@@DISABLE_SESSION_RECORDER@@"
+# Backend-only "accept only this bastion" allowlist (comma/space-separated
+# bastion_id = enrolling client_id). Empty = accept any vouched bastion.
+ALLOWED_BASTIONS="@@ALLOWED_BASTIONS@@"
 
 # ---------------------------------------------------------------------------
 # Runtime variables (resolved during execution)
@@ -662,7 +665,11 @@ step_setup() {
             # OB_CLIENT_SECRET (kept out of /proc/<pid>/cmdline). ob-enroll
             # already ran in step_enroll and wrote the token, so ob-bastion-setup
             # reuses it (no second device-code approval).
-            local _setup_opts=("-p" "${PORTAL_URL}" "-g" "${SERVER_GROUP}")
+            # --yes: the installer already confirmed (its own prompt / -y), so
+            # run ob-bastion-setup non-interactively. Without it, setup prompts
+            # "Continue with bastion setup? [y/N]", reads nothing on a piped
+            # stdin, and ABORTS — leaving sshd unconfigured (no TrustedUserCAKeys).
+            local _setup_opts=("-p" "${PORTAL_URL}" "-g" "${SERVER_GROUP}" "--yes")
             [ -n "${CLIENT_ID}" ] && _setup_opts+=("-c" "${CLIENT_ID}")
             [ "${PAM_MODE}" = "E" ] && _setup_opts+=("--max-security")
             [ "${OPT_INSECURE}" = "true" ] && _setup_opts+=("-k")
@@ -682,8 +689,14 @@ step_setup() {
         backend)
             # Backends never record sessions, so --disable-session-recorder is
             # not applicable here; hardening / audit-trace stay opt-in.
-            local _setup_opts=("-p" "${PORTAL_URL}" "-g" "${SERVER_GROUP}")
+            # --yes: run ob-backend-setup non-interactively (see bastion note).
+            local _setup_opts=("-p" "${PORTAL_URL}" "-g" "${SERVER_GROUP}" "--yes")
             [ -n "${CLIENT_ID}" ] && _setup_opts+=("-c" "${CLIENT_ID}")
+            # "Accept only this bastion": forward the embedded allowlist so the
+            # backend's AuthorizedPrincipalsCommand rejects certs whose key-id
+            # bastion=<id> is not listed. Without this the backend would accept
+            # any vouched bastion (parity with the Ansible backend role).
+            [ -n "${ALLOWED_BASTIONS}" ] && _setup_opts+=("--allowed-bastions" "${ALLOWED_BASTIONS}")
             [ "${PAM_MODE}" = "E" ] && _setup_opts+=("--max-security")
             [ "${OPT_INSECURE}" = "true" ] && _setup_opts+=("-k")
             [ "${ENABLE_HARDENING}" = "yes" ] && _setup_opts+=("--enable-hardening")


### PR DESCRIPTION
Found while validating the local deploy via `--output-shell` (the shell counterpart of the Ansible flow).

The self-extracting installer **never passed `--allowed-bastions`** to `ob-backend-setup`, so a backend deployed via the shell path accepted certs from **any** vouched bastion — even when the admin set an allowlist at build time. The Ansible backend role honours it; the shell path silently dropped it (a security-relevant parity gap).

Fix: embed the allowlist into the installer as `ALLOWED_BASTIONS` (new `@@ALLOWED_BASTIONS@@` placeholder, set from the existing `$ALLOWED_BASTIONS` builder var) and pass `--allowed-bastions "$ALLOWED_BASTIONS"` to `ob-backend-setup` when non-empty. Bastion/standalone embed an empty value (no-op).

Verified: generated backend installer now carries `ALLOWED_BASTIONS="ob-bastion"` and the `--allowed-bastions` arg; bastion installer carries an empty value. Part of an end-to-end shell-path lab deploy.