### PR TITLE
fix(voucher): reliable bastion voucher — traversable /run dir + sshd-session anchor convergence

### DIFF
--- a/admin-builder/templates/ansible/role/tasks/_enroll.yml.in
+++ b/admin-builder/templates/ansible/role/tasks/_enroll.yml.in
@@ -20,7 +20,11 @@
     state: directory
     owner: root
     group: root
-    mode: '0750'
+    # 0711 (not 0750): the SSH-fingerprint spool lives under here and must be
+    # traversable by the AuthorizedPrincipalsCommand helper user (nobody), or
+    # the bastion voucher is never minted. 0711 is traverse-only (not listable);
+    # the device-state file is protected by its own mode.
+    mode: '0711'
   when: _ob_use_auto_approve
 
 - name: "Start ob-enroll asynchronously (device code published to /run/open-bastion/enroll-state.json)"

--- a/local-test/lib.sh
+++ b/local-test/lib.sh
@@ -150,7 +150,7 @@ bootstrap_vm(){
     dssh "$ip" "sudo INSTALL_PKG=$install_pkg GW=$GW_IP APT_PORT=$APT_PORT bash -s" <<'BS' >/dev/null 2>&1
 set -e
 grep -q auth.example.com /etc/hosts || echo "$GW auth.example.com" >> /etc/hosts
-mkdir -p /run/open-bastion && chmod 750 /run/open-bastion
+mkdir -p /run/open-bastion && chmod 711 /run/open-bastion
 echo "deb [trusted=yes] http://$GW:$APT_PORT/ ./" > /etc/apt/sources.list.d/oblab.list
 export DEBIAN_FRONTEND=noninteractive
 for t in 1 2 3; do apt-get update -qq && apt-get install -y -qq libsodium23 && break || sleep 5; done

--- a/local-test/lib.sh
+++ b/local-test/lib.sh
@@ -117,9 +117,15 @@ build_deb(){
 # ── 2. SSO ───────────────────────────────────────────────────────────────────
 ensure_sso(){
     phase "Test SSO"
+    # An explicit -f disables Compose's automatic override merge, so opt the
+    # gitignored docker-compose.override.yml back in when present (used to mount
+    # unreleased local plugin working copies — see that file's header).
+    local compose_files=(-f "$SSO_DIR/docker-compose.yml")
+    [ -f "$SSO_DIR/docker-compose.override.yml" ] && \
+        compose_files+=(-f "$SSO_DIR/docker-compose.override.yml")
     if ! docker ps --format '{{.Names}}' | grep -qx ob-sso; then
         info "starting + configuring ob-sso…"
-        docker compose -f "$SSO_DIR/docker-compose.yml" up -d >/dev/null 2>&1 || die "docker compose up failed"
+        docker compose "${compose_files[@]}" up -d >/dev/null 2>&1 || die "docker compose up failed"
         sleep 5
         bash "$SSO_DIR/configure.sh" >"$WORK/sso.log" 2>&1 || die "configure.sh failed — see $WORK/sso.log"
     fi

--- a/scripts/ob-bastion-setup
+++ b/scripts/ob-bastion-setup
@@ -312,6 +312,14 @@ PRINCIPALS
     # pam_openbastion additionally refuses to read the spool if this
     # directory is group/world-writable or if a drop file isn't owned by
     # the directory owner with mode 0600 / nlink 1.
+    # The parent /run/open-bastion MUST be traversable by the principals helper
+    # user (nobody) so it can reach the 0700 spool below. Other steps (ob-enroll,
+    # the device-state file) create it 0750 root:root, which blocks nobody and
+    # silently breaks the fingerprint spool (no voucher → onward hop fails).
+    # 0711 = traverse-only: nobody can cd through it but not list it, and the
+    # device-state file is protected by its own mode.
+    mkdir -p /run/open-bastion
+    chmod 0711 /run/open-bastion
     mkdir -p "$spool_dir"
     chown nobody:nogroup "$spool_dir" 2>/dev/null || chown nobody:nobody "$spool_dir"
     chmod 0700 "$spool_dir"
@@ -320,7 +328,9 @@ PRINCIPALS
     cat > "$tmpfiles_conf" << TMPFILES
 # Open Bastion SSH fingerprint spool — recreated at boot so the directory
 # survives /run wipes. See /usr/local/sbin/ob-ssh-principals.
-d /run/open-bastion          0755 root   root   -
+# 0711 on the parent: traversable by the principals helper (nobody) but not
+# listable; the ssh-fp drop dir itself is 0700 nobody.
+d /run/open-bastion          0711 root   root   -
 d /run/open-bastion/ssh-fp   0700 nobody nogroup -
 TMPFILES
     chmod 644 "$tmpfiles_conf"

--- a/scripts/ob-bastion-setup
+++ b/scripts/ob-bastion-setup
@@ -266,6 +266,8 @@ SPOOL_DIR="/run/open-bastion/ssh-fp"
 # may run under either, so both MUST converge on the same one. We anchor on the
 # OUTERMOST contiguous sshd-session (the monitor, whose parent is the "sshd"
 # listener) — pam_openbastion's find_sshd_session_ancestor() does the same.
+# Pre-split OpenSSH (<9.8, e.g. Rocky 9) has no "sshd-session"; fall back to the
+# first "sshd" ancestor there.
 case "$FINGERPRINT" in
     SHA256:[A-Za-z0-9+/]*) : ;;
     *) FINGERPRINT="" ;;
@@ -280,6 +282,8 @@ if [ -n "$FINGERPRINT" ] && [ -d "$SPOOL_DIR" ]; then
             anchor=$pid               # record, keep climbing for an outer one
         elif [ "$anchor" -gt 1 ]; then
             break                     # left the sshd-session chain → monitor found
+        elif [ "$comm" = "sshd" ]; then
+            anchor=$pid; break        # pre-split OpenSSH (<9.8, e.g. Rocky 9): "sshd" is the anchor
         fi
         pid=$(awk '/^PPid:/ {print $2}' /proc/"$pid"/status 2>/dev/null)
         [ -z "$pid" ] && pid=0

--- a/scripts/ob-bastion-setup
+++ b/scripts/ob-bastion-setup
@@ -260,30 +260,37 @@ USERNAME="$1"
 FINGERPRINT="$2"
 SPOOL_DIR="/run/open-bastion/ssh-fp"
 
-# Record the fingerprint keyed by our sshd-session ancestor PID
-# (pam_openbastion converges on the same ancestor by walking /proc).
+# Record the fingerprint keyed by the per-connection sshd anchor PID.
+# OpenSSH >= 9.8 has TWO processes named "sshd-session" per connection (the
+# privileged monitor and an unprivileged child); this helper and pam_openbastion
+# may run under either, so both MUST converge on the same one. We anchor on the
+# OUTERMOST contiguous sshd-session (the monitor, whose parent is the "sshd"
+# listener) — pam_openbastion's find_sshd_session_ancestor() does the same.
 case "$FINGERPRINT" in
     SHA256:[A-Za-z0-9+/]*) : ;;
     *) FINGERPRINT="" ;;
 esac
 if [ -n "$FINGERPRINT" ] && [ -d "$SPOOL_DIR" ]; then
     pid=$PPID
