### PR TITLE
fix: server-token freshness — arm heartbeat timer at enrollment + refresh on 401

### DIFF
--- a/include/ob_client.h
+++ b/include/ob_client.h
@@ -176,4 +176,36 @@ void ob_response_free(ob_response_t *response);
  */
 const char *ob_client_error(ob_client_t *client);
 
+/*
+ * HTTP status of the most recent /pam endpoint request (0 if none, or on a transport
+ * error). Lets callers tell "server token expired" (401) apart from other
+ * failures so they can refresh the server token and retry.
+ */
+long ob_client_last_http_code(ob_client_t *client);
+
+/*
+ * Current server access token (the Bearer used for /pam/verify and
+ * /pam/authorize), or NULL. Borrowed pointer; do not free.
+ */
+const char *ob_client_get_server_token(ob_client_t *client);
+
+/*
+ * Replace the server access token (e.g. after an on-demand refresh).
+ */
+void ob_client_set_server_token(ob_client_t *client, const char *token);
+
+/*
+ * Refresh the server access token via /pam/heartbeat (NOT the OIDC
+ * /oauth2/token grant, which fails for the synthetic device identity and would
+ * drop the per-device bastion_id). Posts {refresh_token, hostname,
+ * server_group}; on success returns 0 and sets *new_access_token (caller frees)
+ * plus *expires_in (seconds). Leaves the refresh_token untouched.
+ * Returns -1 on error.
+ */
+int ob_client_refresh_via_heartbeat(ob_client_t *client,
+                                    const char *refresh_token,
+                                    const char *hostname,
+                                    char **new_access_token,
+                                    int *expires_in);
+
 #endif /* OB_CLIENT_H */

--- a/scripts/ob-backend-setup
+++ b/scripts/ob-backend-setup
@@ -1843,6 +1843,36 @@ parse_args() {
     done
 }
 
