### PR TITLE
test(local-test): standalone parity in shell harness + both-harness matrix driver

### DIFF
--- a/local-test/deploy-all-modes.sh
+++ b/local-test/deploy-all-modes.sh
@@ -1,33 +1,50 @@
 #!/usr/bin/env bash
-# Run the Ansible deploy harness once per PAM scenario (all five modes), each on
-# a freshly recreated lab (bastion + 2 backends + standalone). Prints a per-mode
-# PASS/FAIL scoreboard. NOT run in CI (needs libvirt VMs + the Docker SSO).
+# Run the deploy harness(es) once per PAM scenario (all five modes), each on a
+# freshly recreated lab (bastion + 2 backends + standalone). Exercises all three
+# target roles (bastion, backend, standalone) every run. Prints a per-mode,
+# per-harness PASS/FAIL scoreboard. NOT run in CI (needs libvirt VMs + Docker SSO).
 #
 # Usage:  local-test/deploy-all-modes.sh [scenario ...]
-#         OB_GOLDEN=... local-test/deploy-all-modes.sh        # all five modes
-#         local-test/deploy-all-modes.sh max-security         # one mode
+#         OB_GOLDEN=... local-test/deploy-all-modes.sh           # both harnesses, all 5 modes
+#         OB_HARNESS=shell    local-test/deploy-all-modes.sh     # shell harness only
+#         OB_HARNESS=ansible  local-test/deploy-all-modes.sh max-security
+#
+# Env:
+#   OB_HARNESS   space-separated subset of {ansible shell}; default "ansible shell"
+#   OB_GOLDEN    genericcloud golden image (else auto-detected by lib.sh)
+#   SKIP_BUILD   reuse a previously staged .deb (auto-set to 1 after the 1st run)
 set -uo pipefail
 LT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 SCENARIOS=("$@")
 [ "${#SCENARIOS[@]}" -gt 0 ] || SCENARIOS=(token-only token+unix keys+llng mixed max-security)
+read -ra HARNESSES <<< "${OB_HARNESS:-ansible shell}"
 
 declare -A RESULT
 overall=0
-for scen in "${SCENARIOS[@]}"; do
-    log="$LT_DIR/.work/all-modes-$scen.log"
-    printf '\n############ scenario=%s ############\n' "$scen"
-    # Reuse the build + SSO across runs to save time; the harness still recreates
-    # the VMs every run, which is what we want for an isolated per-mode test.
-    if OB_SCENARIO="$scen" SKIP_BUILD="${SKIP_BUILD:-0}" "$LT_DIR/deploy-ansible.sh" 2>&1 | tee "$log"; then
-        RESULT[$scen]="PASS"
-    else
-        RESULT[$scen]="FAIL"; overall=1
-    fi
-    # After the first run the .deb is staged, so skip rebuilding for the rest.
-    SKIP_BUILD=1
+for harness in "${HARNESSES[@]}"; do
+    script="$LT_DIR/deploy-$harness.sh"
+    [ -x "$script" ] || { echo "unknown harness: $harness ($script missing)" >&2; exit 2; }
+    for scen in "${SCENARIOS[@]}"; do
+        log="$LT_DIR/.work/all-modes-$harness-$scen.log"
+        printf '\n############ harness=%s scenario=%s ############\n' "$harness" "$scen"
+        # Reuse the build + SSO across runs to save time; the harness still
+        # recreates the VMs every run, which is what we want for isolation.
+        if OB_SCENARIO="$scen" SKIP_BUILD="${SKIP_BUILD:-0}" "$script" 2>&1 | tee "$log"; then
+            RESULT["$harness/$scen"]="PASS"
+        else
+            RESULT["$harness/$scen"]="FAIL"; overall=1
+        fi
+        # After the first run the .deb is staged, so skip rebuilding for the rest.
+        SKIP_BUILD=1
+    done
 done
 
 printf '\n================ all-modes scoreboard ================\n'
-for scen in "${SCENARIOS[@]}"; do printf '  %-14s %s\n' "$scen" "${RESULT[$scen]}"; done
+printf '  %-14s' 'scenario'; for h in "${HARNESSES[@]}"; do printf ' %-8s' "$h"; done; printf '\n'
+for scen in "${SCENARIOS[@]}"; do
+    printf '  %-14s' "$scen"
+    for h in "${HARNESSES[@]}"; do printf ' %-8s' "${RESULT[$h/$scen]:-?}"; done
+    printf '\n'
+done
 exit "$overall"