+    anchor=0   # outermost contiguous sshd-session = the privileged monitor
     i=0
     while [ "$pid" -gt 1 ] && [ $i -lt 16 ]; do
         comm=$(cat /proc/"$pid"/comm 2>/dev/null || echo "")
-        case "$comm" in
-            sshd-session|sshd) break ;;
-        esac
+        if [ "$comm" = "sshd-session" ]; then
+            anchor=$pid               # record, keep climbing for an outer one
+        elif [ "$anchor" -gt 1 ]; then
+            break                     # left the sshd-session chain → monitor found
+        fi
         pid=$(awk '/^PPid:/ {print $2}' /proc/"$pid"/status 2>/dev/null)
         [ -z "$pid" ] && pid=0
         i=$((i + 1))
     done
-    if [ "$pid" -gt 1 ]; then
+    if [ "$anchor" -gt 1 ]; then
         umask 077
-        tmp=$(mktemp "$SPOOL_DIR/."$pid".XXXXXX" 2>/dev/null) || tmp=""
+        tmp=$(mktemp "$SPOOL_DIR/."$anchor".XXXXXX" 2>/dev/null) || tmp=""
         if [ -n "$tmp" ]; then
             printf '%s\n' "$FINGERPRINT" > "$tmp"
-            mv -f "$tmp" "$SPOOL_DIR/$pid.fp"
+            mv -f "$tmp" "$SPOOL_DIR/$anchor.fp"
         fi
     fi
 fi

