### PR TITLE
fix(setup): register SSH sessions with systemd-logind (pam_systemd)

### DIFF
--- a/scripts/ob-backend-setup
+++ b/scripts/ob-backend-setup
@@ -484,6 +484,17 @@ PermitRootLogin no
 }
 
 # Configure PAM for SSH
+# True if a PAM module (e.g. pam_systemd.so) is installed in any of the standard
+# security module directories (covers Debian multiarch and RHEL lib64 layouts).
+pam_module_present() {
+    local m="$1" d
+    for d in /lib/security /lib64/security /usr/lib/security /usr/lib64/security \
+             /lib/*/security /usr/lib/*/security; do
+        [ -e "$d/$m" ] && return 0
+    done
+    return 1
+}
+
 configure_pam_sshd() {
     step "Configuring PAM for SSH..."
 
@@ -510,6 +521,17 @@ account    required     pam_openbastion.so ssh_cert_aware=true
 session    required     pam_openbastion.so $create_user_opt
 session    required     pam_unix.so
 "
+
+    # Register the session with systemd-logind so who/w/loginctl — and the
+    # ob-heartbeat connected-users report, which reads loginctl/who — actually
+    # see it. Append the line only when pam_systemd is installed: with 'optional'
+    # a missing module is normally ignored, but gating on presence avoids a
+    # per-login dlopen error on a non-systemd host (and any PAM-version edge
+    # case). Mirrors how distros tie the line to the libpam-systemd package.
+    if pam_module_present pam_systemd.so; then
+        pam_content="${pam_content}session    optional     pam_systemd.so
+"
+    fi
 
     if [ "$DRY_RUN" = "true" ]; then
         info "[DRY-RUN] Would configure PAM for SSH"

--- a/scripts/ob-bastion-setup
+++ b/scripts/ob-bastion-setup
@@ -448,6 +448,17 @@ PermitRootLogin no
 }
 
 # Configure PAM for SSH
+# True if a PAM module (e.g. pam_systemd.so) is installed in any of the standard
+# security module directories (covers Debian multiarch and RHEL lib64 layouts).
+pam_module_present() {
+    local m="$1" d
+    for d in /lib/security /lib64/security /usr/lib/security /usr/lib64/security \
+             /lib/*/security /usr/lib/*/security; do
+        [ -e "$d/$m" ] && return 0
+    done
+    return 1
+}
+
 configure_pam_sshd() {
     step "Configuring PAM for SSH..."
 
@@ -469,6 +480,17 @@ session    optional     pam_mkhomedir.so skel=/etc/skel umask=0077
 session    required     pam_unix.so
 session    optional     pam_openbastion.so
 "
+
+    # Register the session with systemd-logind so who/w/loginctl — and the
+    # ob-heartbeat connected-users report, which reads loginctl/who — actually
+    # see it. Append the line only when pam_systemd is installed: with 'optional'
+    # a missing module is normally ignored, but gating on presence avoids a
+    # per-login dlopen error on a non-systemd host (and any PAM-version edge
+    # case). Mirrors how distros tie the line to the libpam-systemd package.
+    if pam_module_present pam_systemd.so; then
+        pam_content="${pam_content}session    optional     pam_systemd.so
+"
+    fi
 
     if [ "$DRY_RUN" = "true" ]; then
         info "[DRY-RUN] Would configure PAM for SSH"


### PR DESCRIPTION
## Problem

A cert-hop SSH session on a backend **and bastion** is **invisible to session
tooling**: `who am i` is empty, the user never appears in `who`/`w`/`loginctl`,
and `sudo su` then surfaces only `root`. The `ob-heartbeat` connected-users
report (which reads `loginctl`/`who`) misses these sessions for the same reason.
This is issue #150.

## Root cause

`ob-bastion-setup` / `ob-backend-setup` write a **minimal custom**
`/etc/pam.d/sshd` (auth `pam_permit`, account `pam_openbastion`, session
`pam_openbastion` + `pam_unix`) that **omits `pam_systemd`** / the distro
`common-session`. On a modern systemd host it is `pam_systemd` that registers the
session with `systemd-logind`, which is what `who`/`w`/`loginctl` (and the
heartbeat) rely on. The "rescue" root session — a direct login through the
standard stack (with `pam_systemd`) — *is* visible, which is the tell.

Confirmed on Debian 13 / OpenSSH 10.0p2 / libpam-systemd 257:
- `loginctl` lists only the root sessions; the `xguimard` cert-hop session is absent.
- `grep pam_systemd /etc/pam.d/sshd` → empty.

## Fix

Add `session optional pam_systemd.so` to the sshd session stack in both setups
(`ob-standalone-setup` is a symlink to `ob-bastion-setup`, so it is covered).
`optional` keeps it harmless on a non-systemd host (module result ignored).

**Verified manually**: after appending the line and reconnecting, `who` shows
`xguimard sshd pts/1` instead of nothing — on **both backends and bastions**.

## Closes #150

Registering the sshd session with logind makes `who`/`w`/`loginctl` correct
everywhere, including on a bastion (logind sees the sshd session ahead of the
recorder's `script(1)` pty). The design's planned sink-side utmp registration
(§11 of `doc/design/tamper-evident-session-recording.md`) is therefore not
needed.

Closes #150