### PR TITLE
feat(ob-heartbeat): report connected users to the SSO

### DIFF
--- a/admin-builder/templates/shell/installer.sh.in
+++ b/admin-builder/templates/shell/installer.sh.in
@@ -669,7 +669,7 @@ step_setup() {
             # run ob-bastion-setup non-interactively. Without it, setup prompts
             # "Continue with bastion setup? [y/N]", reads nothing on a piped
             # stdin, and ABORTS — leaving sshd unconfigured (no TrustedUserCAKeys).
-            local _setup_opts=("-p" "${PORTAL_URL}" "-g" "${SERVER_GROUP}" "--yes")
+            local _setup_opts=("-p" "${PORTAL_URL}" "-g" "${SERVER_GROUP}" "--node-role" "${TARGET_ROLE}" "--yes")
             [ -n "${CLIENT_ID}" ] && _setup_opts+=("-c" "${CLIENT_ID}")
             [ "${PAM_MODE}" = "E" ] && _setup_opts+=("--max-security")
             [ "${OPT_INSECURE}" = "true" ] && _setup_opts+=("-k")
@@ -690,7 +690,7 @@ step_setup() {
             # Backends never record sessions, so --disable-session-recorder is
             # not applicable here; hardening / audit-trace stay opt-in.
             # --yes: run ob-backend-setup non-interactively (see bastion note).
-            local _setup_opts=("-p" "${PORTAL_URL}" "-g" "${SERVER_GROUP}" "--yes")
+            local _setup_opts=("-p" "${PORTAL_URL}" "-g" "${SERVER_GROUP}" "--node-role" "${TARGET_ROLE}" "--yes")
             [ -n "${CLIENT_ID}" ] && _setup_opts+=("-c" "${CLIENT_ID}")
             # "Accept only this bastion": forward the embedded allowlist so the
             # backend's AuthorizedPrincipalsCommand rejects certs whose key-id

--- a/config/openbastion.conf.example
+++ b/config/openbastion.conf.example
@@ -26,6 +26,11 @@ server_token_file = /var/lib/open-bastion/token
 # Default: "default"
 server_group = default
 
+# Node role reported to the SSO in each heartbeat: bastion | standalone | backend
+# Normally written by the setup scripts (ob-bastion-setup / ob-backend-setup).
+# Leave empty/unset if unknown.
+node_role = bastion
+
 # ==============================================================================
 # Heartbeat reporting
 # ==============================================================================

--- a/config/openbastion.conf.example
+++ b/config/openbastion.conf.example
@@ -27,6 +27,23 @@ server_token_file = /var/lib/open-bastion/token
 server_group = default
 
 # ==============================================================================
+# Heartbeat reporting
+# ==============================================================================
+
+# Report the list of currently connected users ("who is connected on this
+# machine") to the SSO in each heartbeat. The SSO stores it per machine so
+# administrators can see active sessions across the fleet.
+# NOTE: active sessions (user, source host, tty, login time) are
+# privacy-sensitive; set to false to disable this reporting.
+# Default: true
+report_sessions = true
+
+# Maximum number of sessions sent in a single heartbeat (avoids a huge payload
+# on a very busy machine). Extra sessions are dropped and a warning is logged.
+# Default: 200
+# max_reported_sessions = 200
+
+# ==============================================================================
 # HTTP Settings
 # ==============================================================================
 

--- a/man/ob-heartbeat.8
+++ b/man/ob-heartbeat.8
@@ -12,6 +12,10 @@ server is still active and using PAM authentication.
 The heartbeat allows administrators to monitor enrolled servers and detect
 "ghost" servers that have uninstalled the PAM module without proper unenrollment.
 .PP
+Each heartbeat also reports the open-bastion client version and the node role
+.RI ( node_role :
+bastion, standalone or backend) so the SSO can track what runs where.
+.PP
 Each heartbeat also reports the list of users currently connected on this
 machine (user, source host, tty and login time), collected via
 .BR loginctl (1)

--- a/man/ob-heartbeat.8
+++ b/man/ob-heartbeat.8
@@ -12,6 +12,16 @@ server is still active and using PAM authentication.
 The heartbeat allows administrators to monitor enrolled servers and detect
 "ghost" servers that have uninstalled the PAM module without proper unenrollment.
 .PP
+Each heartbeat also reports the list of users currently connected on this
+machine (user, source host, tty and login time), collected via
+.BR loginctl (1)
+when systemd-logind is available, otherwise via
+.BR who (1).
+The SSO stores this list per machine so administrators can see "who is
+connected" across the fleet. Reporting can be disabled with the
+.I report_sessions
+configuration setting.
+.PP
 This script is typically run by a systemd timer (ob-heartbeat.timer)
 every 5 minutes.
 .SH OPTIONS

--- a/man/ob-heartbeat.8
+++ b/man/ob-heartbeat.8
@@ -39,11 +39,8 @@ Read settings from config file. Default: /etc/open-bastion/openbastion.conf
 .BR \-t ", " \-\-token\-file " " \fIFILE\fR
 Server token file. Default: /var/lib/open-bastion/token
 .TP
-.BR \-k ", " \-\-insecure
-Skip SSL certificate verification.
-.TP
-.BR \-q ", " \-\-quiet
-Quiet mode (less output).
+.BR \-d ", " \-\-debug
+Enable debug logging.
 .TP
 .BR \-h ", " \-\-help
 Show help message and exit.

--- a/man/ob-heartbeat.8
+++ b/man/ob-heartbeat.8
@@ -20,7 +20,10 @@ when systemd-logind is available, otherwise via
 The SSO stores this list per machine so administrators can see "who is
 connected" across the fleet. Reporting can be disabled with the
 .I report_sessions
-configuration setting.
+configuration setting, and the number of sessions sent in a single
+heartbeat is capped by
+.I max_reported_sessions
+(default 200; extra sessions are dropped and a warning is logged).
 .PP
 This script is typically run by a systemd timer (ob-heartbeat.timer)
 every 5 minutes.

--- a/scripts/ob-backend-setup
+++ b/scripts/ob-backend-setup
@@ -22,6 +22,9 @@ PROG_NAME=$(basename "$0")
 PORTAL_URL=""
 SERVER_GROUP=""
 SERVER_TOKEN=""
+# Node role recorded in openbastion.conf and reported in the heartbeat.
+# This script configures the backend role; overridable via --node-role.
+NODE_ROLE="backend"
 NON_INTERACTIVE=false
 VERIFY_SSL=true
 TIMEOUT=30
@@ -778,6 +781,8 @@ render_openbastion_conf() {
     printf 'server_token_file = %s\n\n' "$OB_TOKEN"
     printf '# Server group for authorization rules\n'
     printf 'server_group = %s\n\n' "$SERVER_GROUP"
+    printf '# Node role reported to the SSO (bastion | standalone | backend)\n'
+    printf 'node_role = %s\n\n' "$NODE_ROLE"
     # Authorization-only mode: pam_sm_authenticate always succeeds (SSH already
     # validated the cert), only pam_sm_acct_mgmt calls /pam/authorize. Without
     # this, pam_openbastion would require client_id/client_secret in this file
@@ -1584,6 +1589,8 @@ Options:
   -g, --server-group NAME Server group name (must match a group defined in
                           LLNG). Prompted interactively if omitted; required
                           when --yes is used.
+      --node-role ROLE    Node role recorded in the config and reported to the
+                          SSO: bastion|standalone|backend (default: backend).
   -t, --token-file FILE   Read server token from file (use - for stdin)
   -c, --client-id ID      OIDC client_id for enrollment. Prompted interactively
                           if omitted (suggested: pam-access); required when
@@ -1647,6 +1654,20 @@ parse_args() {
                     exit 1
                 fi
                 SERVER_GROUP="$2"
+                shift 2
+                ;;
+            --node-role)
+                if [ -z "${2:-}" ] || [[ "${2:-}" == -* ]]; then
+                    error "Option $1 requires an argument"
+                    exit 1
+                fi
+                case "$2" in
+                    bastion | standalone | backend) NODE_ROLE="$2" ;;
+                    *)
+                        error "Invalid --node-role '$2' (bastion|standalone|backend)"
+                        exit 1
+                        ;;
+                esac
                 shift 2
                 ;;
             --allowed-bastions)