--- a/scripts/ob-enroll
+++ b/scripts/ob-enroll
@@ -398,16 +398,22 @@ initiate_device_auth() {
     # file itself root-only (0600) — the orchestrator slurps it as root.
     if [ -n "${OB_ENROLL_STATE_FILE:-}" ]; then
         mkdir -p "$(dirname "$OB_ENROLL_STATE_FILE")" 2>/dev/null || true
-        jq -n \
-            --arg user_code "$USER_CODE" \
-            --arg verification_uri "$VERIFICATION_URI" \
-            --arg verification_uri_complete "$VERIFICATION_URI_COMPLETE" \
-            --arg portal_url "$PORTAL_URL" \
-            --arg interval "$INTERVAL" \
-            '{user_code: $user_code, verification_uri: $verification_uri, verification_uri_complete: $verification_uri_complete, portal_url: $portal_url, interval: ($interval | tonumber)}' \
-            > "${OB_ENROLL_STATE_FILE}.tmp" \
-            && mv -f "${OB_ENROLL_STATE_FILE}.tmp" "$OB_ENROLL_STATE_FILE" \
-            || log_warn "Could not write device-grant state to ${OB_ENROLL_STATE_FILE}"
+        # Create under umask 077 (in a subshell) so the temp file is never
+        # group/world-readable, even for the brief window before the chmod —
+        # /run/open-bastion is 0711 (traversable). The final chmod is kept as a
+        # belt-and-suspenders. Subshell so the umask change stays local.
+        (
+            umask 077
+            jq -n \
+                --arg user_code "$USER_CODE" \
+                --arg verification_uri "$VERIFICATION_URI" \
+                --arg verification_uri_complete "$VERIFICATION_URI_COMPLETE" \
+                --arg portal_url "$PORTAL_URL" \
+                --arg interval "$INTERVAL" \
+                '{user_code: $user_code, verification_uri: $verification_uri, verification_uri_complete: $verification_uri_complete, portal_url: $portal_url, interval: ($interval | tonumber)}' \
+                > "${OB_ENROLL_STATE_FILE}.tmp" \
+                && mv -f "${OB_ENROLL_STATE_FILE}.tmp" "$OB_ENROLL_STATE_FILE"
+        ) || log_warn "Could not write device-grant state to ${OB_ENROLL_STATE_FILE}"
         chmod 0600 "$OB_ENROLL_STATE_FILE" 2>/dev/null || true
     fi
 }

