### PR TITLE
fix(ob-builder): drop duplicate ob_verify_ssl in generated Ansible defaults

### DIFF
--- a/admin-builder/ob-builder
+++ b/admin-builder/ob-builder
@@ -834,14 +834,12 @@ _mode_settings_yaml() {
     case "$mode" in
         A|B)
             cat << 'YML'
-ob_verify_ssl: true
 ob_cache_enabled: true
 ob_cache_ttl: 300
 YML
             ;;
         C)
             cat << 'YML'
-ob_verify_ssl: true
 ob_cache_enabled: true
 ob_cache_ttl: 300
 ob_ssh_key_policy_enabled: true
@@ -850,14 +848,12 @@ YML
             ;;
         D)
             cat << 'YML'
-ob_verify_ssl: true
 ob_cache_enabled: true
 ob_cache_ttl: 300
 YML
             ;;
         E)
             cat << 'YML'
-ob_verify_ssl: true
 ob_min_tls_version: 13
 ob_cache_enabled: true
 ob_cache_ttl: 60


### PR DESCRIPTION
## Problem

A generated Ansible artifact triggers on every `ansible-playbook` run:

```
[WARNING]: Found duplicate mapping key 'ob_verify_ssl'.
Origin: roles/open-bastion/defaults/main.yml:80
Using last defined value only.
```

`ob_verify_ssl: true` is emitted twice in `defaults/main.yml`: once in the canonical OIDC/portal section (from `templates/ansible/role/defaults/main.yml.in`) and again in the "Mode-specific config keys" block produced by `_mode_settings_yaml()` in `ob-builder`.

## Fix

Remove `ob_verify_ssl` from all four mode blocks (`A|B`, `C`, `D`, `E`) in `_mode_settings_yaml()`. The template keeps the single authoritative definition, so generated artifacts now have exactly one `ob_verify_ssl` key.

Harmless before the fix (both values were `true`), but the warning is noise and a divergent override would have silently used the last value.

## Verification

- `bash -n admin-builder/ob-builder` ✅
- No `ob_verify_ssl` left in the mode blocks; one remains in `defaults/main.yml.in`.
- A freshly generated `defaults/main.yml` parses cleanly (`yaml.safe_load`) with a single `ob_verify_ssl`.