### PR TITLE
fix: repair the bastion→backend cert hop (backend fp-spool anchor + recorder exit code) + lab cookie refresh

### DIFF
--- a/local-test/deploy-ansible.sh
+++ b/local-test/deploy-ansible.sh
@@ -103,6 +103,7 @@ obbuild --config "$WORK/build-backend.yml" --output-ansible "$WORK/role-backend"
   echo "        ${BACKEND_VMS[0]}: { ansible_host: ${IP[${BACKEND_VMS[0]}]}, ob_server_group: backend }"
   echo "        ${BACKEND_VMS[1]}: { ansible_host: ${IP[${BACKEND_VMS[1]}]}, ob_server_group: backend }"
 } > "$WORK/role-backend/inv.yml"
+get_cookie   # refresh: the lab SSO uses short TTLs and the bastion phase can outlast the initial cookie
 ( cd "$WORK/role-backend" && ansible-playbook -i inv.yml playbook.yml \
     --extra-vars "ob_llng_cookie='$COOKIE'" ) >"$WORK/deploy-backends.log" 2>&1
 if grep -q "failed=0" "$WORK/deploy-backends.log" && ! grep -q "failed=[1-9]" "$WORK/deploy-backends.log"; then
@@ -130,6 +131,7 @@ EOF
   become: true
   roles: [open-bastion]
 EOF
+    get_cookie   # refresh before enrolling: the initial cookie may have expired by now (short lab TTLs)
     ( cd "$WORK/role-standalone" && ansible-playbook -i inv.yml deploy.yml \
         --extra-vars "ob_llng_cookie='$COOKIE'" ) >"$WORK/deploy-standalone.log" 2>&1
     if grep -q "failed=0" "$WORK/deploy-standalone.log" && ! grep -q "failed=[1-9]" "$WORK/deploy-standalone.log"; then

--- a/local-test/deploy-shell.sh
+++ b/local-test/deploy-shell.sh
@@ -66,6 +66,7 @@ sed -e "s/^allowed_bastions:.*/allowed_bastions: $BID/" \
     -e "s/^scenario:.*/scenario: $SCENARIO/" "$CONFIG_DIR/build-backend.yml" > "$WORK/build-backend.yml"
 obbuild --config "$WORK/build-backend.yml" --output-shell "$WORK/boot-backend.sh" >"$WORK/gen-backend.log" 2>&1 \
     && ok "generated backend installer" || bad "ob-builder backend failed"
+get_cookie   # refresh: the lab SSO uses short TTLs and bastion setup can outlast the initial cookie
 for v in "${BACKEND_VMS[@]}"; do
     ( approve_device "${IP[$v]}" ) &
     run_installer "$v" "$WORK/boot-backend.sh" >"$WORK/$v.log" 2>&1
@@ -83,6 +84,7 @@ if [ -n "$STANDALONE_VM" ]; then
     sed "s/^scenario:.*/scenario: $SCENARIO/" "$CONFIG_DIR/build-standalone.yml" > "$WORK/build-standalone.yml"
     obbuild --config "$WORK/build-standalone.yml" --output-shell "$WORK/boot-standalone.sh" >"$WORK/gen-standalone.log" 2>&1 \
         && ok "generated standalone installer" || { bad "ob-builder standalone failed"; cat "$WORK/gen-standalone.log"; }
+    get_cookie   # refresh before enrolling: the initial cookie may have expired by now (short lab TTLs)
     ( approve_device "${IP[$STANDALONE_VM]}" ) &
     run_installer "$STANDALONE_VM" "$WORK/boot-standalone.sh" >"$WORK/$STANDALONE_VM.log" 2>&1
     wait

--- a/local-test/sso/configure.sh
+++ b/local-test/sso/configure.sh
@@ -156,6 +156,10 @@ jq --rawfile priv "$PRIVKEY" \
      pamAccessBastionGroups: "bastion",
      pamAccessBastionVoucherTtl: 43200,
      pamAccessBastionCertTtl: 120
+     # NB: pamAccessBastionCertPinSourceAddress is OFF by default, so no override
+     # is needed here. (In this lab the bastion reaches the dockerised SSO via the
+     # libvirt gateway, so LLNG would observe the docker-bridge IP, not the real
+     # bastion IP — enabling the pin would make every backend reject the hop.)
    }' "$CURCONF" > "$NEWCONF"
 
 # Validate

