### PR TITLE
fix: robust Ansible Mode E deploy + fail enrollment without refresh token

### DIFF
--- a/admin-builder/templates/ansible/inventory.yml.example.in
+++ b/admin-builder/templates/ansible/inventory.yml.example.in
@@ -8,6 +8,24 @@
 #
 # Override ob_client_secret per-host (or group_vars) via ansible-vault:
 #   ansible-vault encrypt_string 's3cr3t' --name ob_client_secret
+#
+# ── SSH connection variables ──────────────────────────────────────────────────
+# How Ansible reaches and escalates on each host (NOT the open-bastion users —
+# this is the admin account used only to deploy). Set per host or per group:
+#
+#   ansible_host                 IP/FQDN actually used to reach the host. The
+#                                inventory name above can stay logical/symbolic.
+#   ansible_user                 SSH login of the deploy account (needs sudo).
+#   ansible_ssh_private_key_file Path to that account's private key.
+#   ansible_become: true         Escalate to root with sudo for the tasks.
+#                                Add --ask-become-pass (-K) on the CLI, or set
+#                                ansible_become_password (via ansible-vault), if
+#                                sudo needs a password.
+#
+# Tip: if SSH fails with "Too many authentication failures", your agent is
+# offering too many keys. Force the chosen key only:
+#   ansible_ssh_common_args: "-o IdentitiesOnly=yes"
+# Test connectivity before deploying:  ansible -i inventory.yml all -m ping
 
 all:
   children:
@@ -16,6 +34,10 @@ all:
     bastions:
       hosts:
         bastion-01.example.com:
+          # ansible_host: 203.0.113.10
+          # ansible_user: admin
+          # ansible_ssh_private_key_file: ~/.ssh/id_ed25519
+          # ansible_become: true
           ob_server_group: "@@SERVER_GROUP@@"
         bastion-02.example.com:
           ob_server_group: "@@SERVER_GROUP@@"

--- a/admin-builder/templates/ansible/role/handlers/main.yml
+++ b/admin-builder/templates/ansible/role/handlers/main.yml
@@ -9,4 +9,6 @@
   ansible.builtin.service:
     name: "{{ 'sshd' if ansible_facts['os_family'] == 'RedHat' else 'ssh' }}"
     state: restarted
-  when: not (ob_auto_setup | default(true))
+  # | bool so an --extra-vars override (ob_auto_setup=false → string "false",
+  # which is truthy in Jinja) is interpreted correctly, not silently truthy.
+  when: not (ob_auto_setup | default(true) | bool)

--- a/admin-builder/templates/ansible/role/handlers/main.yml
+++ b/admin-builder/templates/ansible/role/handlers/main.yml
@@ -1,5 +1,12 @@
 ---
+# Only restart sshd from Ansible when the role configured sshd itself
+# (ob_auto_setup = false). When ob_auto_setup is true, ob-bastion-setup /
+# ob-backend-setup already restart sshd at the end of their run — and Mode E
+# locks sudo behind an LLNG token, so a become-based handler running afterwards
+# can no longer escalate ("Missing sudo password"). Skipping it then avoids a
+# spurious failure on an otherwise-successful deployment.
 - name: Restart sshd
   ansible.builtin.service:
     name: "{{ 'sshd' if ansible_facts['os_family'] == 'RedHat' else 'ssh' }}"
     state: restarted
+  when: not (ob_auto_setup | default(true))

--- a/scripts/ob-enroll
+++ b/scripts/ob-enroll
@@ -579,18 +579,30 @@ save_token() {
         chmod 600 "$TOKEN_FILE"
     fi
 
-    log_success "Token saved to $TOKEN_FILE (JSON format)"
-
     if [ -n "$REFRESH_TOKEN" ]; then
+        log_success "Token saved to $TOKEN_FILE (JSON format)"
         log_info "Refresh token saved - can be used for automatic token renewal"
         log_info "Token expires at: $(date -d "@$expires_at" 2>/dev/null || date -r "$expires_at" 2>/dev/null || echo "$expires_at")"
-    else
-        log_error "No refresh_token was issued by the portal."
-        log_error "The server got only a short-lived access token; SSO/NSS lookups"
-        log_error "will break after it expires and cannot be renewed."
+    elif printf '%s' "$SCOPE" | grep -qw offline_access; then
+        # offline_access was requested but the portal returned no refresh_token:
+        # the server got only a short-lived access token that cannot be renewed,
+        # so NSS/SSO lookups would break ~1h later. Fail loudly HERE (instead of
+        # returning success and letting ob-*-setup choke later) and remove the
+        # dead token so it is not reused on the next run.
+        rm -f "$TOKEN_FILE"
+        log_error "No refresh_token was issued by the portal (enrollment FAILED)."
+        log_error "The server would get only a short-lived access token; SSO/NSS"
+        log_error "lookups would break after it expires and could not be renewed."
         log_error "The OIDC client '${CLIENT_ID:-pam-access}' must allow offline access:"
-        log_error "  set oidcRPMetaDataOptionsAllowOffline = 1 on that client in LLNG,"
-        log_error "  and make sure 'offline_access' is an allowed scope."
+        log_error "  - set oidcRPMetaDataOptionsAllowOffline = 1 on that client in LLNG,"
+        log_error "  - ensure 'offline_access' is an allowed scope,"
+        log_error "  - and (device flow) deploy oidc-device-organization >= 0.3.3,"
+        log_error "    which keeps offline_access instead of stripping it."
+        exit 1
+    else
+        # offline_access not requested: a refresh-less token is expected.
+        log_success "Token saved to $TOKEN_FILE (JSON format)"
+        log_warn "No refresh_token (offline_access not requested); token cannot be renewed."
     fi
 }
 

