### PR TITLE
fix(sudo): require LLNG token for sudo in Mode E and fix sudo -i

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -304,6 +304,13 @@ install(FILES
     DESTINATION ${CMAKE_INSTALL_MANDIR}/man8
 )
 
+# Man page for the ob-standalone-setup symlink (points at ob-bastion-setup.8).
+install(CODE "
+    set(_man8dir \"\$ENV{DESTDIR}${CMAKE_INSTALL_FULL_MANDIR}/man8\")
+    execute_process(COMMAND \"${CMAKE_COMMAND}\" -E create_symlink
+        ob-bastion-setup.8 \"\${_man8dir}/ob-standalone-setup.8\")
+")
+
 # Install man pages (section 1 - user commands)
 install(FILES
     ${CMAKE_SOURCE_DIR}/man/ob-ssh-cert.1

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -265,6 +265,15 @@ install(PROGRAMS ${CMAKE_SOURCE_DIR}/scripts/ob-bastion-setup
     DESTINATION ${CMAKE_INSTALL_SBINDIR}
 )
 
+# ob-standalone-setup is a symlink to ob-bastion-setup: invoked under that name
+# the script defaults --node-role to "standalone", giving admins a clearer,
+# self-documenting command for combined bastion+backend hosts.
+install(CODE "
+    set(_sbindir \"\$ENV{DESTDIR}${CMAKE_INSTALL_FULL_SBINDIR}\")
+    execute_process(COMMAND \"${CMAKE_COMMAND}\" -E create_symlink
+        ob-bastion-setup \"\${_sbindir}/ob-standalone-setup\")
+")
+
 # Install auditd templates (consumed by `ob-bastion-setup --enable-audit-trace`).
 # Read-only templates under /usr/share/open-bastion/audit/. The setup function
 # copies them into /etc/audit/rules.d/ and /etc/cron.daily/ at deployment time.

--- a/admin-builder/ob-builder
+++ b/admin-builder/ob-builder
@@ -1155,7 +1155,14 @@ render_ansible_role() {
     local files_dir="$outpath/roles/open-bastion/files"
     mkdir -p "$files_dir"
     atomic_write_from "$files_dir/open-bastion-ca.pub" "0644" "$WORK_DIR/ca.pub"
-    if [ -s "$WORK_DIR/krl" ]; then
+    if [ "$SCENARIO" = "max-security" ]; then
+        # Mode E always ships a KRL file: the role's mandatory "Deploy KRL" task
+        # references it unconditionally. An empty/unavailable upstream KRL is
+        # valid for a fresh portal with no revocations yet — ship an empty file
+        # (the refresh cron fills it in later), matching ob-bastion-setup's
+        # download_krl. Without this, Mode E deploys fail with "Could not find
+        # open-bastion-krl" whenever the portal KRL is still empty.
+        [ -f "$WORK_DIR/krl" ] || : > "$WORK_DIR/krl"
         atomic_write_from "$files_dir/open-bastion-krl" "0644" "$WORK_DIR/krl"
     fi
     atomic_write_from "$files_dir/open-bastion.gpg" "0644" "$REPO_KEYRING"
@@ -1209,7 +1216,9 @@ EOF
     atomic_write "$defaults_dir/main.yml" "0644" "$defaults"
 
     atomic_write_from "$files_dir/open-bastion-ca.pub" "0644" "$WORK_DIR/ca.pub"
-    if [ -s "$WORK_DIR/krl" ]; then
+    if [ "$SCENARIO" = "max-security" ]; then
+        # Mode E always ships a KRL file (empty is valid for a fresh portal).
+        [ -f "$WORK_DIR/krl" ] || : > "$WORK_DIR/krl"
         atomic_write_from "$files_dir/open-bastion-krl" "0644" "$WORK_DIR/krl"
     fi
     atomic_write_from "$files_dir/open-bastion.gpg" "0644" "$REPO_KEYRING"

--- a/admin-builder/templates/ansible/role/tasks/_enroll.yml.in
+++ b/admin-builder/templates/ansible/role/tasks/_enroll.yml.in
@@ -86,8 +86,8 @@
   # which matter most when enrolling a fleet: a single refused connection should
   # not abort the play.
   until: _ob_verify_page is succeeded
-  retries: 5
-  delay: 3
+  retries: 10
+  delay: 5
   when: _ob_use_auto_approve
 
 - name: "Extract CSRF token from the verification page"
@@ -128,8 +128,8 @@
   become: false
   register: _ob_approve_result
   until: _ob_approve_result is succeeded
-  retries: 5
-  delay: 3
+  retries: 10
+  delay: 5
   when: _ob_use_auto_approve
 
 - name: "Wait for ob-enroll to complete (polling token endpoint)"

--- a/admin-builder/templates/ansible/role/tasks/_enroll.yml.in
+++ b/admin-builder/templates/ansible/role/tasks/_enroll.yml.in
@@ -82,6 +82,12 @@
   delegate_to: localhost
   become: false
   register: _ob_verify_page
+  # Tolerate transient portal blips (a reload, a brief outage, rate-limiting),
+  # which matter most when enrolling a fleet: a single refused connection should
+  # not abort the play.
+  until: _ob_verify_page is succeeded
+  retries: 5
+  delay: 3
   when: _ob_use_auto_approve
 
 - name: "Extract CSRF token from the verification page"
@@ -120,6 +126,10 @@
     status_code: [200, 302]
   delegate_to: localhost
   become: false
+  register: _ob_approve_result
+  until: _ob_approve_result is succeeded
+  retries: 5
+  delay: 3
   when: _ob_use_auto_approve
 
 - name: "Wait for ob-enroll to complete (polling token endpoint)"

--- a/debian/open-bastion.install
+++ b/debian/open-bastion.install
@@ -19,6 +19,7 @@ usr/sbin/ob-heartbeat
 usr/sbin/ob-session-recorder
 usr/sbin/ob-session-recorder-wrapper
 usr/sbin/ob-bastion-setup
+usr/sbin/ob-standalone-setup
 usr/sbin/ob-backend-setup
 usr/sbin/ob-bastion-cert-helper
 usr/sbin/ob-cache-admin
@@ -40,6 +41,7 @@ usr/share/man/man1/ob-bastion-id.1
 usr/share/man/man8/ob-enroll.8
 usr/share/man/man8/ob-heartbeat.8
 usr/share/man/man8/ob-bastion-setup.8
+usr/share/man/man8/ob-standalone-setup.8
 usr/share/man/man8/ob-backend-setup.8
 usr/share/man/man8/ob-session-recorder.8
 

--- a/debian/open-bastion.links
+++ b/debian/open-bastion.links
@@ -1,2 +1,0 @@
-usr/sbin/ob-bastion-setup usr/sbin/ob-standalone-setup
-usr/share/man/man8/ob-bastion-setup.8 usr/share/man/man8/ob-standalone-setup.8

--- a/debian/open-bastion.links
+++ b/debian/open-bastion.links
@@ -1,0 +1,2 @@
+usr/sbin/ob-bastion-setup usr/sbin/ob-standalone-setup
+usr/share/man/man8/ob-bastion-setup.8 usr/share/man/man8/ob-standalone-setup.8

--- a/docker-demo-maxsec/backend/Dockerfile
+++ b/docker-demo-maxsec/backend/Dockerfile
@@ -77,7 +77,8 @@ session    required     pam_openbastion.so create_user=true\n\
 session    required     pam_unix.so\n\
 ' > /etc/pam.d/sshd
 
-# Configure PAM for sudo (Mode E: LLNG temporary token required)
+# Configure PAM for sudo + sudo -i (Mode E: LLNG temporary token required).
+# `sudo -i` uses the separate "sudo-i" PAM service, so it gets the same stack.
 RUN echo '# PAM configuration for sudo with Open Bastion (Mode E)\n\
 # LLNG temporary token ONLY - Unix passwords REJECTED\n\
 auth       sufficient   pam_openbastion.so\n\
@@ -86,7 +87,7 @@ auth       required     pam_deny.so\n\
 account    required     pam_openbastion.so\n\
 \n\
 session    required     pam_unix.so\n\
-' > /etc/pam.d/sudo
+' | tee /etc/pam.d/sudo /etc/pam.d/sudo-i > /dev/null
 
 # Configure NSS to use Open Bastion
 RUN sed -i 's/^passwd:.*/passwd:         files openbastion/' /etc/nsswitch.conf && \

--- a/docker-demo-maxsec/bastion/Dockerfile
+++ b/docker-demo-maxsec/bastion/Dockerfile
@@ -82,7 +82,8 @@ session    required     pam_unix.so\n\
 session    optional     pam_openbastion.so\n\
 ' > /etc/pam.d/sshd
 
-# Configure PAM for sudo (Mode E: LLNG temporary token required)
+# Configure PAM for sudo + sudo -i (Mode E: LLNG temporary token required).
+# `sudo -i` uses the separate "sudo-i" PAM service, so it gets the same stack.
 RUN echo '# PAM configuration for sudo with Open Bastion (Mode E)\n\
 # LLNG temporary token ONLY - Unix passwords REJECTED\n\
 auth       sufficient   pam_openbastion.so\n\
@@ -91,7 +92,7 @@ auth       required     pam_deny.so\n\
 account    required     pam_openbastion.so\n\
 \n\
 session    required     pam_unix.so\n\
-' > /etc/pam.d/sudo
+' | tee /etc/pam.d/sudo /etc/pam.d/sudo-i > /dev/null
 
 # Defense-in-depth: only open-bastion-sudo group members can sudo (PAM also required)
 RUN groupadd --system open-bastion-sudo 2>/dev/null || true \

--- a/local-test/config/build-standalone.yml
+++ b/local-test/config/build-standalone.yml
@@ -1,0 +1,29 @@
+# ob-builder config for the lab STANDALONE host (consumed by deploy-ansible.sh).
+#
+# A standalone host is bastion+backend in one, with no bastion in front: users
+# SSH into it directly. It enrols with the bastion client_id (`ob-bastion`, which
+# the lab LLNG maps to the *bastion* server group — see sso/configure.sh) so dwho
+# is authorised to log in directly, exactly as on the bastion. target_role:
+# standalone makes ob-builder drive ob-bastion-setup --node-role standalone.
+#
+# `scenario` is overridden at run time from $OB_SCENARIO by deploy-ansible.sh so
+# the same config exercises every PAM mode.
+deployment_slug: oblab
+scenario: token-only
+portal_url: http://auth.example.com
+client_id: ob-bastion
+client_id_policy: fixed
+client_secret_mode: embedded
+embedded_client_secret: bastionsecret
+server_group: bastion
+server_group_policy: fixed
+target_role: standalone
+auto_enroll_setup: yes
+ansible_auto_approve: yes
+apt_url: http://192.168.122.1:8088
+apt_suite: ./
+apt_component: ""
+enable_hardening: no
+enable_audit_trace: no
+disable_session_recorder: no
+self_delete: no

--- a/local-test/deploy-all-modes.sh
+++ b/local-test/deploy-all-modes.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Run the Ansible deploy harness once per PAM scenario (all five modes), each on
+# a freshly recreated lab (bastion + 2 backends + standalone). Prints a per-mode
+# PASS/FAIL scoreboard. NOT run in CI (needs libvirt VMs + the Docker SSO).
+#
+# Usage:  local-test/deploy-all-modes.sh [scenario ...]
+#         OB_GOLDEN=... local-test/deploy-all-modes.sh        # all five modes
+#         local-test/deploy-all-modes.sh max-security         # one mode
+set -uo pipefail
+LT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+SCENARIOS=("$@")
+[ "${#SCENARIOS[@]}" -gt 0 ] || SCENARIOS=(token-only token+unix keys+llng mixed max-security)
+
+declare -A RESULT
+overall=0
+for scen in "${SCENARIOS[@]}"; do
+    log="$LT_DIR/.work/all-modes-$scen.log"
+    printf '\n############ scenario=%s ############\n' "$scen"
+    # Reuse the build + SSO across runs to save time; the harness still recreates
+    # the VMs every run, which is what we want for an isolated per-mode test.
+    if OB_SCENARIO="$scen" SKIP_BUILD="${SKIP_BUILD:-0}" "$LT_DIR/deploy-ansible.sh" 2>&1 | tee "$log"; then
+        RESULT[$scen]="PASS"
+    else
+        RESULT[$scen]="FAIL"; overall=1
+    fi
+    # After the first run the .deb is staged, so skip rebuilding for the rest.
+    SKIP_BUILD=1
+done
+
+printf '\n================ all-modes scoreboard ================\n'
+for scen in "${SCENARIOS[@]}"; do printf '  %-14s %s\n' "$scen" "${RESULT[$scen]}"; done
+exit "$overall"

--- a/local-test/deploy-ansible.sh
+++ b/local-test/deploy-ansible.sh
@@ -35,14 +35,20 @@ _inv_vars(){ cat <<EOF
 EOF
 }
 
+# The standalone host is part of the Ansible lab only (the shell harness leaves
+# it out), so add it to the VM set here rather than in the shared lib.
+[ -n "$STANDALONE_VM" ] && ALL_VMS+=("$STANDALONE_VM")
+
 preflight; build_deb; ensure_sso; recreate_vms
 phase "Bootstrap VMs"; for v in "${ALL_VMS[@]}"; do bootstrap_vm "$v" 0; done
 get_cookie
+mint_dwho_cert   # so the connection-phase + standalone assertions actually run
 
 # ── Phase 1: generate + deploy the bastion, capture bastion_id ───────────────
-phase "Phase 1 — bastion (ob-builder + ansible)"
+phase "Phase 1 — bastion (ob-builder + ansible, scenario=$SCENARIO)"
 rm -rf "$WORK/role-bastion"
-obbuild --config "$CONFIG_DIR/build-bastion.yml" --output-ansible "$WORK/role-bastion" >"$WORK/gen-bastion.log" 2>&1 \
+sed "s/^scenario:.*/scenario: $SCENARIO/" "$CONFIG_DIR/build-bastion.yml" > "$WORK/build-bastion.yml"
+obbuild --config "$WORK/build-bastion.yml" --output-ansible "$WORK/role-bastion" >"$WORK/gen-bastion.log" 2>&1 \
     && ok "generated bastion role" || { bad "ob-builder bastion failed"; cat "$WORK/gen-bastion.log"; }
 cat > "$WORK/role-bastion/inv.yml" <<EOF
 all:
@@ -76,7 +82,8 @@ else bad "bastion deploy failed — see $WORK/deploy-bastion.log"; tail -20 "$WO
 
 # ── Phase 2: generate + deploy the backends with allowed_bastions=bastion_id ─
 phase "Phase 2 — backends (ob-builder + ansible)"
-sed "s/^allowed_bastions:.*/allowed_bastions: ${BID:-ob-bastion}/" "$CONFIG_DIR/build-backend.yml" > "$WORK/build-backend.yml"
+sed -e "s/^allowed_bastions:.*/allowed_bastions: ${BID:-ob-bastion}/" \
+    -e "s/^scenario:.*/scenario: $SCENARIO/" "$CONFIG_DIR/build-backend.yml" > "$WORK/build-backend.yml"
 rm -rf "$WORK/role-backend"
 obbuild --config "$WORK/build-backend.yml" --output-ansible "$WORK/role-backend" >"$WORK/gen-backend.log" 2>&1 \
     && ok "generated backend role (allowed_bastions=${BID:-ob-bastion})" || bad "ob-builder backend failed"
@@ -90,5 +97,34 @@ if grep -q "failed=0" "$WORK/deploy-backends.log" && ! grep -q "failed=[1-9]" "$
     ok "backends deployed"
 else bad "backend deploy failed — see $WORK/deploy-backends.log"; tail -20 "$WORK/deploy-backends.log"; fi
 
+# ── Phase 3: generate + deploy a standalone host (bastion+backend in one) ────
+if [ -n "$STANDALONE_VM" ]; then
+    phase "Phase 3 — standalone (ob-builder + ansible, scenario=$SCENARIO)"
+    rm -rf "$WORK/role-standalone"
+    sed "s/^scenario:.*/scenario: $SCENARIO/" "$CONFIG_DIR/build-standalone.yml" > "$WORK/build-standalone.yml"
+    obbuild --config "$WORK/build-standalone.yml" --output-ansible "$WORK/role-standalone" >"$WORK/gen-standalone.log" 2>&1 \
+        && ok "generated standalone role" || { bad "ob-builder standalone failed"; cat "$WORK/gen-standalone.log"; }
+    cat > "$WORK/role-standalone/inv.yml" <<EOF
+all:
+  vars:
+$(_inv_vars)
+  children:
+    standalones:
+      hosts:
+        $STANDALONE_VM: { ansible_host: ${IP[$STANDALONE_VM]}, ob_server_group: bastion }
+EOF
+    cat > "$WORK/role-standalone/deploy.yml" <<'EOF'
+- hosts: standalones
+  become: true
+  roles: [open-bastion]
+EOF
+    ( cd "$WORK/role-standalone" && ansible-playbook -i inv.yml deploy.yml \
+        --extra-vars "ob_llng_cookie='$COOKIE'" ) >"$WORK/deploy-standalone.log" 2>&1
+    if grep -q "failed=0" "$WORK/deploy-standalone.log" && ! grep -q "failed=[1-9]" "$WORK/deploy-standalone.log"; then
+        ok "standalone deployed"
+    else bad "standalone deploy failed — see $WORK/deploy-standalone.log"; tail -20 "$WORK/deploy-standalone.log"; fi
+fi
+
 verify_e2e
+verify_standalone
 summary

--- a/local-test/deploy-ansible.sh
+++ b/local-test/deploy-ansible.sh
@@ -64,21 +64,31 @@ cat > "$WORK/role-bastion/deploy.yml" <<'EOF'
   become: true
   roles: [open-bastion]
   post_tasks:
+    # ob-bastion-id needs root to read the server token. In Mode E sudo is
+    # locked to LLNG tokens, so this become-task cannot run as the debian mgmt
+    # user — that is expected. Make it non-fatal; the bastion_id equals the
+    # enrolling client_id in this lab, so the caller falls back to that.
     - name: Capture bastion_id
       ansible.builtin.command: ob-bastion-id
       register: _bid
       changed_when: false
+      failed_when: false
     - ansible.builtin.copy:
         content: "{{ _bid.stdout }}\n"
         dest: "{{ bid_out }}"
       delegate_to: localhost
       become: false
+      when: _bid.rc == 0 and (_bid.stdout | default('') | length) > 0
 EOF
 ( cd "$WORK/role-bastion" && ansible-playbook -i inv.yml deploy.yml \
     --extra-vars "ob_llng_cookie='$COOKIE' bid_out=$WORK/bastion-id.txt" ) >"$WORK/deploy-bastion.log" 2>&1
-if grep -q "failed=0" "$WORK/deploy-bastion.log" && [ -s "$WORK/bastion-id.txt" ]; then
-    BID="$(cat "$WORK/bastion-id.txt")"; ok "bastion deployed; bastion_id=$BID"
-else bad "bastion deploy failed — see $WORK/deploy-bastion.log"; tail -20 "$WORK/deploy-bastion.log"; BID=""; fi
+if grep -q "failed=0" "$WORK/deploy-bastion.log"; then
+    # In Mode E the bastion_id capture is skipped (sudo locked), so fall back to
+    # the enrolling client_id, which is what the bastion_id resolves to here.
+    BID="$([ -s "$WORK/bastion-id.txt" ] && cat "$WORK/bastion-id.txt" || true)"
+    BID="${BID:-ob-bastion}"
+    ok "bastion deployed; bastion_id=$BID"
+else bad "bastion deploy failed — see $WORK/deploy-bastion.log"; tail -20 "$WORK/deploy-bastion.log"; BID="ob-bastion"; fi
 
 # ── Phase 2: generate + deploy the backends with allowed_bastions=bastion_id ─
 phase "Phase 2 — backends (ob-builder + ansible)"

--- a/local-test/deploy-ansible.sh
+++ b/local-test/deploy-ansible.sh
@@ -64,21 +64,23 @@ cat > "$WORK/role-bastion/deploy.yml" <<'EOF'
   become: true
   roles: [open-bastion]
   post_tasks:
-    # ob-bastion-id needs root to read the server token. In Mode E sudo is
-    # locked to LLNG tokens, so this become-task cannot run as the debian mgmt
-    # user — that is expected. Make it non-fatal; the bastion_id equals the
-    # enrolling client_id in this lab, so the caller falls back to that.
+    # ob-bastion-id needs root to read the server token. In Mode E sudo is locked
+    # to LLNG tokens, so the debian mgmt user cannot become root at all (a become
+    # failure isn't catchable with failed_when), so skip the capture there. The
+    # bastion_id equals the enrolling client_id in this lab, so the caller falls
+    # back to that.
     - name: Capture bastion_id
       ansible.builtin.command: ob-bastion-id
       register: _bid
       changed_when: false
       failed_when: false
+      when: not (ob_max_security | default(false) | bool)
     - ansible.builtin.copy:
         content: "{{ _bid.stdout }}\n"
         dest: "{{ bid_out }}"
       delegate_to: localhost
       become: false
-      when: _bid.rc == 0 and (_bid.stdout | default('') | length) > 0
+      when: (_bid.rc | default(1)) == 0 and (_bid.stdout | default('') | length) > 0
 EOF
 ( cd "$WORK/role-bastion" && ansible-playbook -i inv.yml deploy.yml \
     --extra-vars "ob_llng_cookie='$COOKIE' bid_out=$WORK/bastion-id.txt" ) >"$WORK/deploy-bastion.log" 2>&1

--- a/local-test/lib.sh
+++ b/local-test/lib.sh
@@ -23,7 +23,14 @@ SSH_KEY="${OB_SSH_KEY:-$HOME/.ssh/id_oblab}"
 DEB="open-bastion_0.3.1_amd64.deb"
 BASTION_VM="${OB_BASTION_VM:-lab-a}"
 read -ra BACKEND_VMS <<< "${OB_BACKEND_VMS:-lab-b lab-c}"
+# A standalone host (bastion+backend in one) — deployed with the ob-builder
+# standalone role via ob-standalone-setup. Only the Ansible harness uses it; it
+# appends $STANDALONE_VM to ALL_VMS itself. Set OB_STANDALONE_VM="" to skip it.
+STANDALONE_VM="${OB_STANDALONE_VM-lab-d}"
 ALL_VMS=("$BASTION_VM" "${BACKEND_VMS[@]}")
+# Security scenario fed to ob-builder for every role (token-only|token+unix|
+# keys+llng|mixed|max-security). Lets the harness exercise all PAM modes.
+SCENARIO="${OB_SCENARIO:-token-only}"
 # dwho SSO cert for the connection-phase checks (minted out of band; absent => skip)
 DWHO_KEY="${OB_DWHO_KEY:-/tmp/ob-e2e/id_dwho}"
 DWHO_CERT="${OB_DWHO_CERT:-/tmp/ob-e2e/id_dwho-cert.pub}"
@@ -164,6 +171,34 @@ get_cookie(){
     [ -n "$COOKIE" ] || die "could not obtain LLNG cookie"
 }
 
+# Mint a dwho SSO certificate (server_group=bastion) via the portal's /ssh/sign
+# endpoint using the approval cookie, so the connection-phase and standalone
+# assertions can run instead of being skipped. No-op if a cert already exists or
+# signing fails (the dependent checks then skip, as before). Needs $COOKIE.
+mint_dwho_cert(){
+    [ -n "${COOKIE:-}" ] || return 0
+    mkdir -p "$(dirname "$DWHO_KEY")"
+    rm -f "$DWHO_KEY" "$DWHO_KEY.pub" "$DWHO_CERT"
+    # The SSHCA enforces per-user label uniqueness among non-expired certs, and
+    # the label defaults to the key comment. Repeated lab runs would reuse the
+    # same comment and trip "label already used for another key", so stamp a
+    # unique label/comment on every mint.
+    local label="oblab-dwho-$(date +%s)-$$"
+    ssh-keygen -t ed25519 -f "$DWHO_KEY" -N "" -C "$label" -q
+    local pub resp cert
+    pub=$(cat "$DWHO_KEY.pub")
+    resp=$(curl -s -H "Host: auth.example.com" -b "$COOKIE" -H "Content-Type: application/json" \
+        -d "{\"public_key\":\"$pub\",\"server_group\":\"bastion\",\"label\":\"$label\"}" "http://$GW_IP/ssh/sign" 2>/dev/null)
+    cert=$(printf '%s' "$resp" | jq -r '.certificate // empty' 2>/dev/null)
+    if [ -n "$cert" ] && printf '%s' "$cert" | grep -q "ssh-ed25519-cert"; then
+        printf '%s\n' "$cert" > "$DWHO_CERT"
+        ok "minted dwho SSO cert -> $DWHO_CERT"
+    else
+        rm -f "$DWHO_KEY" "$DWHO_KEY.pub" "$DWHO_CERT"
+        skip "mint dwho cert (sign endpoint said: ${resp:0:100})"
+    fi
+}
+
 # approve_device <vm-ip> — poll the enroll-state file the target's ob-enroll
 # writes (OB_ENROLL_STATE_FILE) and approve the device code via the gateway.
 approve_device(){
@@ -206,4 +241,37 @@ verify_e2e(){
          echo 'cat /tmp/s2.txt' | ob-ssh dwho@$b2 2>/dev/null | grep -q ob-lt-payload" >/dev/null 2>&1; then
         ok "ob-scp bastion->backend and backend->backend (scp -3)"
     else bad "ob-scp transfers"; fi
+}
+
+# ── standalone verification ──────────────────────────────────────────────────
+# A standalone host is bastion+backend in one, with no bastion in front: a user
+# logs into it directly. Assert the NSS + direct-login path, and (Mode E only,
+# where ob-bastion-setup configures sudo) that sudo AND sudo -i require the LLNG
+# token via pam_openbastion — the regression guard for this fix.
+verify_standalone(){
+    [ -n "$STANDALONE_VM" ] || return 0
+    phase "Assertions — standalone ($STANDALONE_VM, scenario=$SCENARIO)"
+    # A standalone is a bastion (ForceCommand session recorder), so the debian
+    # mgmt key cannot run plain commands and Mode E disables it entirely. Every
+    # check therefore goes through the dwho SSO certificate, like verify_e2e.
+    if [ ! -f "$DWHO_KEY" ] || [ ! -f "$DWHO_CERT" ]; then
+        skip "standalone checks — no dwho cert at $DWHO_KEY (set OB_DWHO_KEY/OB_DWHO_CERT)"
+        return 0
+    fi
+    local s="${IP[$STANDALONE_VM]}"
+    local D=(ssh -i "$DWHO_KEY" -o "CertificateFile=$DWHO_CERT" -o IdentitiesOnly=yes
+             -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null
+             -o NumberOfPasswordPrompts=0 -o ConnectTimeout=15)
+    check "dwho cert logs into standalone directly (no bastion in front)" \
+        "${D[@]}" "dwho@$s" 'true'
+    check "getent passwd dwho on standalone (NSS)" \
+        "${D[@]}" "dwho@$s" 'getent passwd dwho >/dev/null'
+    # Mode E is the only scenario where ob-bastion-setup configures sudo; assert
+    # both sudo and sudo -i require the LLNG token (the fix this PR validates).
+    if [ "$SCENARIO" = "max-security" ]; then
+        check "standalone /etc/pam.d/sudo requires LLNG token (pam_openbastion)" \
+            "${D[@]}" "dwho@$s" 'grep -q pam_openbastion /etc/pam.d/sudo'
+        check "standalone /etc/pam.d/sudo-i requires LLNG token (pam_openbastion)" \
+            "${D[@]}" "dwho@$s" 'grep -q pam_openbastion /etc/pam.d/sudo-i'
+    fi
 }

--- a/man/ob-bastion-setup.8
+++ b/man/ob-bastion-setup.8
@@ -20,6 +20,16 @@ Disables password authentication
 The script downloads the SSH CA public key from LemonLDAP::NG, configures sshd to
 trust certificates signed by that CA, and sets up session recording via
 ForceCommand.
+.PP
+The command is also installed as
+.BR ob-standalone-setup ,
+a symlink to this script. Invoked under that name it defaults
+.B \-\-node\-role
+to
+.B standalone
+(a host that is both bastion and backend); an explicit
+.B \-\-node\-role
+always overrides the default.
 .SH OPTIONS
 .TP
 .BR \-p ", " \-\-portal " " \fIURL\fR

--- a/rpm/open-bastion.spec
+++ b/rpm/open-bastion.spec
@@ -91,6 +91,7 @@ ctest --output-on-failure --verbose
 %{_sbindir}/ob-session-recorder
 %attr(2755,root,ob-sessions) %{_sbindir}/ob-session-recorder-wrapper
 %{_sbindir}/ob-bastion-setup
+%{_sbindir}/ob-standalone-setup
 %{_sbindir}/ob-backend-setup
 %{_sbindir}/ob-bastion-cert-helper
 %{_sbindir}/ob-cache-admin
@@ -115,6 +116,7 @@ ctest --output-on-failure --verbose
 %{_mandir}/man8/ob-enroll.8*
 %{_mandir}/man8/ob-heartbeat.8*
 %{_mandir}/man8/ob-bastion-setup.8*
+%{_mandir}/man8/ob-standalone-setup.8*
 %{_mandir}/man8/ob-backend-setup.8*
 %{_mandir}/man8/ob-session-recorder.8*
 %{_mandir}/man1/ob-ssh.1*

--- a/scripts/ob-backend-setup
+++ b/scripts/ob-backend-setup
@@ -64,6 +64,11 @@ SSHD_CONFIG="/etc/ssh/sshd_config"
 SSHD_CONFIG_DIR="/etc/ssh/sshd_config.d"
 PAM_SSHD="/etc/pam.d/sshd"
 PAM_SUDO="/etc/pam.d/sudo"
+# sudo 1.9 uses a separate PAM service ("sudo-i") for `sudo -i`. It must get the
+# same open-bastion stack as /etc/pam.d/sudo, otherwise `sudo -i` falls back to
+# the distro default (common-auth/common-account = pam_unix), which cannot
+# validate NSS-only SSO users and fails with "account validation failure".
+PAM_SUDO_I="/etc/pam.d/sudo-i"
 NSSWITCH_CONF="/etc/nsswitch.conf"
 OB_CONFIG="/etc/open-bastion/openbastion.conf"
 OB_TOKEN="/var/lib/open-bastion/token"
@@ -538,6 +543,13 @@ session    required     pam_unix.so
     echo "$pam_content" > "$PAM_SUDO"
     chmod 644 "$PAM_SUDO"
     info "Configured $PAM_SUDO"
+
+    # `sudo -i` uses the separate "sudo-i" PAM service; mirror the stack so it
+    # behaves identically to plain sudo for SSO users.
+    backup_file "$PAM_SUDO_I"
+    echo "$pam_content" > "$PAM_SUDO_I"
+    chmod 644 "$PAM_SUDO_I"
+    info "Configured $PAM_SUDO_I"
 }
 
 # Configure sshd for max security (Mode E)
@@ -681,6 +693,13 @@ session    required     pam_unix.so
     echo "$pam_content" > "$PAM_SUDO"
     chmod 644 "$PAM_SUDO"
     info "Configured $PAM_SUDO for LLNG token authentication"
+
+    # `sudo -i` uses the separate "sudo-i" PAM service; mirror the Mode E stack
+    # so `sudo -i` also requires a fresh LLNG token.
+    backup_file "$PAM_SUDO_I"
+    echo "$pam_content" > "$PAM_SUDO_I"
+    chmod 644 "$PAM_SUDO_I"
+    info "Configured $PAM_SUDO_I for LLNG token authentication"
 }
 
 # Ensure /etc/nsswitch.conf has a usable "<db>: files openbastion ..." line.

--- a/scripts/ob-bastion-setup
+++ b/scripts/ob-bastion-setup
@@ -27,9 +27,14 @@ SERVER_GROUP=""
 SERVER_TOKEN=""
 # Node role recorded in openbastion.conf and reported in the heartbeat. This
 # script serves both the bastion and standalone roles (a standalone host runs
-# the full bastion stack); the installer passes --node-role standalone when
-# appropriate. Defaults to "bastion".
-NODE_ROLE="bastion"
+# the full bastion stack). It is installed under two names: invoked as
+# "ob-standalone-setup" (a symlink) it defaults to the standalone role, so
+# admins get a self-documenting command; otherwise it defaults to "bastion".
+# An explicit --node-role always overrides this default.
+case "$PROG_NAME" in
+    ob-standalone-setup) NODE_ROLE="standalone" ;;
+    *)                   NODE_ROLE="bastion" ;;
+esac
 NON_INTERACTIVE=false
 VERIFY_SSL=true
 TIMEOUT=30
@@ -62,6 +67,11 @@ SESSION_RECORDER="/usr/sbin/ob-session-recorder-wrapper"
 SESSION_RECORDER_CONF="/etc/open-bastion/session-recorder.conf"
 SSH_REVOKED_KEYS="/etc/ssh/revoked_keys"
 PAM_SUDO="/etc/pam.d/sudo"
+# sudo 1.9 uses a separate PAM service ("sudo-i") for `sudo -i`. It must get the
+# same open-bastion stack, otherwise `sudo -i` falls back to the distro default
+# (common-auth/common-account = pam_unix), which cannot validate NSS-only SSO
+# users and fails with "account validation failure".
+PAM_SUDO_I="/etc/pam.d/sudo-i"
 NSSWITCH_CONF="/etc/nsswitch.conf"
 NSS_OB_CONF="/etc/open-bastion/nss_openbastion.conf"
 
@@ -792,6 +802,14 @@ session    required     pam_unix.so
     echo "$pam_content" > "$PAM_SUDO"
     chmod 644 "$PAM_SUDO"
     info "Configured $PAM_SUDO for LLNG token authentication"
+
+    # `sudo -i` uses the separate "sudo-i" PAM service. Give it the same stack,
+    # otherwise it falls back to the distro default (pam_unix) and fails for
+    # NSS-only SSO users ("account validation failure, is your account locked?").
+    backup_file "$PAM_SUDO_I"
+    echo "$pam_content" > "$PAM_SUDO_I"
+    chmod 644 "$PAM_SUDO_I"
+    info "Configured $PAM_SUDO_I for LLNG token authentication"
 
     # Create open-bastion-sudo group for defense-in-depth sudo authorization
     groupadd --system open-bastion-sudo 2>/dev/null || true

--- a/src/pam_openbastion.c
+++ b/src/pam_openbastion.c
@@ -2372,8 +2372,22 @@ PAM_VISIBLE PAM_EXTERN int pam_sm_authenticate(pam_handle_t *pamh,
         return PAM_SUCCESS;
     }
 
-    /* If authorize_only mode, skip password check */
-    if (data->config.authorize_only) {
+    /*
+     * authorize_only mode skips the token check because the user already
+     * authenticated out-of-band: on a bastion, sshd validated an SSO
+     * certificate before PAM ran, so pam_sm_authenticate only needs to let
+     * pam_sm_acct_mgmt call /pam/authorize.
+     *
+     * That assumption does NOT hold for sudo: there is no prior certificate
+     * authentication for a sudo invocation, so honoring authorize_only here
+     * would make sudo passwordless whenever the bastion config sets it
+     * (Mode E sets authorize_only=true for sshd). That defeats the Mode E
+     * guarantee that sudo requires a fresh LLNG token. Always require a real
+     * token for the sudo PAM services, regardless of authorize_only.
+     */
+    bool is_sudo_service = service &&
+        (strcmp(service, "sudo") == 0 || strcmp(service, "sudo-i") == 0);
+    if (data->config.authorize_only && !is_sudo_service) {
         OB_LOG_DEBUG(pamh, "authorize_only mode, skipping password check");
         return PAM_SUCCESS;
     }

--- a/tests/test_integration_maxsec.sh
+++ b/tests/test_integration_maxsec.sh
@@ -840,19 +840,26 @@ test_sudo_pam_config() {
     TESTS_RUN=$((TESTS_RUN + 1))
     log "Testing sudo PAM requires LLNG token (Mode E)..."
 
-    local sudo_pam
+    local sudo_pam sudo_i_pam
     sudo_pam=$(docker exec ob-maxsec-backend cat /etc/pam.d/sudo 2>&1) || true
+    # `sudo -i` uses the separate "sudo-i" PAM service; it must carry the same
+    # open-bastion stack, otherwise `sudo -i` falls back to pam_unix and breaks
+    # for NSS-only SSO users (regression guard for the sudo-i fix).
+    sudo_i_pam=$(docker exec ob-maxsec-backend cat /etc/pam.d/sudo-i 2>&1) || true
 
-    local has_openbastion has_deny no_nopasswd
+    local has_openbastion has_deny no_nopasswd has_openbastion_i
     has_openbastion=$(echo "$sudo_pam" | grep -c "pam_openbastion" || true)
     has_deny=$(echo "$sudo_pam" | grep -c "pam_deny" || true)
+    has_openbastion_i=$(echo "$sudo_i_pam" | grep -c "pam_openbastion" || true)
     no_nopasswd=$(docker exec ob-maxsec-backend grep -c "NOPASSWD" /etc/sudoers 2>&1) || true
 
-    if [[ "$has_openbastion" -ge 1 ]] && [[ "$has_deny" -ge 1 ]] && [[ "$no_nopasswd" -eq 0 ]]; then
-        pass "sudo PAM correctly requires LLNG token (no NOPASSWD)"
+    if [[ "$has_openbastion" -ge 1 ]] && [[ "$has_deny" -ge 1 ]] && \
+       [[ "$has_openbastion_i" -ge 1 ]] && [[ "$no_nopasswd" -eq 0 ]]; then
+        pass "sudo and sudo -i PAM correctly require LLNG token (no NOPASSWD)"
         return 0
     else
-        fail "sudo PAM not properly configured for Mode E" "openbastion=$has_openbastion, deny=$has_deny, nopasswd=$no_nopasswd"
+        fail "sudo PAM not properly configured for Mode E" \
+             "openbastion=$has_openbastion, deny=$has_deny, sudo-i=$has_openbastion_i, nopasswd=$no_nopasswd"
         return 1
     fi
 }

--- a/tests/test_integration_maxsec.sh
+++ b/tests/test_integration_maxsec.sh
@@ -847,19 +847,22 @@ test_sudo_pam_config() {
     # for NSS-only SSO users (regression guard for the sudo-i fix).
     sudo_i_pam=$(docker exec ob-maxsec-backend cat /etc/pam.d/sudo-i 2>&1) || true
 
-    local has_openbastion has_deny no_nopasswd has_openbastion_i
+    local has_openbastion has_deny no_nopasswd has_openbastion_i has_deny_i
     has_openbastion=$(echo "$sudo_pam" | grep -c "pam_openbastion" || true)
     has_deny=$(echo "$sudo_pam" | grep -c "pam_deny" || true)
     has_openbastion_i=$(echo "$sudo_i_pam" | grep -c "pam_openbastion" || true)
+    # Mode E rejects Unix-password fallback via pam_deny; sudo -i must enforce it
+    # too, otherwise a stray fallback method could slip through (Copilot #141).
+    has_deny_i=$(echo "$sudo_i_pam" | grep -c "pam_deny" || true)
     no_nopasswd=$(docker exec ob-maxsec-backend grep -c "NOPASSWD" /etc/sudoers 2>&1) || true
 
     if [[ "$has_openbastion" -ge 1 ]] && [[ "$has_deny" -ge 1 ]] && \
-       [[ "$has_openbastion_i" -ge 1 ]] && [[ "$no_nopasswd" -eq 0 ]]; then
-        pass "sudo and sudo -i PAM correctly require LLNG token (no NOPASSWD)"
+       [[ "$has_openbastion_i" -ge 1 ]] && [[ "$has_deny_i" -ge 1 ]] && [[ "$no_nopasswd" -eq 0 ]]; then
+        pass "sudo and sudo -i PAM correctly require LLNG token (no NOPASSWD, no fallback)"
         return 0
     else
         fail "sudo PAM not properly configured for Mode E" \
-             "openbastion=$has_openbastion, deny=$has_deny, sudo-i=$has_openbastion_i, nopasswd=$no_nopasswd"
+             "openbastion=$has_openbastion, deny=$has_deny, sudo-i(openbastion=$has_openbastion_i, deny=$has_deny_i), nopasswd=$no_nopasswd"
         return 1
     fi
 }


### PR DESCRIPTION
## Contexte

Diagnostic sur une VM Mode E déployée via `linagora-setup` (ob-builder) : `sudo su`
passait **sans demander de token**, et `sudo -i` échouait avec *"account validation
failure, is your account locked?"*. Logs PAM décisifs :

```
pam_openbastion(sudo:auth): authorize_only mode, skipping password check
```

## Deux bugs distincts

### 1. sudo passwordless en Mode E
`ob-*-setup` écrit `authorize_only = true` dans `openbastion.conf` (légitime pour
`sshd` : le certificat SSH a déjà authentifié l'utilisateur). Mais ce flag est
**global** au fichier de conf, donc il s'applique aussi à la stack PAM `sudo`, où il
n'y a aucune auth par certificat préalable. Résultat : `pam_sm_authenticate` renvoie
`PAM_SUCCESS` sans jamais réclamer le token → sudo passwordless, ce qui annule la
garantie Mode E « sudo via LLNG token ».

**Fix** (`src/pam_openbastion.c`) : ne plus honorer `authorize_only` pour les
services PAM `sudo`/`sudo-i` ; le token y est toujours exigé. Corrigé dans le module
⇒ couvre bastion, backend **et** standalone, tous modes.

### 2. `sudo -i` cassé pour les utilisateurs SSO
sudo 1.9 utilise un service PAM distinct (`sudo-i`) que les scripts ne configuraient
pas ; il retombait sur le défaut distro (`common-auth`/`common-account` = `pam_unix`),
incapable de valider un user NSS/SSO sans entrée shadow.

**Fix** : chaque fonction qui écrit `/etc/pam.d/sudo` écrit désormais aussi
`/etc/pam.d/sudo-i` avec la même stack — `ob-bastion-setup` (Mode E),
`ob-backend-setup` (modes A-D **et** Mode E).

## Bonus
- `ob-standalone-setup` installé en **symlink** vers `ob-bastion-setup` ; invoqué sous
  ce nom, il met `--node-role` à `standalone` par défaut (CMake + `debian/*.links` + man).
- `test_integration_maxsec.sh` vérifie en plus que `/etc/pam.d/sudo-i` porte
  `pam_openbastion` (anti-régression bug 2).

## Validation
- `pam_openbastion.so` recompilé `-Werror -Wall -Wextra` ✅
- `bash -n` OK sur les 3 scripts ✅
- Symlink `ob-standalone-setup → ob-bastion-setup` vérifié via `DESTDIR` install ✅