--- a/scripts/ob-backend-setup
+++ b/scripts/ob-backend-setup
@@ -297,28 +297,41 @@ if [ "$enforce" = 1 ]; then
     fi
 fi
 
+# Record the fingerprint keyed by the per-connection sshd anchor PID. OpenSSH
+# >= 9.8 has TWO processes named "sshd-session" per connection (the privileged
+# monitor and an unprivileged child); this helper and pam_openbastion may run
+# under either, so both MUST converge on the same one. We anchor on the OUTERMOST
+# contiguous sshd-session (the monitor, whose parent is the "sshd" listener) —
+# pam_openbastion's find_sshd_session_ancestor() does the same. Pre-split OpenSSH
+# (<9.8, e.g. Rocky 9) has no "sshd-session"; fall back to the first "sshd".
+# (Mirrors the bastion helper in ob-bastion-setup; keep the two in sync.)
 case "$FINGERPRINT" in
     SHA256:[A-Za-z0-9+/]*) : ;;
     *) FINGERPRINT="" ;;
 esac
 if [ -n "$FINGERPRINT" ] && [ -d "$SPOOL_DIR" ]; then
     pid=$PPID
+    anchor=0   # outermost contiguous sshd-session = the privileged monitor
     i=0
     while [ "$pid" -gt 1 ] && [ $i -lt 16 ]; do
         comm=$(cat /proc/"$pid"/comm 2>/dev/null || echo "")
-        case "$comm" in
-            sshd-session|sshd) break ;;
-        esac
+        if [ "$comm" = "sshd-session" ]; then
+            anchor=$pid               # record, keep climbing for an outer one
+        elif [ "$anchor" -gt 1 ]; then
+            break                     # left the sshd-session chain → monitor found
+        elif [ "$comm" = "sshd" ]; then
+            anchor=$pid; break        # pre-split OpenSSH (<9.8, e.g. Rocky 9): "sshd" is the anchor
+        fi
         pid=$(awk '/^PPid:/ {print $2}' /proc/"$pid"/status 2>/dev/null)
         [ -z "$pid" ] && pid=0
         i=$((i + 1))
     done
-    if [ "$pid" -gt 1 ]; then
+    if [ "$anchor" -gt 1 ]; then
         umask 077
-        tmp=$(mktemp "$SPOOL_DIR/."$pid".XXXXXX" 2>/dev/null) || tmp=""
+        tmp=$(mktemp "$SPOOL_DIR/."$anchor".XXXXXX" 2>/dev/null) || tmp=""
         if [ -n "$tmp" ]; then
             printf '%s\n' "$FINGERPRINT" > "$tmp"
-            mv -f "$tmp" "$SPOOL_DIR/$pid.fp"
+            mv -f "$tmp" "$SPOOL_DIR/$anchor.fp"
         fi
     fi
 fi
@@ -350,6 +363,12 @@ PRINCIPALS
         info "Backend accepts any vouched bastion (no bastion_id allowlist set)"
     fi
 
+    # Parent /run/open-bastion must be traversable by the principals helper user
+    # (nobody) so it can reach the 0700 spool below. 0711 = traverse-only (not
+    # listable). Mirrors ob-bastion-setup; other steps (ob-enroll) may create it
+    # with a more restrictive mode, so set it authoritatively here.
+    mkdir -p /run/open-bastion
+    chmod 0711 /run/open-bastion
     # Spool directory: owned by AuthorizedPrincipalsCommandUser (nobody),
     # mode 0700 — see ob-bastion-setup for rationale (a world-writable
     # directory would expose PAM to a spoofed-fingerprint attack via
@@ -362,7 +381,9 @@ PRINCIPALS
     cat > "$tmpfiles_conf" << TMPFILES
 # Open Bastion SSH fingerprint spool — recreated at boot so the directory
 # survives /run wipes. See /usr/local/sbin/ob-ssh-principals.
-d /run/open-bastion          0755 root   root   -
+# 0711 on the parent: traversable by the principals helper (nobody) but not
+# listable; the ssh-fp drop dir itself is 0700 nobody.
+d /run/open-bastion          0711 root   root   -
 d /run/open-bastion/ssh-fp   0700 nobody nogroup -
 TMPFILES
     chmod 644 "$tmpfiles_conf"