--- a/scripts/ob-bastion-setup
+++ b/scripts/ob-bastion-setup
@@ -25,6 +25,11 @@ PORTAL_URL=""
 # main() if --server-group was not provided.
 SERVER_GROUP=""
 SERVER_TOKEN=""
+# Node role recorded in openbastion.conf and reported in the heartbeat. This
+# script serves both the bastion and standalone roles (a standalone host runs
+# the full bastion stack); the installer passes --node-role standalone when
+# appropriate. Defaults to "bastion".
+NODE_ROLE="bastion"
 NON_INTERACTIVE=false
 VERIFY_SSL=true
 TIMEOUT=30
@@ -455,6 +460,8 @@ render_openbastion_conf() {
     printf 'server_token_file = %s\n\n' "$OB_TOKEN"
     printf '# Server group for authorization rules\n'
     printf 'server_group = %s\n\n' "$SERVER_GROUP"
+    printf '# Node role reported to the SSO (bastion | standalone | backend)\n'
+    printf 'node_role = %s\n\n' "$NODE_ROLE"
     # Authorization-only mode: pam_sm_authenticate always succeeds (SSH already
     # validated the cert), only pam_sm_acct_mgmt calls /pam/authorize. Without
     # this, pam_openbastion would require client_id/client_secret in this file
@@ -1615,6 +1622,8 @@ Options:
   -g, --server-group NAME Server group name (must match a group defined in
                           LLNG). Prompted interactively if omitted; required
                           when --yes is used.
+      --node-role ROLE    Node role recorded in the config and reported to the
+                          SSO: bastion|standalone|backend (default: bastion).
   -t, --token-file FILE   Read server token from file (use - for stdin)
   -c, --client-id ID      OIDC client_id for enrollment. Prompted interactively
                           if omitted (suggested: pam-access); required when
@@ -1683,6 +1692,20 @@ parse_args() {
                     exit 1
                 fi
                 SERVER_GROUP="$2"
+                shift 2
+                ;;
+            --node-role)
+                if [ -z "${2:-}" ] || [[ "${2:-}" == -* ]]; then
+                    error "Option $1 requires an argument"
+                    exit 1
+                fi
+                case "$2" in
+                    bastion | standalone | backend) NODE_ROLE="$2" ;;
+                    *)
+                        error "Invalid --node-role '$2' (bastion|standalone|backend)"
+                        exit 1
+                        ;;
+                esac
                 shift 2
                 ;;
             -t|--token-file)