--- a/local-test/deploy-all-modes.sh
+++ b/local-test/deploy-all-modes.sh
@@ -23,8 +23,14 @@ read -ra HARNESSES <<< "${OB_HARNESS:-ansible shell}"
 declare -A RESULT
 overall=0
 for harness in "${HARNESSES[@]}"; do
+    # Whitelist the harness name so it can never inject path components into the
+    # script path below (only these two harnesses exist).
+    case "$harness" in
+        ansible|shell) ;;
+        *) echo "unknown harness: '$harness' (expected: ansible|shell)" >&2; exit 2 ;;
+    esac
     script="$LT_DIR/deploy-$harness.sh"
-    [ -x "$script" ] || { echo "unknown harness: $harness ($script missing)" >&2; exit 2; }
+    [ -x "$script" ] || { echo "harness script missing: $script" >&2; exit 2; }
     for scen in "${SCENARIOS[@]}"; do
         log="$LT_DIR/.work/all-modes-$harness-$scen.log"
         printf '\n############ harness=%s scenario=%s ############\n' "$harness" "$scen"
@@ -44,7 +50,7 @@ printf '\n================ all-modes scoreboard ================\n'
 printf '  %-14s' 'scenario'; for h in "${HARNESSES[@]}"; do printf ' %-8s' "$h"; done; printf '\n'
 for scen in "${SCENARIOS[@]}"; do
     printf '  %-14s' "$scen"
-    for h in "${HARNESSES[@]}"; do printf ' %-8s' "${RESULT[$h/$scen]:-?}"; done
+    for h in "${HARNESSES[@]}"; do printf ' %-8s' "${RESULT["$h/$scen"]:-?}"; done
     printf '\n'
 done
 exit "$overall"

--- a/local-test/deploy-shell.sh
+++ b/local-test/deploy-shell.sh
@@ -19,6 +19,11 @@ SHIMBIN="$WORK/shimbin"; mkdir -p "$SHIMBIN"
 ln -sf "$SSO_DIR/ob-builder-curl-shim.sh" "$SHIMBIN/curl"
 obbuild(){ PATH="$SHIMBIN:$PATH" "$REPO_ROOT/admin-builder/ob-builder" "$@" --allow-http; }
 
+# Standalone host: only the harness wires it in (lib.sh keeps it out of the
+# shared VM set). Same as deploy-ansible.sh — append it here so it is recreated,
+# bootstrapped and deployed. Set OB_STANDALONE_VM="" to skip it.
+[ -n "$STANDALONE_VM" ] && ALL_VMS+=("$STANDALONE_VM")
+
 # run_installer <vm> <installer> [extra installer args…]
 # Copies the installer and runs it as root with the lab flags. --skip-install
 # (package pre-installed in bootstrap, unsigned repo), --force (postinst already
@@ -36,10 +41,12 @@ preflight; build_deb; ensure_sso; recreate_vms
 phase "Bootstrap VMs (incl. package install — shell path uses --skip-install)"
 for v in "${ALL_VMS[@]}"; do bootstrap_vm "$v" 1; done
 get_cookie
+mint_dwho_cert   # so the connection-phase + standalone assertions actually run
 
 # ── Phase 1: bastion installer — enrol, read bastion_id, then setup ──────────
-phase "Phase 1 — bastion (ob-builder --output-shell)"
-obbuild --config "$CONFIG_DIR/build-bastion.yml" --output-shell "$WORK/boot-bastion.sh" >"$WORK/gen-bastion.log" 2>&1 \
+phase "Phase 1 — bastion (ob-builder --output-shell, scenario=$SCENARIO)"
+sed "s/^scenario:.*/scenario: $SCENARIO/" "$CONFIG_DIR/build-bastion.yml" > "$WORK/build-bastion.yml"
+obbuild --config "$WORK/build-bastion.yml" --output-shell "$WORK/boot-bastion.sh" >"$WORK/gen-bastion.log" 2>&1 \
     && ok "generated bastion installer" || { bad "ob-builder bastion failed"; cat "$WORK/gen-bastion.log"; }
 
 info "enrol the bastion (--skip-setup), approving the device code in parallel"
@@ -54,8 +61,9 @@ run_installer "$BASTION_VM" "$WORK/boot-bastion.sh" --skip-enroll >"$WORK/bastio
     && ok "bastion setup complete" || bad "bastion setup failed — see $WORK/bastion-setup.log"
 
 # ── Phase 2: backend installer with allowed_bastions=bastion_id ──────────────