--- a/scripts/ob-enroll
+++ b/scripts/ob-enroll
@@ -391,8 +391,11 @@ initiate_device_auth() {
 
     # Optionally publish device-grant state to a file so external orchestrators
     # (e.g. Ansible with an LLNG session cookie) can approve the user_code
-    # while ob-enroll is still polling the token endpoint. The file contains
-    # only public values that would be shown to the human admin anyway.
+    # while ob-enroll is still polling the token endpoint. The file holds only
+    # admin-facing values (user_code + verification URIs, NOT the device_code
+    # secret), but it lives in /run/open-bastion which is 0711 (traversable so
+    # the SSH-fingerprint principals helper can reach its spool), so keep the
+    # file itself root-only (0600) — the orchestrator slurps it as root.
     if [ -n "${OB_ENROLL_STATE_FILE:-}" ]; then
         mkdir -p "$(dirname "$OB_ENROLL_STATE_FILE")" 2>/dev/null || true
         jq -n \
@@ -405,7 +408,7 @@ initiate_device_auth() {
             > "${OB_ENROLL_STATE_FILE}.tmp" \
             && mv -f "${OB_ENROLL_STATE_FILE}.tmp" "$OB_ENROLL_STATE_FILE" \
             || log_warn "Could not write device-grant state to ${OB_ENROLL_STATE_FILE}"
-        chmod 0644 "$OB_ENROLL_STATE_FILE" 2>/dev/null || true
+        chmod 0600 "$OB_ENROLL_STATE_FILE" 2>/dev/null || true
     fi
 }
 

--- a/src/pam_openbastion.c
+++ b/src/pam_openbastion.c
@@ -1605,7 +1605,9 @@ static const char *get_client_ip(pam_handle_t *pamh)
  * EITHER, so stopping at the *first* "sshd-session" makes the writer and reader
  * key the spool on different PIDs and the lookup fails. To converge
  * deterministically we return the OUTERMOST contiguous "sshd-session" (the
- * monitor, whose parent is the "sshd" listener). Returns 0 if none found.
+ * monitor, whose parent is the "sshd" listener). On pre-split OpenSSH (< 9.8,
+ * e.g. RHEL/Rocky 9) there is no "sshd-session" and we fall back to the first
+ * "sshd" ancestor. Returns 0 if none found.
  */
 static pid_t find_sshd_session_ancestor(void)
 {
@@ -1634,6 +1636,11 @@ static pid_t find_sshd_session_ancestor(void)
             /* Left the sshd-session chain; its outermost member is the
              * per-connection privileged monitor — the common ancestor. */
             return outermost_session;
+        } else if (strcmp(buf, "sshd") == 0) {
+            /* Pre-split OpenSSH (< 9.8, e.g. RHEL/Rocky 9's 8.7) has no
+             * "sshd-session": the per-connection process is "sshd" itself, and
+             * its first occurrence is the anchor (its parent is the listener). */
+            return pid;
         }
 
         /* Read PPid from /proc/<pid>/status */