--- a/scripts/ob-session-recorder
+++ b/scripts/ob-session-recorder
@@ -267,10 +267,19 @@ record_transfer() {
 record_script() {
     local shell="${SHELL:-/bin/bash}"
 
+    # -e (--return) makes script(1) exit with the CHILD's status. Without it
+    # script always exits 0, so any command run non-interactively through the
+    # bastion (ob-ssh / ob-scp hops, scripted ssh, CI jobs) reports success even
+    # when it failed, and the session metadata status is always "completed".
+    # util-linux >= 2.31 (Debian 11+, RHEL/Rocky 8+) supports -e; on anything
+    # older we fall back to the legacy behaviour rather than erroring out.
+    local ret_opt=""
+    script --help 2>/dev/null | grep -q -- '--return' && ret_opt="-e"
+
     if [ -n "$ORIGINAL_COMMAND" ]; then
-        script -q -c "$ORIGINAL_COMMAND" "$SESSION_FILE"
+        script -q $ret_opt -c "$ORIGINAL_COMMAND" "$SESSION_FILE"
     else
-        script -q -c "$shell" "$SESSION_FILE"
+        script -q $ret_opt -c "$shell" "$SESSION_FILE"
     fi
 }
 


### PR DESCRIPTION
## Summary

Linked to https://github.com/linagora/lemonldap-ng-plugins/pull/34

Repairs the `ob-ssh`/`ob-scp` bastion→backend certificate hop, which failed in **every** lab scenario. Root-causing it uncovered **three stacked causes** (two in this repo, one in the LLNG `pam-access` plugin):

1. **Source-address pin on a NAT'd IP** *(plugin side)* — LLNG pinned the ephemeral cert to the IP it observed (`$req->address`), which in the lab is the docker-bridge gateway, not the bastion's real IP → backend rejected with `Permission denied (publickey)`. Fixed upstream by gating the pin behind `pamAccessBastionCertPinSourceAddress` (off by default).
2. **Backend fp-spool anchor mismatch** *(this PR — `scripts/ob-backend-setup`)* — PR #142 fixed the SSH-fingerprint spool anchor in `ob-bastion-setup` + `pam_openbastion.c` but **not** the backend helper, so on OpenSSH ≥9.8 the backend writer and the pam reader keyed the spool on different `sshd-session` PIDs → pam never recovered the hop cert's fingerprint.
3. **Ephemeral fingerprint not registered** *(plugin side)* — once the fingerprint was recovered and forwarded, the backend's `/pam/authorize` SSH-fingerprint binding rejected it as `not-found` (the ephemeral cert isn't in the user's `_sshCerts`). Fixed in the plugin (`/pam/bastion-cert` now registers the ephemeral fingerprint).

The June 12 "validated 2-host" cert hop was a **false positive**: the broken fp-spool (#142) meant the backend forwarded no fingerprint, so the (pre-existing) fp binding was silently skipped. Fixing the spool exposed cause 3.

## Changes in this PR (open-bastion)

- **`scripts/ob-backend-setup`** — converge the fp-spool anchor on the outermost `sshd-session` (with `sshd` fallback for pre-9.8), mirroring `ob-bastion-setup`; align `/run/open-bastion` to `0711`.
- **`scripts/ob-session-recorder`** — `script -e` so the recorded command's exit status propagates. Without it, any non-interactive command through a bastion (hops, scripted ssh, CI) reported success even on failure, and the session status was always "completed" — this was masking a failing `ob-scp` in the harness.
- **`local-test/`** — refresh the SSO cookie before the backend/standalone enrolment phases (short lab TTLs caused device-approval timeouts on long runs); drop the now-redundant pin override in `configure.sh`.

## Dependency

End-to-end success requires the companion `pam-access` plugin changes (source-address pin gating — already released in plugin v0.3.5 — and the ephemeral-fingerprint registration). With those deployed:

```
== Assertions — e2e (dwho cert) ==
[OK] dwho cert logs into the bastion (no password fallback)
[OK] ob-ssh hop bastion->lab-b (ran on the backend)
[OK] getent passwd dwho on bastion (NSS)
[OK] ob-scp bastion->backend and backend->backend (scp -3)
== Summary ==
passed=28  failed=0  skipped=1
```

## Test

Validated on a fresh libvirt lab (token-only): bastion + 2 backends + standalone, ob-ssh hop and ob-scp green end-to-end. `bash -n` clean on all modified scripts.