### PR TITLE
fix(backend): provision open-bastion-sudo group + sudoers rule on backends (#154)

### DIFF
--- a/scripts/ob-backend-setup
+++ b/scripts/ob-backend-setup
@@ -557,6 +557,8 @@ session    required     pam_unix.so
     if [ "$DRY_RUN" = "true" ]; then
         info "[DRY-RUN] Would configure PAM for sudo"
         echo "$pam_content"
+        info "[DRY-RUN] Would create group open-bastion-sudo"
+        info "[DRY-RUN] Would create /etc/sudoers.d/open-bastion with: %open-bastion-sudo ALL=(ALL) ALL"
         return 0
     fi
 
@@ -571,6 +573,33 @@ session    required     pam_unix.so
     echo "$pam_content" > "$PAM_SUDO_I"
     chmod 644 "$PAM_SUDO_I"
     info "Configured $PAM_SUDO_I"
+
+    # PAM authorizes sudo, but sudoers must still grant the right. pam_openbastion
+    # adds an authorized user to the open-bastion-sudo group during its session
+    # phase — but only if that group exists — and the group needs a sudoers rule.
+    # Without both, an LLNG-authorized SSO user still gets "not in the sudoers
+    # file" (#154). Mirror ob-bastion-setup so backends honor pamAccessSudoRules.
+    groupadd --system open-bastion-sudo 2>/dev/null || true
+
+    local sudoers_file="/etc/sudoers.d/open-bastion"
+    if [ ! -f "$sudoers_file" ]; then
+        # Write to a temp file and validate with visudo before installing, so a
+        # malformed drop-in can never break sudo on the host.
+        local tmp_sudoers
+        tmp_sudoers=$(mktemp)
+        {
+            echo "# Open Bastion: defense-in-depth sudo authorization"
+            echo "# Both group membership (managed by PAM session) AND LLNG token are required"
+            echo "%open-bastion-sudo ALL=(ALL) ALL"
+        } > "$tmp_sudoers"
+        if visudo -cf "$tmp_sudoers" >/dev/null 2>&1; then
+            install -m 0440 -o root -g root "$tmp_sudoers" "$sudoers_file"
+            info "Created $sudoers_file"
+        else
+            warn "Generated sudoers rule failed visudo validation; not installing"
+        fi
+        rm -f "$tmp_sudoers"
+    fi
 }
 
 # Configure sshd for max security (Mode E)

--- a/scripts/ob-backend-setup
+++ b/scripts/ob-backend-setup
@@ -593,8 +593,16 @@ session    required     pam_unix.so
             echo "%open-bastion-sudo ALL=(ALL) ALL"
         } > "$tmp_sudoers"
         if visudo -cf "$tmp_sudoers" >/dev/null 2>&1; then
-            install -m 0440 -o root -g root "$tmp_sudoers" "$sudoers_file"
-            info "Created $sudoers_file"
+            # Ensure the drop-in directory exists (created 0750 root:root only
+            # when missing, so we never relax an existing one), then install and
+            # CHECK the result — otherwise a failed install would leave sudo
+            # broken while we log success.
+            [ -d /etc/sudoers.d ] || install -d -m 0750 -o root -g root /etc/sudoers.d
+            if install -m 0440 -o root -g root "$tmp_sudoers" "$sudoers_file"; then
+                info "Created $sudoers_file"
+            else
+                warn "Failed to install $sudoers_file; sudo may not work for SSO users"
+            fi
         else
             warn "Generated sudoers rule failed visudo validation; not installing"
         fi

--- a/tests/test_ob_backend_setup.sh
+++ b/tests/test_ob_backend_setup.sh
@@ -112,6 +112,39 @@ test_no_sudo() {
     fi
 }
 
+# ── Test 7b: sudo config provisions the open-bastion-sudo group + sudoers rule (#154) ──
+# ob-backend-setup used to configure only PAM for sudo, never the sudoers
+# drop-in, so SSO users always got "not in the sudoers file" on backends.
+test_sudo_creates_sudoers_rule() {
+    local out
+    out=$(
+        source_script "ob-backend-setup"
+        parse_args -p "https://x" -g "g" --dry-run
+        configure_pam_sudo 2>&1
+    )
+    if echo "$out" | grep -q "open-bastion-sudo" \
+       && echo "$out" | grep -q "/etc/sudoers.d/open-bastion"; then
+        pass "configure_pam_sudo provisions open-bastion-sudo group + sudoers rule (#154)"
+    else
+        fail "configure_pam_sudo provisions sudoers rule (#154)" "$out"
+    fi
+}
+
+# ── Test 7c: --no-sudo skips the sudoers rule entirely ──
+test_no_sudo_skips_sudoers() {
+    local out
+    out=$(
+        source_script "ob-backend-setup"
+        parse_args -p "https://x" -g "g" --no-sudo --dry-run
+        configure_pam_sudo 2>&1
+    )
+    if echo "$out" | grep -q "sudoers.d/open-bastion"; then
+        fail "--no-sudo must not provision a sudoers rule" "$out"
+    else
+        pass "--no-sudo skips the sudoers rule"
+    fi
+}
+
 # ── Test 8: --no-create-user sets CREATE_USERS=false ──
 test_no_create_user() {
     (
@@ -256,6 +289,8 @@ run_test test_missing_portal
 run_test test_missing_server_group
 run_test test_parse_args_sets_variables
 run_test test_no_sudo
+run_test test_sudo_creates_sudoers_rule
+run_test test_no_sudo_skips_sudoers
 run_test test_no_create_user
 run_test test_dry_run
 run_test test_confirm_noninteractive


### PR DESCRIPTION
## Problem (#154)

On a backend configured by `ob-backend-setup` (incl. via the generated Ansible
role, 0.4.1), `sudo` is unusable for SSO users:

```
xguimard@test-xavier-03-tby:~$ sudo su
[sudo] password for xguimard:
xguimard is not in the sudoers file.
```

`/etc/sudoers.d/` had no open-bastion drop-in.

## Root cause

`ob-backend-setup` configured only the **PAM** side of sudo (`/etc/pam.d/sudo`
and `/etc/pam.d/sudo-i` with `pam_openbastion.so service_type=sudo`) but never
created the `open-bastion-sudo` group nor the `/etc/sudoers.d/open-bastion`
rule. `ob-bastion-setup` does both. The sudo-authorization chain then breaks:

1. The `open-bastion-sudo` group does not exist → `pam_openbastion`'s session
   phase skips adding the authorized user to it.
2. No sudoers rule references the group → `sudo` denies with "not in the
   sudoers file".

A backend with `pamAccessSudoRules` granting the user's server_group (e.g.
`romain => 1`) still could not sudo: LLNG authorized, but the host had no
sudoers policy to honor it.

## Fix

In `configure_pam_sudo` (under the same `--no-sudo` guard), mirror
`ob-bastion-setup`:

- `groupadd --system open-bastion-sudo` (idempotent),
- write `/etc/sudoers.d/open-bastion` (`%open-bastion-sudo ALL=(ALL) ALL`,
  mode 0440) — generated to a temp file and **validated with `visudo -c`**
  before install, so a malformed drop-in can never break sudo on the host.

## Tests

- `test_ob_backend_setup.sh`: two new dry-run unit tests — the sudoers rule is
  provisioned when sudo is enabled, and skipped under `--no-sudo`. 18/18 pass.
- Confirmed on production backends: adding `/etc/sudoers.d/open-bastion` makes
  sudo work.

Closes #154
