### PR TITLE
fix(pam): authorize `sudo -i` (canonicalize sudo-i service) (#152)

### DIFF
--- a/src/pam_openbastion.c
+++ b/src/pam_openbastion.c
@@ -2213,7 +2213,7 @@ PAM_VISIBLE PAM_EXTERN int pam_sm_authenticate(pam_handle_t *pamh,
     /* Get context information for audit and rate limiting */
     client_ip = get_client_ip(pamh);
     tty = get_tty(pamh);
-    if (pam_get_item(pamh, PAM_SERVICE, (const void **)&service) != PAM_SUCCESS) {
+    if (pam_get_item(pamh, PAM_SERVICE, (const void **)&service) != PAM_SUCCESS || !service) {
         service = "unknown";
     }
     service = canonical_service(service);

--- a/src/pam_openbastion.c
+++ b/src/pam_openbastion.c
@@ -103,6 +103,24 @@ typedef struct {
 /* Defense-in-depth: group required by sudoers for sudo access */
 #define OB_SUDO_GROUP "open-bastion-sudo"
 
+/*
+ * Canonicalize the PAM service name for authorization purposes.
+ *
+ * `sudo -i` (login shell) runs under the PAM service name "sudo-i", distinct
+ * from "sudo" used by `sudo`, `sudo -s` and `sudo su`. The two are identical
+ * as far as authorization is concerned: both are a sudo elevation. Map
+ * "sudo-i" to "sudo" so /pam/authorize and every sudo-permission check treat
+ * them the same. Without this, the LLNG pam-access plugin — which only knows
+ * "ssh"/"sshd"/"sudo" and default-denies anything else — rejects "sudo-i" at
+ * PAM account management, so `sudo -i` fails while `sudo su` succeeds (#152).
+ */
+static const char *canonical_service(const char *service)
+{
+    if (service && strcmp(service, "sudo-i") == 0)
+        return "sudo";
+    return service;
+}
+
 /* Logging macros - prefixed to avoid conflict with syslog constants */
 #define OB_LOG_ERR(handle, fmt, ...) \
     pam_syslog(handle, LOG_ERR, fmt, ##__VA_ARGS__)
@@ -2198,6 +2216,7 @@ PAM_VISIBLE PAM_EXTERN int pam_sm_authenticate(pam_handle_t *pamh,
     if (pam_get_item(pamh, PAM_SERVICE, (const void **)&service) != PAM_SUCCESS) {
         service = "unknown";
     }
+    service = canonical_service(service);
 
     /* Initialize audit event */
     if (data->audit) {
@@ -2988,6 +3007,7 @@ PAM_VISIBLE PAM_EXTERN int pam_sm_acct_mgmt(pam_handle_t *pamh,
     if (pam_get_item(pamh, PAM_SERVICE, (const void **)&service) != PAM_SUCCESS || !service) {
         service = "unknown";
     }
+    service = canonical_service(service);
 
     /*
      * SSH key policy validation (#91)

--- a/tests/test_integration_maxsec.sh
+++ b/tests/test_integration_maxsec.sh
@@ -1097,6 +1097,13 @@ test_service_account_sudo() {
 
     # -n: non-interactive. If anything prompts for a password this fails,
     # which is exactly what we want to assert about sudo_nopasswd.
+    #
+    # We exercise BOTH `sudo` and `sudo -i`: the latter runs under the separate
+    # PAM service name "sudo-i", which pam_openbastion canonicalizes to "sudo"
+    # for authorization. Without that canonicalization `sudo -i` is treated as
+    # an unknown service and rejected at PAM account management while plain
+    # `sudo` works — regression guard for #152. The `&&` chain fails the test
+    # if either form is denied.
     local output rc=0
     output=$(ssh -i "${SVC_KEY}" \
                  -o IdentitiesOnly=yes \
@@ -1106,7 +1113,7 @@ test_service_account_sudo() {
                  -o ConnectTimeout=10 \
                  -p 2222 \
                  "${SVC_ACCOUNT}@localhost" \
-                 "sudo -n id -u && sudo -n id -un" 2>&1) || rc=$?
+                 "sudo -n id -u && sudo -n id -un && sudo -n -i id -u && sudo -n -i id -un" 2>&1) || rc=$?
     log_verbose "SSH(svc+sudo) rc=$rc output: $output"
 
     if [[ $rc -ne 0 ]]; then
@@ -1124,7 +1131,7 @@ test_service_account_sudo() {
         return 1
     fi
 
-    pass "sudo -n from ${SVC_ACCOUNT} runs as root (nopasswd path)"
+    pass "sudo -n and sudo -n -i from ${SVC_ACCOUNT} run as root (nopasswd path, #152)"
     return 0
 }
 


### PR DESCRIPTION
## Problem (#152)

`sudo -i` was rejected on bastions while `sudo su` / `sudo -s` worked:

```
sudo su -c id   → uid=0(root)   ✅
sudo -s -- id   → uid=0(root)   ✅
sudo -i id      → sudo: PAM account management error: Authorization refused   ❌
```

Diagnosed live on a production bastion. With sudo credentials **already cached**
(no token prompt), `sudo -i` still failed — proving it is an **authorization**
decision (PAM `account` phase), not authentication or a tty/recorder issue. The
only PAM-level difference between the working and failing cases is the **service
name**: `sudo -i` runs under the separate PAM service `sudo-i`, while `sudo`,
`sudo -s` and `sudo su` use `sudo`.

## Root cause

`pam_openbastion` forwards the PAM service name verbatim to LLNG
`/pam/authorize`, and the pam-access plugin's `_checkPamRule` only recognizes
`ssh`/`sshd`/`sudo`:

```perl
if    ( $service eq 'sshd' || $service eq 'ssh' ) { ... }
elsif ( $service eq 'sudo' )                      { ... }
# For other services, deny     ← sudo-i lands here
```

So `sudo-i` hits the default-deny branch → `authorized=0` → the module returns
`PAM_PERM_DENIED`. The module's own sudo checks are likewise gated on
`strcmp(service,"sudo")==0`.

## Fix

Canonicalize `sudo-i` → `sudo` in both `pam_sm_authenticate` and
`pam_sm_acct_mgmt`, so the authorize request and every sudo-permission check
treat them identically.

This is **self-contained in the bastion module**: LLNG never sees `sudo-i`, so
no plugin change or coordinated SSO deploy is required to fix existing
deployments.

## Tests

- Build: `pam_openbastion.so` compiles clean.
- `test_integration_maxsec.sh`: the service-account sudo test now runs
  `sudo -n -i` alongside `sudo -n`; both must reach uid 0 (regression guard).
- The existing `test_sudo_pam_config` already asserts `/etc/pam.d/sudo-i` carries
  the open-bastion stack (config side); this PR fixes the runtime routing side.

## Optional follow-up (LLNG plugin, defense-in-depth)

Not required for this fix, but the plugin could also accept `sudo-i`
(`$service =~ /^sudo(-i)?$/`) so any other PAM client benefits. Tracked
separately.

Closes #152