--- a/scripts/ob-heartbeat
+++ b/scripts/ob-heartbeat
@@ -96,6 +96,17 @@ load_config() {
     VERIFY_SSL=$(read_config "verify_ssl" "$CONFIG_FILE")
     [ -z "$VERIFY_SSL" ] && VERIFY_SSL="true"
 
+    # Whether to report the list of currently connected users to the SSO in the
+    # heartbeat ("who is connected on this machine"). Active sessions are
+    # privacy-sensitive, so this can be disabled. Default: true.
+    REPORT_SESSIONS=$(read_config "report_sessions" "$CONFIG_FILE")
+    [ -z "$REPORT_SESSIONS" ] && REPORT_SESSIONS="true"
+
+    # Upper bound on the number of sessions sent, to avoid a huge payload on a
+    # very busy machine. Default: 200.
+    MAX_SESSIONS=$(read_config "max_reported_sessions" "$CONFIG_FILE")
+    [ -z "$MAX_SESSIONS" ] && MAX_SESSIONS=200
+
     if [ -z "$PORTAL_URL" ]; then
         log_error "portal_url not configured"
         exit 1
@@ -139,6 +150,90 @@ get_stats() {
         cat "$STATS_FILE"
     else
         echo '{}'
+    fi
+}
+
+# Build a JSON array describing who is currently connected on this machine.
+# Each entry: { user, from (remote host), tty, since (login epoch or null) }.
+# Prefers systemd-logind (loginctl), falls back to who(1)/utmp when logind is
+# unavailable. Returns '[]' when reporting is disabled or nothing is found.
+get_sessions() {
+    case "$REPORT_SESSIONS" in
+        true | 1 | yes | on) ;;
+        *)
+            echo '[]'
+            return 0
+            ;;
+    esac
+
+    local objs="" count=0 truncated=0
+
+    if command -v loginctl >/dev/null 2>&1; then
+        local ids id props
+        ids=$(loginctl list-sessions --no-legend 2>/dev/null | awk '{print $1}') || ids=""
+        for id in $ids; do
+            [ -n "$id" ] || continue
+            props=$(loginctl show-session "$id" \
+                -p Name -p RemoteHost -p TTY -p Timestamp -p Class 2>/dev/null) || props=""
+            local name="" remote="" tty="" class="" ts="" since="" key val
+            while IFS='=' read -r key val; do
+                case "$key" in
+                    Name) name="$val" ;;
+                    RemoteHost) remote="$val" ;;
+                    TTY) tty="$val" ;;
+                    Class) class="$val" ;;
+                    Timestamp) ts="$val" ;;
+                esac
+            done <<EOF
+$props
+EOF
+            # Only interactive user sessions (skip greeter/manager/etc.)
+            [ "$class" = "user" ] || continue
+            [ -n "$name" ] || continue
+            if [ "$count" -ge "$MAX_SESSIONS" ]; then
+                truncated=1
+                break
+            fi
+            [ -n "$ts" ] && since=$(date -d "$ts" +%s 2>/dev/null || echo "")
+            objs+=$(jq -cn \
+                --arg user "$name" \
+                --arg from "$remote" \
+                --arg tty "$tty" \
+                --argjson since "${since:-null}" \
+                '{user: $user, from: $from, tty: $tty, since: $since}')
+            objs+=$'\n'
+            count=$((count + 1))
+        done
+    else
+        # Fallback: who reads utmp. Columns are NAME LINE DATE TIME [(HOST)];
+        # the optional source host is the parenthesised trailing comment.
+        local user tty d t host since
+        while read -r user tty d t host; do
+            [ -n "$user" ] || continue
+            if [ "$count" -ge "$MAX_SESSIONS" ]; then
+                truncated=1
+                break
+            fi
+            host=$(echo "$host" | tr -d '()')
+            since=""
+            [ -n "$d" ] && [ -n "$t" ] && since=$(date -d "$d $t" +%s 2>/dev/null || echo "")
+            objs+=$(jq -cn \
+                --arg user "$user" \
+                --arg from "$host" \
+                --arg tty "$tty" \
+                --argjson since "${since:-null}" \
+                '{user: $user, from: $from, tty: $tty, since: $since}')
+            objs+=$'\n'
+            count=$((count + 1))
+        done < <(who 2>/dev/null || true)
+    fi
+
+    [ "$truncated" = "1" ] && log_warn "Reported session list truncated to $MAX_SESSIONS entries"
+
+    if [ -z "$objs" ]; then
+        echo '[]'
+    else
+        printf '%s' "$objs" | jq -s '.'
     fi
 }
 