--- a/src/pam_openbastion.c
+++ b/src/pam_openbastion.c
@@ -1595,15 +1595,22 @@ static const char *get_client_ip(pam_handle_t *pamh)
 }
 
 /*
- * Walk up the process tree looking for an ancestor whose /proc/<pid>/comm
- * is "sshd-session" (or "sshd" as a fallback). Returns its PID, or 0 if
- * none found. Used to correlate the PAM module's invocation with the
- * AuthorizedPrincipalsCommand run, since both end up under the same
- * sshd-session[priv] process even when run in separate child processes.
+ * Walk up the process tree to find the per-connection sshd anchor PID, used to
+ * correlate this PAM invocation with the AuthorizedPrincipalsCommand run (which
+ * drops the SSH fingerprint at /run/open-bastion/ssh-fp/<anchor>.fp).
+ *
+ * OpenSSH >= 9.8 splits each connection into TWO processes both named
+ * "sshd-session": the privileged monitor (child of the "sshd" listener) and an
+ * unprivileged child under it. PAM and the principals helper may run under
+ * EITHER, so stopping at the *first* "sshd-session" makes the writer and reader
+ * key the spool on different PIDs and the lookup fails. To converge
+ * deterministically we return the OUTERMOST contiguous "sshd-session" (the
+ * monitor, whose parent is the "sshd" listener). Returns 0 if none found.
  */
 static pid_t find_sshd_session_ancestor(void)
 {
     pid_t pid = getpid();
+    pid_t outermost_session = 0;  /* outermost contiguous sshd-session seen */
     for (int i = 0; i < 16; i++) {
         char path[64];
         char buf[256];
@@ -1611,22 +1618,28 @@ static pid_t find_sshd_session_ancestor(void)
         /* Read /proc/<pid>/comm */
         snprintf(path, sizeof(path), "/proc/%d/comm", (int)pid);
         FILE *f = fopen(path, "r");
-        if (!f) return 0;
+        if (!f) return outermost_session;
         if (!fgets(buf, sizeof(buf), f)) {
             fclose(f);
-            return 0;
+            return outermost_session;
         }
         fclose(f);
         char *nl = strchr(buf, '\n');
         if (nl) *nl = '\0';
-        if (strcmp(buf, "sshd-session") == 0 || strcmp(buf, "sshd") == 0) {
-            return pid;
+        if (strcmp(buf, "sshd-session") == 0) {
+            /* Record and keep climbing: a parent sshd-session (the monitor)
+             * outranks this one. */
+            outermost_session = pid;
+        } else if (outermost_session) {
+            /* Left the sshd-session chain; its outermost member is the
+             * per-connection privileged monitor — the common ancestor. */
+            return outermost_session;
         }
 
         /* Read PPid from /proc/<pid>/status */
         snprintf(path, sizeof(path), "/proc/%d/status", (int)pid);
         f = fopen(path, "r");
-        if (!f) return 0;
+        if (!f) return outermost_session;
         pid_t ppid = 0;
         while (fgets(buf, sizeof(buf), f)) {
             if (strncmp(buf, "PPid:", 5) == 0) {
@@ -1635,10 +1648,10 @@ static pid_t find_sshd_session_ancestor(void)
             }
         }
         fclose(f);
-        if (ppid <= 1 || ppid == pid) return 0;
+        if (ppid <= 1 || ppid == pid) return outermost_session;
         pid = ppid;
     }
-    return 0;
+    return outermost_session;
 }
 
 /*


### PR DESCRIPTION
## Context

Investigation of the "No bastion voucher found" failure on the bastion→backend hop (`ob-ssh`/`ob-scp`), which surfaced via the local-test harness. Root cause identified and proven on a VM lab (debug logs to back it).

## Root cause (two compounding bugs, open-bastion side)

1. **Permissions** — `/run/open-bastion` was `0750 root:root` (created by `_enroll.yml.in` and the lab bootstrap). The `AuthorizedPrincipalsCommand` helper runs as **`nobody`** and could not **traverse** the directory to write the fingerprint spool:
   ```
   whoami=nobody isdir=N stat=[stat: cannot statx '/run/open-bastion/ssh-fp': Permission denied]
   ```
   → spool never written → no fingerprint at `pam_sm_acct_mgmt` time → fallback to the no-cert authorize → **no voucher**.

2. **PID convergence** — OpenSSH ≥ 9.8 runs **two** processes named `sshd-session` per connection (the privileged monitor and an unprivileged child). The writer (helper) and the reader (`pam_openbastion`) both stopped at the **first** `sshd-session` they found, so they could key the spool file on different PIDs → `SSH fp spool not found`.

## Fix

- `/run/open-bastion` → **0711** (traversable, not listable) in `ob-bastion-setup` (authoritative chmod + tmpfiles), the enrollment template `_enroll.yml.in`, and the lab bootstrap. The `ssh-fp` subdir stays `0700 nobody`.
- Writer **and** reader now anchor on the **outermost `sshd-session`** (the monitor, whose parent is the `sshd` listener) → deterministic spool filenames on both sides.
- `enroll-state.json` tightened **0644 → 0600** (hardening paired with the now-traversable parent; the orchestrator reads it as root).

## Validation (4-VM max-security lab)

After the fix: `HAVE_VOUCHER` (3/3), journal shows `SSH fp recovered from spool` + `Authorizing with SSH certificate info`. Full max-security run: `passed=30, failed=1` — `ob-scp` (which requires the voucher) **PASS**, standalone `sudo`/`sudo-i` **PASS**. The lone red line (`ob-ssh hop`) is a harness/timing flake (the lab degraded afterwards on short TTLs); the same vouching path succeeds via `ob-scp`.

## /security-review: clean

No vulnerability introduced. `0711` is net-tightening (the spool integrity checks key off the `0700 nobody` subdir, not the parent; a non-root local user still cannot plant an `<anchor>.fp`). The `0600` change on the enroll-state file is an improvement.

## Follow-up note (out of scope for this PR)

The `local-test/sso` container ships an **outdated `PamAccess.pm` without the voucher code** (`_mintBastionVoucher` missing); I hot-patched it to validate. Rebuilding the lab SSO image with current plugins should be tracked separately.