### PR TITLE
release: 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-06-16
+
+Tamper-evident session recording — a non-root user can no longer delete or alter
+its own session recordings — plus `sudo -i` and backend `sudo` fixes.
+
+> **Upgrade note (session recording).** Recording now streams to a root,
+> socket-activated sink (`ob-record-sink`) instead of being written by the user.
+> After upgrade, **re-run `ob-bastion-setup`** (or `ob-standalone-setup`) so it
+> enables `ob-record.socket`, sets `/var/lib/open-bastion/sessions` to
+> `root:ob-sessions 0750`, and migrates any legacy per-user dirs to root
+> ownership. Recording is **fail-closed** when enabled: if `ob-record.socket` is
+> not active, recorded logins are refused. `ForceCommand` now points directly at
+> `ob-session-recorder` (the setgid `ob-session-recorder-wrapper` is removed).
+
 ### Added
 
 - **Tamper-evident session recording (#151).** Sessions are now streamed to a
@@ -33,6 +47,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `root:ob-sessions 0750` (was `3771` setgid+sticky). `ob-bastion-setup` enables
   `ob-record.socket` and migrates any legacy user-owned per-user dirs to root
   ownership.
+
+### Fixed
+
+- **`sudo -i` is authorized again on bastions (#152).** `sudo -i` runs under the
+  PAM service name `sudo-i`; `pam_openbastion` forwarded it verbatim to LLNG,
+  whose pam-access plugin only knows `ssh`/`sshd`/`sudo` and default-denied the
+  rest — so `sudo -i` failed at PAM account management while `sudo`/`sudo su`
+  worked. The module now canonicalizes `sudo-i` to `sudo` (self-contained in the
+  bastion; no plugin change required).
+- **Backend `sudo` works for SSO users (#154).** `ob-backend-setup` configured
+  the PAM side of sudo but never created the `open-bastion-sudo` group nor the
+  `/etc/sudoers.d/open-bastion` rule, so an LLNG-authorized user still got "not
+  in the sudoers file". It now provisions both (mirroring `ob-bastion-setup`,
+  `visudo`-validated).
+- **Debian package ships the socket-activation template units.** `dh_installsystemd`
+  does not auto-install named `@.service` templates, so `ob-cert@.service` and
+  `ob-record@.service` were missing from the `.deb` — the sockets could not spawn
+  an instance ("Connection refused"). Both templates are now installed. (This was
+  a latent gap for `ob-cert@.service` too.)
+- **RPM GPG signature check (#99).** Release RPMs are signed with the native EL
+  `rpm` so the signature verifies.
 
 ## [0.4.1] - 2026-06-16
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.10)
-project(open-bastion VERSION 0.4.1 LANGUAGES C)
+project(open-bastion VERSION 0.5.0 LANGUAGES C)
 
 set(CMAKE_C_STANDARD 11)
 set(CMAKE_C_STANDARD_REQUIRED ON)

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+open-bastion (0.5.0) unstable; urgency=medium
+
+  * See https://github.com/linagora/open-bastion/blob/main/CHANGELOG.md
+
+ -- Xavier Guimard <yadd@debian.org>  Tue, 16 Jun 2026 23:30:00 +0200
+
 open-bastion (0.4.1) unstable; urgency=medium
 
   * See https://github.com/linagora/open-bastion/blob/main/CHANGELOG.md

--- a/doc/design/tamper-evident-session-recording.md
+++ b/doc/design/tamper-evident-session-recording.md
@@ -140,7 +140,7 @@ wait                                          # forwarder drains, half-closes th
 ```
 
 `ob-record-connect` `connect()`s **first** (fast for a local listening socket)
-and exits non-zero on failure, so the recorder can refuse the session *before*
+and exits non-zero on failure, so the recorder can refuse the session _before_
 `script` starts. It then writes the header and copies the FIFO to the socket
 until EOF. `script`'s PTY handling (raw mode, window size, **Ctrl-C** delivered
 to the foreground process group) is unchanged — we reuse it rather than

--- a/rpm/open-bastion.spec
+++ b/rpm/open-bastion.spec
@@ -1,5 +1,5 @@
 Name:           open-bastion
-Version:        0.4.1
+Version:        0.5.0
 Release:        1%{?dist}
 Summary:        Open Bastion PAM/NSS module for SSH bastion authentication
 
@@ -223,33 +223,18 @@ if [ "$1" = "0" ]; then
 fi
 
 %changelog
+* Tue Jun 16 2026 Xavier Guimard <xguimard@linagora.com> - 0.5.0-1
+- See https://github.com/linagora/open-bastion/blob/main/CHANGELOG.md
 * Tue Jun 16 2026 Xavier Guimard <xguimard@linagora.com> - 0.4.1-1
-- Bastion hop-certificate minting no longer goes through sudo: ob-cert-daemon
-  (socket-activated, user from SO_PEERCRED) plus the unprivileged ob-cert-request
-  client replace the ob-bastion-cert-helper + NOPASSWD sudoers bridge, so
-  ob-ssh/ob-scp work in max-security (Mode E, where sudo required an LLNG token).
-  ob-bastion-setup now enables ob-cert.socket. Requires the matching pam-access
-  plugin update. See CHANGELOG.md
+- See https://github.com/linagora/open-bastion/blob/main/CHANGELOG.md
 * Tue Jun 16 2026 Xavier Guimard <xguimard@linagora.com> - 0.4.0-1
-- Certificate bastion->backend hop (ob-ssh/ob-scp) works end to end on OpenSSH
-  9.8+: the SSH-fingerprint spool now converges on the outermost sshd-session on
-  both bastion and backend (with an sshd fallback for pre-9.8), and
-  /run/open-bastion is 0711 so the principals helper can write it.
-  ob-session-recorder propagates the recorded command's exit status (script -e).
-  Requires the matching pam-access plugin. See CHANGELOG.md
+- See https://github.com/linagora/open-bastion/blob/main/CHANGELOG.md
 * Tue Jun 16 2026 Xavier Guimard <xguimard@linagora.com> - 0.3.2-1
-- Mode E sudo requires the LLNG token again (authorize_only no longer bypasses
-  it for the sudo PAM service); sudo -i works for SSO users (the separate sudo-i
-  PAM service is now configured); ob-builder Mode E roles always ship the KRL
-  file; ob-standalone-setup symlink. See CHANGELOG.md
+- See https://github.com/linagora/open-bastion/blob/main/CHANGELOG.md
 * Mon Jun 15 2026 Xavier Guimard <xguimard@linagora.com> - 0.3.1-1
-- ob-heartbeat reports connected users (who-is-connected), client version and
-  node role to the SSO; ob-enroll fails when offline_access yields no refresh
-  token; ob-builder/Ansible Mode E deploy fixes. See CHANGELOG.md
+- See https://github.com/linagora/open-bastion/blob/main/CHANGELOG.md
 * Sat Jun 13 2026 Xavier Guimard <xguimard@linagora.com> - 0.3.0-1
-- Certificate-based bastion->backend vouching (replaces the broken JWT/SendEnv
-  transport); ob-scp; token-lifecycle/NSS/sshd/recorder fixes; ob-builder
-  artefacts deploy unattended. See CHANGELOG.md
+- See https://github.com/linagora/open-bastion/blob/main/CHANGELOG.md
 * Sat May 23 2026 Xavier Guimard <xguimard@linagora.com> - 0.2.3-1
 - See https://github.com/linagora/open-bastion/blob/main/CHANGELOG.md
 * Thu May 21 2026 Xavier Guimard <xguimard@linagora.com> - 0.2.2-1


### PR DESCRIPTION
Version bump and changelog for **0.5.0**.

Minor bump (semver): a new feature plus behavioral/deployment changes, not just patches.

## Highlights (full detail in CHANGELOG.md)
- **Added:** tamper-evident session recording (#151) — root socket sink (`ob-record-sink`), unprivileged `ob-record-connect` connector, `ob-record.socket`/`ob-record@.service`; recordings root-owned, the non-root user cannot delete/alter them; fail-closed.
- **Changed:** setgid `ob-session-recorder-wrapper` removed; `ForceCommand` → `ob-session-recorder`; sessions tree `root:ob-sessions 0750`.
- **Fixed:** `sudo -i` on bastions (#152), backend `sudo` (#154), Debian `@.service` template packaging (also fixed `ob-cert@`), RPM GPG signing (#99).

## Files
- `CMakeLists.txt`, `rpm/open-bastion.spec`, `debian/changelog` → 0.5.0
- `CHANGELOG.md` → 0.5.0 section with the recording **upgrade note** (re-run `ob-bastion-setup`; recording is fail-closed when enabled)
- rpm/debian changelogs kept minimal (point at CHANGELOG.md)

Validated: 3-VM Mode E lab 33/33 + recordings; CI green on the merged work.