-phase "Phase 2 — backends (ob-builder --output-shell, allowed_bastions=$BID)"
-sed "s/^allowed_bastions:.*/allowed_bastions: $BID/" "$CONFIG_DIR/build-backend.yml" > "$WORK/build-backend.yml"
+phase "Phase 2 — backends (ob-builder --output-shell, allowed_bastions=$BID, scenario=$SCENARIO)"
+sed -e "s/^allowed_bastions:.*/allowed_bastions: $BID/" \
+    -e "s/^scenario:.*/scenario: $SCENARIO/" "$CONFIG_DIR/build-backend.yml" > "$WORK/build-backend.yml"
 obbuild --config "$WORK/build-backend.yml" --output-shell "$WORK/boot-backend.sh" >"$WORK/gen-backend.log" 2>&1 \
     && ok "generated backend installer" || bad "ob-builder backend failed"
 for v in "${BACKEND_VMS[@]}"; do
@@ -65,5 +73,23 @@ for v in "${BACKEND_VMS[@]}"; do
     grep -q "Setup complete\|5/5\|Role-specific setup" "$WORK/$v.log" && ok "$v deployed" || bad "$v deploy — see $WORK/$v.log"
 done
 
+# ── Phase 3: standalone installer (bastion+backend in one, no bastion in front) ─
+# A standalone does not need a bastion_id, so it is a single installer run like a
+# backend: enrol + setup in one go, approving the device code in parallel. In
+# Mode E this locks port 22 afterwards, which is fine — every assertion goes
+# through the dwho SSO cert (see verify_standalone).
+if [ -n "$STANDALONE_VM" ]; then
+    phase "Phase 3 — standalone (ob-builder --output-shell, scenario=$SCENARIO)"
+    sed "s/^scenario:.*/scenario: $SCENARIO/" "$CONFIG_DIR/build-standalone.yml" > "$WORK/build-standalone.yml"
+    obbuild --config "$WORK/build-standalone.yml" --output-shell "$WORK/boot-standalone.sh" >"$WORK/gen-standalone.log" 2>&1 \
+        && ok "generated standalone installer" || { bad "ob-builder standalone failed"; cat "$WORK/gen-standalone.log"; }
+    ( approve_device "${IP[$STANDALONE_VM]}" ) &
+    run_installer "$STANDALONE_VM" "$WORK/boot-standalone.sh" >"$WORK/$STANDALONE_VM.log" 2>&1
+    wait
+    grep -q "Setup complete\|5/5\|Role-specific setup" "$WORK/$STANDALONE_VM.log" \
+        && ok "$STANDALONE_VM deployed" || bad "$STANDALONE_VM deploy — see $WORK/$STANDALONE_VM.log"
+fi
+
 verify_e2e
+verify_standalone
 summary


### PR DESCRIPTION
## What

Brings the **shell installer** harness (`deploy-shell.sh`) to full parity with the **Ansible** harness so the lab validation matrix is *ansible + shell × 5 PAM modes × 3 target roles*.

### `deploy-shell.sh`
- Appends `$STANDALONE_VM` to `ALL_VMS` (so the standalone host is recreated, bootstrapped and deployed), mirroring `deploy-ansible.sh`.
- Injects `$OB_SCENARIO` into the bastion + backend ob-builder configs. Previously the shell path always used the `token-only` default in the YAML, so it never exercised the other four PAM modes.
- Mints the `dwho` SSO certificate (`mint_dwho_cert`) so `verify_e2e` and `verify_standalone` actually run instead of skipping.
- Adds **Phase 3 — standalone**: a single installer run (a standalone needs no `bastion_id`), approving the device code in parallel, followed by `verify_standalone`.

### `deploy-all-modes.sh`
- Now drives **both** harnesses via `OB_HARNESS` (default `"ansible shell"`) across all five scenarios, and prints a per-harness / per-mode scoreboard — i.e. the full matrix in one command.

## Why

`deploy-shell.sh` had no standalone target and ignored `$OB_SCENARIO`, so only the Ansible path covered standalone and non-default PAM modes. This closes that coverage gap; the harness changes are lab-only (not run in CI).

## Test

`bash -n` clean on all three scripts; `shellcheck -x` reports only the pre-existing `SC2015` style notes shared with the rest of the harness. Full lab matrix run results are reported separately in the conversation.