@@ -188,6 +283,10 @@ send_heartbeat() {
     local stats
     stats=$(get_stats)
 
+    # List of users currently connected on this machine (may be '[]')
+    local sessions
+    sessions=$(get_sessions)
+
     # Build JSON payload using jq for safety
     local payload
     payload=$(jq -n \
@@ -197,13 +296,15 @@ send_heartbeat() {
         --arg version "$VERSION" \
         --argjson uptime "$uptime_seconds" \
         --argjson stats "$stats" \
+        --argjson sessions "$sessions" \
         '{
             refresh_token: $refresh_token,
             hostname: $hostname,
             server_group: $server_group,
             version: $version,
             uptime: $uptime,
-            stats: $stats
+            stats: $stats,
+            sessions: $sessions
         }')
 
     build_curl_opts

--- a/scripts/ob-heartbeat
+++ b/scripts/ob-heartbeat
@@ -103,9 +103,15 @@ load_config() {
     [ -z "$REPORT_SESSIONS" ] && REPORT_SESSIONS="true"
 
     # Upper bound on the number of sessions sent, to avoid a huge payload on a
-    # very busy machine. Default: 200.
+    # very busy machine. Must be a positive integer; fall back to 200 on an
+    # empty or invalid value (it is used in numeric `[ -ge ]` tests under
+    # `set -e`, where a non-integer would abort the heartbeat).
     MAX_SESSIONS=$(read_config "max_reported_sessions" "$CONFIG_FILE")
-    [ -z "$MAX_SESSIONS" ] && MAX_SESSIONS=200
+    if ! [[ "$MAX_SESSIONS" =~ ^[1-9][0-9]*$ ]]; then
+        [ -n "$MAX_SESSIONS" ] &&
+            log_warn "Invalid max_reported_sessions '$MAX_SESSIONS', using default 200"
+        MAX_SESSIONS=200
+    fi
 
     if [ -z "$PORTAL_URL" ]; then
         log_error "portal_url not configured"
@@ -168,9 +174,15 @@ get_sessions() {
 
     local objs="" count=0 truncated=0
 
-    if command -v loginctl >/dev/null 2>&1; then
-        local ids id props
-        ids=$(loginctl list-sessions --no-legend 2>/dev/null | awk '{print $1}') || ids=""
+    # Use loginctl only if it is present AND actually answers: on hosts where
+    # loginctl exists but systemd-logind/dbus is unavailable (containers,
+    # chroots) list-sessions fails, and we must fall back to who(1) rather than
+    # silently report an empty list.
+    local ids=""
+    if command -v loginctl >/dev/null 2>&1 &&
+        ids=$(loginctl list-sessions --no-legend 2>/dev/null); then
+        ids=$(printf '%s\n' "$ids" | awk '{print $1}')
+        local id props
         for id in $ids; do
             [ -n "$id" ] || continue
             props=$(loginctl show-session "$id" \

--- a/scripts/ob-heartbeat
+++ b/scripts/ob-heartbeat
@@ -10,7 +10,7 @@
 
 set -e
 
-VERSION="0.2.3"
+VERSION="0.3.0"
 PROG_NAME=$(basename "$0")
 
 # Default values
@@ -87,6 +87,10 @@ load_config() {
 
     SERVER_GROUP=$(read_config "server_group" "$CONFIG_FILE")
     [ -z "$SERVER_GROUP" ] && SERVER_GROUP="default"
+
+    # Node role reported to the SSO: bastion | standalone | backend. Written by
+    # the setup scripts (ob-bastion-setup / ob-backend-setup); empty if unknown.
+    NODE_ROLE=$(read_config "node_role" "$CONFIG_FILE")
 
     local token_file_config
     token_file_config=$(read_config "server_token_file" "$CONFIG_FILE")
@@ -306,6 +310,7 @@ send_heartbeat() {
         --arg hostname "$hostname" \
         --arg server_group "$SERVER_GROUP" \
         --arg version "$VERSION" \
+        --arg node_role "$NODE_ROLE" \
         --argjson uptime "$uptime_seconds" \
         --argjson stats "$stats" \
         --argjson sessions "$sessions" \
@@ -314,6 +319,7 @@ send_heartbeat() {
             hostname: $hostname,
             server_group: $server_group,
             version: $version,
+            node_role: $node_role,
             uptime: $uptime,
             stats: $stats,
             sessions: $sessions

--- a/tests/test_ob_backend_setup.sh
+++ b/tests/test_ob_backend_setup.sh
@@ -207,6 +207,42 @@ test_max_security() {
     fi
 }
 
+# ── Test 14: default node_role is backend, --node-role overrides ──
+test_node_role_default() {
+    (
+        source_script "ob-backend-setup"
+        PORTAL_URL="https://x"; OB_TOKEN="/v/t"; SERVER_GROUP="g"
+        CLIENT_ID=""; CLIENT_SECRET=""; VERIFY_SSL=true
+        render_openbastion_conf | grep -q "^node_role = backend$" && exit 0 || exit 1
+    )
+    if [ $? -eq 0 ]; then
+        pass "default node_role is backend"
+    else
+        fail "default node_role is backend"
+    fi
+}
+
+test_node_role_override() {
+    local rc1 rc2
+    (
+        source_script "ob-backend-setup"
+        parse_args -p "https://x" -g "g" --node-role bastion
+        [ "$NODE_ROLE" = "bastion" ] && exit 0 || exit 1
+    )
+    rc1=$?
+    # invalid role: parse_args errors out (exits non-zero)
+    (
+        source_script "ob-backend-setup"
+        parse_args -p "https://x" -g "g" --node-role bogus 2>/dev/null
+    )
+    rc2=$?
+    if [ "$rc1" -eq 0 ] && [ "$rc2" -ne 0 ]; then
+        pass "--node-role accepts valid role and rejects invalid"
+    else
+        fail "--node-role accepts valid role and rejects invalid"
+    fi
+}
+
 # ── Run all tests ──
 echo "=== Testing ob-backend-setup ==="
 run_test test_syntax
@@ -223,6 +259,8 @@ run_test test_confirm_noninteractive
 run_test test_backup_file
 run_test test_trailing_slash
 run_test test_max_security
+run_test test_node_role_default
+run_test test_node_role_override
 
 echo ""
 echo "=== Results: $TESTS_PASSED/$TESTS_RUN passed, $TESTS_FAILED failed ==="

--- a/tests/test_ob_backend_setup.sh
+++ b/tests/test_ob_backend_setup.sh
@@ -213,7 +213,10 @@ test_node_role_default() {
         source_script "ob-backend-setup"
         PORTAL_URL="https://x"; OB_TOKEN="/v/t"; SERVER_GROUP="g"
         CLIENT_ID=""; CLIENT_SECRET=""; VERIFY_SSL=true
-        render_openbastion_conf | grep -q "^node_role = backend$" && exit 0 || exit 1
+        # Capture first: piping into `grep -q` makes grep exit on first match,
+        # which SIGPIPEs render_openbastion_conf and trips `set -o pipefail`.
+        local conf; conf=$(render_openbastion_conf)
+        grep -q "^node_role = backend$" <<<"$conf" && exit 0 || exit 1
     )
     if [ $? -eq 0 ]; then
         pass "default node_role is backend"

--- a/tests/test_ob_bastion_setup.sh
+++ b/tests/test_ob_bastion_setup.sh
@@ -232,7 +232,10 @@ test_node_role() {
         [ "$NODE_ROLE" = "standalone" ] || exit 1
         PORTAL_URL="https://x"; OB_TOKEN="/v/t"; SERVER_GROUP="g"
         CLIENT_ID=""; CLIENT_SECRET=""; VERIFY_SSL=true
-        render_openbastion_conf | grep -q "^node_role = standalone$" && exit 0 || exit 1
+        # Capture first: piping into `grep -q` makes grep exit on first match,
+        # which SIGPIPEs render_openbastion_conf and trips `set -o pipefail`.
+        local conf; conf=$(render_openbastion_conf)
+        grep -q "^node_role = standalone$" <<<"$conf" && exit 0 || exit 1
     )
     if [ $? -eq 0 ]; then
         pass "--node-role is parsed and written to the config"
@@ -260,7 +263,8 @@ test_node_role_default() {
         source_script "ob-bastion-setup"
         PORTAL_URL="https://x"; OB_TOKEN="/v/t"; SERVER_GROUP="g"
         CLIENT_ID=""; CLIENT_SECRET=""; VERIFY_SSL=true
-        render_openbastion_conf | grep -q "^node_role = bastion$" && exit 0 || exit 1
+        local conf; conf=$(render_openbastion_conf)
+        grep -q "^node_role = bastion$" <<<"$conf" && exit 0 || exit 1
     )
     if [ $? -eq 0 ]; then
         pass "default node_role is bastion"

--- a/tests/test_ob_bastion_setup.sh
+++ b/tests/test_ob_bastion_setup.sh
@@ -224,6 +224,51 @@ test_max_security() {
     fi
 }
 
+# ── Test 14: --node-role parsed and rendered into the config ──
+test_node_role() {
+    (
+        source_script "ob-bastion-setup"
+        parse_args -p "https://x" --node-role standalone
+        [ "$NODE_ROLE" = "standalone" ] || exit 1
+        PORTAL_URL="https://x"; OB_TOKEN="/v/t"; SERVER_GROUP="g"
+        CLIENT_ID=""; CLIENT_SECRET=""; VERIFY_SSL=true
+        render_openbastion_conf | grep -q "^node_role = standalone$" && exit 0 || exit 1
+    )
+    if [ $? -eq 0 ]; then
+        pass "--node-role is parsed and written to the config"
+    else
+        fail "--node-role is parsed and written to the config"
+    fi
+}
+
+# ── Test 15: invalid --node-role is rejected ──
+test_node_role_invalid() {
+    (
+        source_script "ob-bastion-setup"
+        parse_args -p "https://x" --node-role bogus 2>/dev/null
+    )
+    if [ $? -ne 0 ]; then
+        pass "invalid --node-role is rejected"
+    else
+        fail "invalid --node-role is rejected"
+    fi
+}
+
+# ── Test 16: default node_role is bastion ──
+test_node_role_default() {
+    (
+        source_script "ob-bastion-setup"
+        PORTAL_URL="https://x"; OB_TOKEN="/v/t"; SERVER_GROUP="g"
+        CLIENT_ID=""; CLIENT_SECRET=""; VERIFY_SSL=true
+        render_openbastion_conf | grep -q "^node_role = bastion$" && exit 0 || exit 1
+    )
+    if [ $? -eq 0 ]; then
+        pass "default node_role is bastion"
+    else
+        fail "default node_role is bastion"
+    fi
+}
+
 # ── Run all tests ──
 echo "=== Testing ob-bastion-setup ==="
 run_test test_syntax
@@ -241,6 +286,9 @@ run_test test_backup_file
 run_test test_build_curl_opts_default
 run_test test_build_curl_opts_insecure
 run_test test_max_security
+run_test test_node_role
+run_test test_node_role_invalid
+run_test test_node_role_default
 
 echo ""
 echo "=== Results: $TESTS_PASSED/$TESTS_RUN passed, $TESTS_FAILED failed ==="

--- a/tests/test_ob_heartbeat.sh
+++ b/tests/test_ob_heartbeat.sh
@@ -285,6 +285,163 @@ test_parse_args() {
     fi
 }
 
+# ── Test 13: load_config sanitizes invalid max_reported_sessions ──
+test_load_config_invalid_max_sessions() {
+    local tmpconf
+    tmpconf=$(mktemp)
+    cat > "$tmpconf" <<'CONF'
+portal_url = https://portal.test.com
+max_reported_sessions = abc
+CONF
+    (
+        source_script "ob-heartbeat"
+        CONFIG_FILE="$tmpconf"
+        load_config 2>/dev/null
+        [ "$MAX_SESSIONS" = "200" ] && exit 0 || exit 1
+    )
+    local rc=$?
+    rm -f "$tmpconf"
+    if [ $rc -eq 0 ]; then
+        pass "load_config sanitizes invalid max_reported_sessions to 200"
+    else
+        fail "load_config sanitizes invalid max_reported_sessions to 200"
+    fi
+}
+
+# ── Test 14: load_config keeps a valid max_reported_sessions / report_sessions ──
+test_load_config_session_settings() {
+    local tmpconf
+    tmpconf=$(mktemp)
+    cat > "$tmpconf" <<'CONF'
+portal_url = https://portal.test.com
+report_sessions = false
+max_reported_sessions = 50
+CONF
+    (
+        source_script "ob-heartbeat"
+        CONFIG_FILE="$tmpconf"
+        load_config 2>/dev/null
+        local ok=true
+        [ "$REPORT_SESSIONS" = "false" ] || ok=false
+        [ "$MAX_SESSIONS" = "50" ] || ok=false
+        $ok && exit 0 || exit 1
+    )
+    local rc=$?
+    rm -f "$tmpconf"
+    if [ $rc -eq 0 ]; then
+        pass "load_config keeps valid report_sessions/max_reported_sessions"
+    else
+        fail "load_config keeps valid report_sessions/max_reported_sessions"
+    fi
+}
+
+# ── Test 15: get_sessions returns [] when reporting disabled ──
+test_get_sessions_disabled() {
+    local out
+    out=$(
+        source_script "ob-heartbeat"
+        REPORT_SESSIONS=false
+        MAX_SESSIONS=200
+        get_sessions
+    )
+    if [ "$out" = "[]" ]; then
+        pass "get_sessions returns [] when report_sessions=false"
+    else
+        fail "get_sessions returns [] when report_sessions=false" "$out"
+    fi
+}
+
+# ── Test 16: get_sessions via loginctl (stubbed) ──
+test_get_sessions_loginctl() {
+    local out
+    out=$(
+        source_script "ob-heartbeat"
+        REPORT_SESSIONS=true
+        MAX_SESSIONS=200
+        loginctl() {
+            case "$1" in
+                list-sessions) printf '%s\n' "c1 1000 alice seat0 tty2" ;;
+                show-session)
+                    printf '%s\n' "Name=alice" "RemoteHost=10.0.0.9" \
+                        "TTY=pts/0" "Timestamp=Sun 2026-06-14 22:03:00 UTC" "Class=user" ;;
+            esac
+        }
+        get_sessions
+    )
+    if echo "$out" | jq -e \
+        '.[0].user=="alice" and .[0].from=="10.0.0.9" and .[0].tty=="pts/0"' >/dev/null 2>&1; then
+        pass "get_sessions (loginctl) reports user/from/tty"
+    else
+        fail "get_sessions (loginctl) reports user/from/tty" "$out"
+    fi
+}
+
+# ── Test 17: get_sessions skips non-user (greeter) loginctl sessions ──
+test_get_sessions_loginctl_skips_nonuser() {
+    local out
+    out=$(
+        source_script "ob-heartbeat"
+        REPORT_SESSIONS=true
+        MAX_SESSIONS=200
+        loginctl() {
+            case "$1" in
+                list-sessions) printf '%s\n' "c1 121 gdm seat0 tty1" ;;
+                show-session)
+                    printf '%s\n' "Name=gdm" "RemoteHost=" "TTY=tty1" \
+                        "Timestamp=Sun 2026-06-14 22:03:00 UTC" "Class=greeter" ;;
+            esac
+        }
+        get_sessions
+    )
+    if [ "$out" = "[]" ]; then
+        pass "get_sessions skips non-user loginctl sessions"
+    else
+        fail "get_sessions skips non-user loginctl sessions" "$out"
+    fi
+}
+
+# ── Test 18: get_sessions falls back to who when loginctl fails ──
+test_get_sessions_who_fallback() {
+    local out
+    out=$(
+        source_script "ob-heartbeat"
+        REPORT_SESSIONS=true
+        MAX_SESSIONS=200
+        # loginctl exists but list-sessions fails (logind/dbus down)
+        loginctl() { return 1; }
+        who() { printf '%s\n' "carol pts/1 2026-06-14 23:00 (192.168.1.5)"; }
+        get_sessions
+    )
+    if echo "$out" | jq -e \
+        '.[0].user=="carol" and .[0].from=="192.168.1.5" and .[0].tty=="pts/1"' >/dev/null 2>&1; then
+        pass "get_sessions falls back to who when loginctl fails"
+    else
+        fail "get_sessions falls back to who when loginctl fails" "$out"
+    fi
+}
+
+# ── Test 19: get_sessions honours max_reported_sessions cap ──
+test_get_sessions_cap() {
+    local out
+    out=$(
+        source_script "ob-heartbeat"
+        REPORT_SESSIONS=true
+        MAX_SESSIONS=1
+        loginctl() { return 1; }
+        who() {
+            printf '%s\n' \
+                "u1 pts/1 2026-06-14 23:00 (1.1.1.1)" \
+                "u2 pts/2 2026-06-14 23:01 (2.2.2.2)"
+        }
+        get_sessions 2>/dev/null
+    )
+    if [ "$(echo "$out" | jq 'length')" = "1" ]; then
+        pass "get_sessions caps the list at max_reported_sessions"
+    else
+        fail "get_sessions caps the list at max_reported_sessions" "$out"
+    fi
+}
+
 # ── Run all tests ──
 echo "=== Testing ob-heartbeat ==="
 run_test test_syntax
@@ -301,6 +458,13 @@ run_test test_read_token_legacy
 run_test test_build_curl_opts_default
 run_test test_build_curl_opts_insecure
 run_test test_parse_args
+run_test test_load_config_invalid_max_sessions
+run_test test_load_config_session_settings
+run_test test_get_sessions_disabled
+run_test test_get_sessions_loginctl
+run_test test_get_sessions_loginctl_skips_nonuser
+run_test test_get_sessions_who_fallback
+run_test test_get_sessions_cap
 
 echo ""
 echo "=== Results: $TESTS_PASSED/$TESTS_RUN passed, $TESTS_FAILED failed ==="

--- a/tests/test_ob_heartbeat.sh
+++ b/tests/test_ob_heartbeat.sh
@@ -335,6 +335,29 @@ CONF
     fi
 }
 
+# ── Test 14b: load_config reads node_role ──
+test_load_config_node_role() {
+    local tmpconf
+    tmpconf=$(mktemp)
+    cat > "$tmpconf" <<'CONF'
+portal_url = https://portal.test.com
+node_role = standalone
+CONF
+    (
+        source_script "ob-heartbeat"
+        CONFIG_FILE="$tmpconf"
+        load_config 2>/dev/null
+        [ "$NODE_ROLE" = "standalone" ] && exit 0 || exit 1
+    )
+    local rc=$?
+    rm -f "$tmpconf"
+    if [ $rc -eq 0 ]; then
+        pass "load_config reads node_role"
+    else
+        fail "load_config reads node_role"
+    fi
+}
+
 # ── Test 15: get_sessions returns [] when reporting disabled ──
 test_get_sessions_disabled() {
     local out
@@ -460,6 +483,7 @@ run_test test_build_curl_opts_insecure
 run_test test_parse_args
 run_test test_load_config_invalid_max_sessions
 run_test test_load_config_session_settings
+run_test test_load_config_node_role
 run_test test_get_sessions_disabled
 run_test test_get_sessions_loginctl
 run_test test_get_sessions_loginctl_skips_nonuser


### PR DESCRIPTION
Related to #137

## Summary

Make each machine report **who is currently connected** to the SSO, via the existing heartbeat mechanism.

`ob-heartbeat` now collects the list of active user sessions and includes them as a `sessions` array in the `/pam/heartbeat` payload, alongside the existing `stats` field.

Each entry: `{ user, from (source host), tty, since (login epoch) }`.

## Details

- **Source**: `loginctl show-session` (systemd-logind, filtered on `Class=user`), with a fallback to `who(1)`/utmp when logind is unavailable.
- **Config** (`openbastion.conf`):
  - `report_sessions` (default `true`) — disable reporting (active sessions are privacy-sensitive).
  - `max_reported_sessions` (default `200`) — cap the payload; truncation is logged, never silent.
- JSON is always built with `jq` (no shell interpolation).

## Companion PR

Server-side storage lives in **linagora/lemonldap-ng-plugins** (`feat/heartbeat-connected-sessions`): the `/pam/heartbeat` endpoint persists the `sessions` array as `_pamSessions` / `_pamSessionCount` in the refresh-token session. Both PRs are needed for the end-to-end feature.

## Tests

- `bash -n scripts/ob-heartbeat` ✅
- `get_sessions` validated on both the loginctl path and the `who` fallback (valid JSON, correct epoch/host/tty) ✅
- `report_sessions=false` → `[]` ✅
- Full payload with `sessions` field validated ✅

Remaining: end-to-end validation on the 3-VM lab (portal must be running).