+# Arm the heartbeat timer now that the server token exists.
+#
+# The packaged ob-heartbeat.timer is enabled+started at install time, but it
+# carries ConditionPathExists=/var/lib/open-bastion/token and enrollment runs
+# *after* install, so the install-time start is skipped (condition false) and
+# the timer never arms until the next reboot. With no heartbeat the short-lived
+# enrollment token expires within hours and is never refreshed, so the backend's
+# /pam/authorize calls start failing (offline fallback / token expired). Start
+# it here, once the token is in place. Mirrors ob-bastion-setup.
+enable_heartbeat_timer() {
+    if [ "$DRY_RUN" = "true" ]; then
+        info "[DRY-RUN] Would enable --now ob-heartbeat.timer"
+        return 0
+    fi
+
+    # No token (enrollment skipped/declined) -> nothing to heartbeat yet.
+    [ -s "$OB_TOKEN" ] || return 0
+
+    if command -v systemctl >/dev/null 2>&1; then
+        if systemctl enable --now ob-heartbeat.timer >/dev/null 2>&1; then
+            info "Enabled ob-heartbeat.timer (keeps the server token fresh)"
+        else
+            warn "Could not enable ob-heartbeat.timer — enable it manually:"
+            warn "  systemctl enable --now ob-heartbeat.timer"
+        fi
+    else
+        warn "systemctl not available — enable ob-heartbeat.timer manually"
+    fi
+}
+
 # Main
 main() {
     parse_args "$@"
@@ -1972,6 +2002,10 @@ main() {
         # future re-enrollments via ob-enroll alone keep working.
         refresh_openbastion_conf
     fi
+
+    # Keep the freshly enrolled token alive (timer would otherwise only arm on
+    # the next reboot — see enable_heartbeat_timer).
+    enable_heartbeat_timer
 
     # ── Phase 3: SSH / PAM lockdown ──
     configure_sshd || exit 1

--- a/scripts/ob-bastion-setup
+++ b/scripts/ob-bastion-setup
@@ -720,6 +720,39 @@ TIMEOUT=10
     fi
 }
 
+# Arm the heartbeat timer now that the server token exists.
+#
+# The packaged ob-heartbeat.timer is enabled+started at install time by
+# dh_installsystemd, but it carries ConditionPathExists=/var/lib/open-bastion/
+# token. Enrollment runs *after* package install, so at that install-time start
+# the token does not exist yet, the condition fails, and the timer is silently
+# skipped — it never arms in the running system until the next reboot. With no
+# heartbeat, the short-lived enrollment access token expires within hours and is
+# never refreshed: PAM then falls back to the offline cache (SSH login still
+# works but no bastion voucher is minted, so ob-ssh breaks with "voucher unset")
+# and sudo locks out ("server token invalid or expired"). Starting it here, once
+# the token is in place, closes that window. Mirrors ob-cert.socket above.
+enable_heartbeat_timer() {
+    if [ "$DRY_RUN" = "true" ]; then
+        info "[DRY-RUN] Would enable --now ob-heartbeat.timer"
+        return 0
+    fi
+
+    # No token (enrollment skipped/declined) -> nothing to heartbeat yet.
+    [ -s "$OB_TOKEN" ] || return 0
+
+    if command -v systemctl >/dev/null 2>&1; then
+        if systemctl enable --now ob-heartbeat.timer >/dev/null 2>&1; then
+            info "Enabled ob-heartbeat.timer (keeps the server token fresh)"
+        else
+            warn "Could not enable ob-heartbeat.timer — enable it manually:"
+            warn "  systemctl enable --now ob-heartbeat.timer"
+        fi
+    else
+        warn "systemctl not available — enable ob-heartbeat.timer manually"
+    fi
+}
+
 # Configure sshd for max security (Mode E)
 configure_max_security_sshd() {
     if [ "$MAX_SECURITY" != "true" ]; then
@@ -2002,6 +2035,11 @@ main() {
         # future re-enrollments via ob-enroll alone keep working.
         refresh_openbastion_conf
     fi
+
+    # Keep the freshly enrolled token alive. Without this the timer only arms on
+    # the next reboot (ConditionPathExists was false at package-install time),
+    # and the token expires overnight -> offline fallback + sudo lockout.
+    enable_heartbeat_timer
 
     # ── Phase 3: SSH / PAM lockdown ──
     # From this point on, a failure may require restoring files from

--- a/scripts/ob-enroll
+++ b/scripts/ob-enroll
@@ -708,6 +708,28 @@ show_summary() {
     echo ""
 }
 
+# Arm the heartbeat timer so the freshly minted token keeps getting refreshed.
+#
+# ob-heartbeat.timer ships enabled, but its
+# ConditionPathExists=/var/lib/open-bastion/token is false at package-install
+# time (enrollment runs afterwards), so the install-time start is skipped and
+# the timer only arms on the next reboot. Until then the short-lived access
+# token expires with nothing to refresh it: PAM then falls back to the offline
+# cache (SSH login works but no bastion voucher is minted, so ob-ssh breaks) and
+# sudo locks out ("server token expired"). Start it here, right after the token
+# is in place. Only meaningful when the token sits at the path the timer watches.
+arm_heartbeat_timer() {
+    [ "$TOKEN_FILE" = "/var/lib/open-bastion/token" ] || return 0
+    [ -s "$TOKEN_FILE" ] || return 0
+    command -v systemctl >/dev/null 2>&1 || return 0
+
+    if systemctl enable --now ob-heartbeat.timer >/dev/null 2>&1; then
+        log_success "Heartbeat timer armed (keeps the server token fresh)"
+    else
+        log_warn "Could not arm ob-heartbeat.timer — run: systemctl enable --now ob-heartbeat.timer"
+    fi
+}
+
 # Main function
 main() {
     # Check if running as root
@@ -737,6 +759,7 @@ main() {
     save_token
     update_config
     verify_enrollment
+    arm_heartbeat_timer
     show_summary
 }
 

--- a/src/ob_client.c
+++ b/src/ob_client.c
@@ -34,6 +34,9 @@
 /* Use shared JSON strdup utility */
 #define safe_json_strdup str_json_strdup
 
+/* Forward declaration for curl option setup (defined further below) */
+static void setup_curl(ob_client_t *client);
+
 /* Forward declaration for internal authorize function */
 static int ob_authorize_user_internal(ob_client_t *client,
                                          const char *user,
@@ -58,6 +61,7 @@ struct ob_client {
     char *server_token;
     char *server_group;
     char error[256];
+    long last_http_code;   /* HTTP status of the most recent /pam request */
     int timeout;
     bool verify_ssl;
     char *ca_cert;
@@ -469,6 +473,128 @@ void ob_client_destroy(ob_client_t *client)
     free(client);
 }
 
+long ob_client_last_http_code(ob_client_t *client)
+{
+    return client ? client->last_http_code : 0;
+}
+
+const char *ob_client_get_server_token(ob_client_t *client)
+{
+    return client ? client->server_token : NULL;
+}
+
+void ob_client_set_server_token(ob_client_t *client, const char *token)
+{
+    if (!client) return;
+    secure_free(client->server_token);
+    client->server_token = strdup_or_null(token);
+}
+
+/*
+ * Refresh the server access token via /pam/heartbeat, mirroring the
+ * ob-heartbeat timer. We deliberately do NOT use the OIDC /oauth2/token refresh
+ * grant: for the bastion's synthetic device identity that grant fails (it
+ * re-resolves the user in the UserDB) and would drop the per-device bastion_id,
+ * breaking voucher binding. The portal authenticates the call by the
+ * refresh_token in the body (no Bearer) and mints a fresh access token that
+ * keeps the device id. Only the access token changes; the refresh_token is
+ * untouched. Returns 0 and sets *new_access_token (caller frees) on success.
+ */
+int ob_client_refresh_via_heartbeat(ob_client_t *client,
+                                    const char *refresh_token,
+                                    const char *hostname,
+                                    char **new_access_token,
+                                    int *expires_in)
+{
+    if (!client || !refresh_token || !new_access_token) {
+        if (client) snprintf(client->error, sizeof(client->error),
+                             "Invalid parameters");
+        return -1;
+    }
+    *new_access_token = NULL;
+    if (expires_in) *expires_in = 0;
+
+    setup_curl(client);
+
+    char url[1024];
+    snprintf(url, sizeof(url), "%s/pam/heartbeat", client->portal_url);
+
+    struct json_object *req_json = json_object_new_object();
+    json_object_object_add(req_json, "refresh_token",
+                           json_object_new_string(refresh_token));
+    if (hostname && *hostname) {
+        json_object_object_add(req_json, "hostname",
+                               json_object_new_string(hostname));
+    }
+    if (client->server_group) {
+        json_object_object_add(req_json, "server_group",
+                               json_object_new_string(client->server_group));
+    }
+    const char *req_body = json_object_to_json_string(req_json);
+
+    /* /pam/heartbeat authenticates via the refresh_token in the body, like the
+     * shell ob-heartbeat — no Authorization header, no request signing. */
+    struct curl_slist *headers = NULL;
+    headers = curl_slist_append(headers, "Content-Type: application/json");
+
+    response_buffer_t buf;
+    init_buffer(&buf);
+
+    client->last_http_code = 0;
+    curl_easy_setopt(client->curl, CURLOPT_URL, url);
+    curl_easy_setopt(client->curl, CURLOPT_POSTFIELDS, req_body);
+    curl_easy_setopt(client->curl, CURLOPT_HTTPHEADER, headers);
+    curl_easy_setopt(client->curl, CURLOPT_WRITEDATA, &buf);
+
+    CURLcode res = curl_easy_perform(client->curl);
+
+    json_object_put(req_json);
+    curl_slist_free_all(headers);
+
+    if (res != CURLE_OK) {
+        snprintf(client->error, sizeof(client->error),
+                 "Curl error: %s", curl_easy_strerror(res));
+        free_buffer(&buf);
+        return -1;
+    }
+
+    long http_code;
+    curl_easy_getinfo(client->curl, CURLINFO_RESPONSE_CODE, &http_code);
+    client->last_http_code = http_code;
+
+    if (http_code != 200) {
+        snprintf(client->error, sizeof(client->error),
+                 "Heartbeat refresh failed: HTTP %ld", http_code);
+        free_buffer(&buf);
+        return -1;
+    }
+
+    struct json_object *json = json_tokener_parse(buf.data);
+    free_buffer(&buf);
+    if (!json) {
+        snprintf(client->error, sizeof(client->error),
+                 "Invalid JSON in heartbeat response");
+        return -1;
+    }
+
+    struct json_object *val;
+    if (!json_object_object_get_ex(json, "access_token", &val)
+        || !json_object_is_type(val, json_type_string)) {
+        snprintf(client->error, sizeof(client->error),
+                 "Heartbeat response missing access_token");
+        json_object_put(json);
+        return -1;
+    }
+    *new_access_token = strdup(json_object_get_string(val));
+
+    if (expires_in && json_object_object_get_ex(json, "expires_in", &val)) {
+        *expires_in = json_object_get_int(val);
+    }
+
+    json_object_put(json);
+    return (*new_access_token) ? 0 : -1;
+}
+
 const char *ob_client_error(ob_client_t *client)
 {
     return client ? client->error : "No client";
@@ -552,6 +678,7 @@ int ob_verify_token(ob_client_t *client,
     /* Build URL */
     char url[1024];
     snprintf(url, sizeof(url), "%s/pam/verify", client->portal_url);
+    client->last_http_code = 0;
 
     /* Build JSON request body */
     struct json_object *req_json = json_object_new_object();
@@ -605,6 +732,7 @@ int ob_verify_token(ob_client_t *client,
 
     long http_code;
     curl_easy_getinfo(client->curl, CURLINFO_RESPONSE_CODE, &http_code);
+    client->last_http_code = http_code;
 
     if (http_code == 401) {
         snprintf(client->error, sizeof(client->error),
@@ -795,6 +923,7 @@ int ob_introspect_token(ob_client_t *client,
 
     long http_code;
     curl_easy_getinfo(client->curl, CURLINFO_RESPONSE_CODE, &http_code);
+    client->last_http_code = http_code;
 
     if (http_code != 200) {
         snprintf(client->error, sizeof(client->error),
@@ -876,6 +1005,7 @@ static int ob_authorize_user_internal(ob_client_t *client,
     /* Build URL */
     char url[1024];
     snprintf(url, sizeof(url), "%s/pam/authorize", client->portal_url);
+    client->last_http_code = 0;
 
     /* Build JSON request body */
     struct json_object *req_json = json_object_new_object();
@@ -960,6 +1090,7 @@ static int ob_authorize_user_internal(ob_client_t *client,
 
     long http_code;
     curl_easy_getinfo(client->curl, CURLINFO_RESPONSE_CODE, &http_code);
+    client->last_http_code = http_code;
 
     if (http_code == 401) {
         snprintf(client->error, sizeof(client->error),

--- a/src/pam_openbastion.c
+++ b/src/pam_openbastion.c
@@ -2167,6 +2167,82 @@ static int user_exists_locally(const char *username)
 }
 
 /*
+ * On a 401 from /pam/verify or /pam/authorize the bastion's own server access
+ * token has expired. Normally the ob-heartbeat timer keeps it fresh, but if the
+ * timer lapsed the module would otherwise fall back to the offline cache (a
+ * bastion login then mints no voucher, so ob-ssh breaks) or deny sudo. Refresh
+ * the token on demand so a fresh login is self-healing.
+ *
+ * Returns 0 if a fresh token was installed on the client (caller should retry
+ * the request once); -1 otherwise (caller proceeds as before, e.g. offline).
+ */
+static int refresh_server_token_on_demand(pam_handle_t *pamh,
+                                          pam_openbastion_data_t *data)
+{
+    if (!data || !data->config.server_token_file || !data->client) {
+        return -1;
+    }
+
+    token_info_t ti = {0};
+    if (token_manager_load_file(data->config.server_token_file, &ti) != 0) {
+        OB_LOG_WARN(pamh, "On-demand refresh: cannot read token file %s",
+                    data->config.server_token_file);
+        return -1;
+    }
+
+    int rc = -1;
+
+    /* If the timer heartbeat already refreshed the on-disk token since this PAM
+     * handle loaded it, just adopt the newer token — no network call needed. */
+    const char *current = ob_client_get_server_token(data->client);
+    if (ti.access_token && (!current || strcmp(ti.access_token, current) != 0)) {
+        ob_client_set_server_token(data->client, ti.access_token);
+        OB_LOG_INFO(pamh, "On-demand refresh: adopted newer server token from %s",
+                    data->config.server_token_file);
+        rc = 0;
+        goto out;
+    }
+
+    /* Otherwise refresh via /pam/heartbeat (keeps the per-device bastion_id). */
+    if (!ti.refresh_token) {
+        OB_LOG_WARN(pamh, "On-demand refresh: no refresh_token in token file");
+        goto out;
+    }
+
+    char hostname[256] = {0};
+    if (gethostname(hostname, sizeof(hostname) - 1) != 0) {
+        hostname[0] = '\0';
+    }
+
+    char *new_at = NULL;
+    int new_ttl = 0;
+    if (ob_client_refresh_via_heartbeat(data->client, ti.refresh_token,
+                                        hostname, &new_at, &new_ttl) != 0) {
+        OB_LOG_WARN(pamh, "On-demand server token refresh failed: %s",
+                    ob_client_error(data->client));
+        goto out;
+    }
+
+    /* Persist only the access token + its expiry, keeping refresh_token and
+     * enrolled_at, exactly like the ob-heartbeat timer. */
+    free(ti.access_token);
+    ti.access_token = new_at;  /* transfer ownership */
+    ti.expires_at = time(NULL) + (new_ttl > 0 ? new_ttl : 3600);
+    if (token_manager_save_file(data->config.server_token_file, &ti) != 0) {
+        OB_LOG_WARN(pamh, "On-demand refresh: refreshed token but could not "
+                          "persist it to %s", data->config.server_token_file);
+        /* Still install it in-memory so this login succeeds. */
+    }
+    ob_client_set_server_token(data->client, ti.access_token);
+    OB_LOG_INFO(pamh, "Refreshed server token on demand via /pam/heartbeat");
+    rc = 0;
+
+out:
+    token_info_free(&ti);
+    return rc;
+}
+
+/*
  * pam_sm_authenticate - Authenticate user with LLNG token
  *
  * The password provided by the user is expected to be an LLNG access token
@@ -2823,6 +2899,15 @@ PAM_VISIBLE PAM_EXTERN int pam_sm_authenticate(pam_handle_t *pamh,
 
         int verify_rc = ob_verify_token(data->client, password,
                                         ssh_fingerprint, &response);
+
+        /* Server token expired (401)? Refresh on demand and retry once. */
+        if (verify_rc != 0
+            && ob_client_last_http_code(data->client) == 401
+            && refresh_server_token_on_demand(pamh, data) == 0) {
+            verify_rc = ob_verify_token(data->client, password,
+                                        ssh_fingerprint, &response);
+        }
+
         free(ssh_fingerprint);
         ssh_fingerprint = NULL;
 
@@ -3248,9 +3333,26 @@ PAM_VISIBLE PAM_EXTERN int pam_sm_acct_mgmt(pam_handle_t *pamh,
         OB_LOG_DEBUG(pamh, "Authorizing with SSH certificate info");
         auth_result = ob_authorize_user_with_cert(data->client, user, hostname,
                                                      service, &ssh_cert_info, &response);
-        ob_ssh_cert_info_free(&ssh_cert_info);
     } else {
         auth_result = ob_authorize_user(data->client, user, hostname, service, &response);
+    }
+
+    /* Server token expired (401)? Refresh on demand and retry once, BEFORE any
+     * offline fallback — otherwise a stale bastion token silently yields a
+     * cached authorization that mints no bastion voucher (ob-ssh then breaks). */
+    if (auth_result != 0
+        && ob_client_last_http_code(data->client) == 401
+        && refresh_server_token_on_demand(pamh, data) == 0) {
+        if (has_ssh_cert) {
+            auth_result = ob_authorize_user_with_cert(data->client, user, hostname,
+                                                         service, &ssh_cert_info, &response);
+        } else {
+            auth_result = ob_authorize_user(data->client, user, hostname, service, &response);
+        }
+    }
+
+    if (has_ssh_cert) {
+        ob_ssh_cert_info_free(&ssh_cert_info);
     }
 
     if (auth_result != 0) {


### PR DESCRIPTION
## Context

A bastion that worked one day failed the next morning: a fresh SSH login
succeeded but `ob-ssh` reported `LLNG_BASTION_VOUCHER is unset`, and `sudo`
locked out (`server token invalid or expired`). Root-caused on a prod bastion
(0.4.1) via the persistent `pam_openbastion` journal:

- `07:38 sshd:account: Server unavailable, using cached authorization … (from cache)` — login authorized **offline**, so **no voucher minted** → `unset`.
- `07:42 sudo:auth: Token verification failed: Server token invalid or expired` → **sudo lockout**.

Both stem from the bastion's **server access token expiring overnight** because
the heartbeat never ran (`journalctl -b -1 -u ob-heartbeat.service` → *No
entries*). The offline cache silently masked it at login.

## Two independent fixes

### 1. `fix(setup)` — arm `ob-heartbeat.timer` right after enrollment
`ob-heartbeat.timer` carries `ConditionPathExists=/var/lib/open-bastion/token`.
The package's install-time `systemctl start` runs **before** enrollment writes
that token, so the condition is false and the timer is silently skipped — it
only arms on the next reboot. It is an **ordering race**: a backend enrolled
before its package was (re)configured had the timer armed; the usual
"install then enroll" order does not. Until a reboot, the short-lived token
expires with nothing to refresh it.

Fix: `systemctl enable --now ob-heartbeat.timer` once the token exists, from
every enrollment path — `ob-enroll` (standalone + called by the setups),
`ob-bastion-setup`, `ob-backend-setup` (token-provided / reused paths).
Idempotent.

### 2. `feat(pam)` — refresh the server token on demand on 401
On a 401 from `/pam/verify` or `/pam/authorize`, refresh the server token and
retry **once** before any offline fallback, so a fresh login is self-healing
even if the timer lapsed. The refresh goes through **`/pam/heartbeat`** (like
the timer), **not** the OIDC `/oauth2/token` grant — that grant fails for the
bastion's synthetic device identity and would drop the per-device `bastion_id`,
breaking voucher binding. Only the access token + expiry are rewritten;
`refresh_token`/`enrolled_at` are preserved. If the timer already refreshed the
on-disk token, it is adopted with no network call.

## Validation
- Build green, `ctest` 18/18 pass (incl. `test_ob_client`, `test_token_manager`).
- `local-test/deploy-shell.sh` (3-VM lab, shell installer) **passed** — e2e
  `ob-ssh` hop + deploy with the timer armed.
- Note: fix #2 is exercised by any deploy; fix #3's refresh path needs a
  deliberately-stale token to trigger and was not hit by the normal e2e run.

> Companion voucher-rotation fix (concurrent sessions → `voucher_mismatch`) is
> in the lemonldap-ng-plugins PR.