### PR TITLE
fix(release): sign RPMs with native EL rpm to fix GPG check FAILED (#99)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -178,11 +178,21 @@ jobs:
           rc=0
           for rpm in packages/*.rpm; do
             [ -f "$rpm" ] || continue
-            if rpm --checksig "$rpm" | grep -qiE 'pgp.*OK|signatures OK'; then
+            out=$(rpm -Kvv "$rpm" 2>&1)
+            echo "$out"
+            # Two independent gates:
+            #  1. `rpm --checksig` exit code: non-zero on a BAD or NOKEY
+            #     signature (don't grep its text -- "OK" is a substring of
+            #     "NOT OK").
+            #  2. an explicit "signature ...: OK" line must be present, so an
+            #     *unsigned* package (which --checksig passes with exit 0,
+            #     "digests OK") is still rejected. `.*` keeps this tolerant of
+            #     the differing verbose layouts across rpm versions.
+            if rpm --checksig "$rpm" >/dev/null 2>&1 \
+               && echo "$out" | grep -iqE 'signature.*:[[:space:]]*OK'; then
               echo "OK: $rpm"
             else
-              echo "BAD SIGNATURE: $rpm"
-              rpm -Kvv "$rpm" || true
+              echo "BAD/UNVERIFIED SIGNATURE: $rpm"
               rc=1
             fi
           done

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,7 +102,9 @@ jobs:
             openssl-devel \
             libsodium-devel \
             pkgconfig \
-            systemd-rpm-macros
+            systemd-rpm-macros \
+            gnupg2 \
+            rpm-sign
 
       - name: Get version
         id: version
@@ -141,6 +143,50 @@ jobs:
           mkdir -p packages
           mv ~/rpmbuild/RPMS/x86_64/*.rpm packages/ 2>/dev/null || true
           mv ~/rpmbuild/RPMS/noarch/*.rpm packages/ 2>/dev/null || true
+
+      # Sign the RPMs here, with the *native* EL rpm/rpm-sign, in the same
+      # toolchain that built them. Signing them later on Ubuntu (apt's rpm)
+      # re-serialises the header signature region and produces a signature
+      # that EL/Rocky rejects as "Header signature: BAD" -> "GPG check FAILED"
+      # on `dnf install`. See issue #99.
+      - name: Import GPG signing key
+        env:
+          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+        run: |
+          echo "$GPG_PRIVATE_KEY" | gpg --batch --import
+          KEY_ID=$(gpg --list-secret-keys --keyid-format LONG \
+            | awk '/^sec/{print $2}' | head -1 | cut -d'/' -f2)
+          echo "GPG_KEY_ID=$KEY_ID" >> "$GITHUB_ENV"
+
+      - name: Sign RPM packages
+        env:
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+        run: |
+          for rpm in packages/*.rpm; do
+            [ -f "$rpm" ] || continue
+            echo "$GPG_PASSPHRASE" | rpm --addsign "$rpm" \
+              --define "_gpg_name $GPG_KEY_ID" \
+              --define "_gpg_sign_cmd_extra_args --batch --pinentry-mode loopback --passphrase-fd 0"
+          done
+
+      - name: Verify RPM signatures
+        run: |
+          # Fail the build if any package does not validate against our key,
+          # so a broken signature can never reach the published repo again.
+          gpg --armor --export "$GPG_KEY_ID" > /tmp/open-bastion-KEY.gpg
+          rpm --import /tmp/open-bastion-KEY.gpg
+          rc=0
+          for rpm in packages/*.rpm; do
+            [ -f "$rpm" ] || continue
+            if rpm --checksig "$rpm" | grep -qiE 'pgp.*OK|signatures OK'; then
+              echo "OK: $rpm"
+            else
+              echo "BAD SIGNATURE: $rpm"
+              rpm -Kvv "$rpm" || true
+              rc=1
+            fi
+          done
+          exit $rc
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v7
@@ -257,19 +303,11 @@ jobs:
             # Create directory structure
             mkdir -p "repo/rpm/${elver}/x86_64"
 
-            # Copy .rpm files
+            # Copy .rpm files (already signed by the build-rpm job, with the
+            # native EL rpm — see issue #99). We only build repo metadata here.
             if [ -d "artifacts/rpm-${elver}" ]; then
               cp artifacts/rpm-${elver}/*.rpm "repo/rpm/${elver}/x86_64/"
             fi
-
-            # Sign RPM packages
-            for rpm in repo/rpm/${elver}/x86_64/*.rpm; do
-              if [ -f "$rpm" ]; then
-                echo "$GPG_PASSPHRASE" | rpm --addsign "$rpm" \
-                  --define "_gpg_name $GPG_KEY_ID" \
-                  --define "_gpg_sign_cmd_extra_args --batch --pinentry-mode loopback --passphrase-fd 0"
-              fi
-            done
 
             # Create repository metadata
             createrepo_c "repo/rpm/${elver}/x86_64"


### PR DESCRIPTION
Closes #99

## Problem (#99)

`dnf install open-bastion` fails on Rocky Linux 9 with `Error: GPG check FAILED`, even though the GPG key was imported correctly.

## Root cause (verified against the published artifact)

The published RPM is intact (all header/payload digests are `OK`) and references the correct key, but its **header signature is BAD**:

```
Header SHA256 digest:   OK
Payload SHA256 digest:  OK
Header OpenPGP V4 RSA/SHA512 signature, key fingerprint 7763...c05ad0df: BAD
```

Confirmed independently with rpm 4.16 (Rocky 9) and rpm 6.0.1.

In `release.yml`, the RPMs are **built inside `rockylinux:9/10` containers** (native EL rpm) but **signed afterwards on `ubuntu-latest`** with Debian's `rpm` (`apt-get install rpm` + `rpm --addsign`). Ubuntu's `rpm --addsign` re-serialises the RPM header signature region differently from the EL rpm, producing a V4 RSA signature that EL/Rocky reject as `BAD` → `GPG check FAILED`.

The APT/.deb side is unaffected (it signs the text `Release`/`InRelease` files directly with `gpg`), which is consistent with the bug being RPM-only.

## Fix

- Sign the RPMs **in the `build-rpm` job**, in the same Rocky container that built them (native rpm + `rpm-sign`), and upload them **already signed**.
- Add a **verify** step that fails the build if any signature does not validate — so a broken artifact can never reach the repo again.
- The `create-repo` job on Ubuntu now only builds and signs the repo metadata (`createrepo_c` + `repomd.xml.asc`).

## Follow-up

After merge, a release must be **re-published**: the 0.1.1 and 0.4.1 artifacts currently online remain invalidly signed until regenerated by the fixed workflow.

## Testing

- YAML validated.
- Diagnosis reproduced from the actually-published RPM (signature `BAD`).