--- a/tests/test_ob_enroll.sh
+++ b/tests/test_ob_enroll.sh
@@ -587,6 +587,44 @@ test_jwt_expiration() {
     return 0
 }
 
+# Test 26: save_token FAILS (and removes the token) when offline_access was
+# requested but the portal returned no refresh_token (the real-world cause of
+# the failure was a portal stripping offline_access).
+test_save_token_no_refresh_fails() {
+    local token_file="$TEMP_DIR/no_refresh_token.json"
+    (
+        source_script_functions
+        TOKEN_FILE="$token_file"
+        SCOPE="pam:server offline_access"
+        ACCESS_TOKEN="at_only"
+        REFRESH_TOKEN=""
+        EXPIRES_IN=3600
+        save_token > /dev/null 2>&1
+    )
+    local rc=$?
+    # Must fail (non-zero) AND not leave a dead, unrenewable token behind.
+    [ "$rc" -ne 0 ] || return 1
+    [ ! -f "$token_file" ] || return 1
+    return 0
+}
+
+# Test 27: save_token SUCCEEDS without a refresh_token when offline_access was
+# not requested (a refresh-less token is expected there, just a warning).
+test_save_token_no_offline_ok() {
+    local token_file="$TEMP_DIR/no_offline_token.json"
+    (
+        source_script_functions
+        TOKEN_FILE="$token_file"
+        SCOPE="pam:server"
+        ACCESS_TOKEN="at_only"
+        REFRESH_TOKEN=""
+        EXPIRES_IN=3600
+        save_token > /dev/null 2>&1
+    ) || return 1
+    [ -f "$token_file" ] || return 1
+    return 0
+}
+
 # Run all tests
 main() {
     echo "================================"
@@ -614,6 +652,8 @@ main() {
     run_test "build_curl_opts with insecure" test_build_curl_opts_insecure
     run_test "Color disabled when not terminal" test_colors_disabled_non_tty
     run_test "save_token creates valid JSON via jq" test_save_token_json
+    run_test "save_token fails + removes token when no refresh_token" test_save_token_no_refresh_fails
+    run_test "save_token ok without refresh when offline not requested" test_save_token_no_offline_ok
     run_test "Config file with 'portal' alias works" test_config_portal_alias
     run_test "Multiple values in config - last one wins" test_config_last_value_wins
     run_test "Empty config file doesn't break load_config" test_empty_config


### PR DESCRIPTION
Three fixes found while deploying a Mode E bastion through the ob-builder Ansible artifact.

## 1. `ob-enroll`: fail when offline requested but no refresh token issued
When the scope includes `offline_access` but the portal returns **no** `refresh_token`, `save_token` previously wrote the (unrenewable) token and returned 0. NSS/SSO then worked for ~1h, and `ob-bastion-setup` only aborted later — leaving a dead token that got reused on the next run.

Now: remove the token and `exit 1` with an actionable message (enable `AllowOffline`, allow `offline_access`, deploy `oidc-device-organization >= 0.3.3` which keeps `offline_access` instead of stripping it). A refresh-less token is still accepted when `offline_access` was **not** requested.

> Context: a portal running an old `oidc-device-organization` stripped `offline_access` from the device-code scope, so the device grant returned no refresh token while the auth-code grant did. `ob-bastion-setup` (Mode E) rightly refused; this change surfaces it at enrollment instead.

## 2. Ansible role: gate the `Restart sshd` handler on `ob_auto_setup`
With `ob_auto_setup: true`, `ob-*-setup` already restarts sshd, **and** Mode E locks `sudo` behind an LLNG token — so a `become` handler flushed afterwards fails with "Missing sudo password" on an otherwise-successful deploy. The handler now runs only when `ob_auto_setup` is false (Ansible-managed config without the setup script).

## 3. `inventory.yml.example`: document SSH connection variables
Commented `ansible_host` / `ansible_user` / `ansible_ssh_private_key_file` / `ansible_become` on the first host, plus the `IdentitiesOnly=yes` tip for "Too many authentication failures" and an `-m ping` connectivity check.

## Tests
- `tests/test_ob_enroll.sh`: +2 cases (no-refresh ⇒ fail+remove; no-offline ⇒ ok). Full suite **27/27**.
- Templates validated as YAML; `bash -n scripts/ob-enroll` clean.

(2) and (3) are ob-builder template changes; regenerate artifacts to pick them up.