### PR TITLE
feat(recording): add ob-session-prune retention timer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Session-recording retention (`ob-session-prune`).** A new daily timer
+  (`ob-session-prune.timer`, enabled at install) bounds the recordings store,
+  which matters because recording is fail-closed — a full disk refuses new
+  logins. It compresses closed recording payloads older than
+  `recording_compress_after_days` (default 1; typescripts compress ~10–20×,
+  the `.json` index is left readable) and deletes recordings older than
+  `recording_retention_days` (default 365; `0` keeps them forever). Expiry is
+  logged at `notice` level since it drops audit evidence. Runs as root from a
+  sandboxed oneshot service and only writes under
+  `/var/lib/open-bastion/sessions`, preserving the tamper-evident layout. See
+  `doc/session-recording.md` and `ob-session-prune(8)`.
+
 ## [0.5.1] - 2026-06-17
 
 Server-token resilience and session-visibility fixes: bastions no longer silently

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -182,6 +182,11 @@ install(PROGRAMS ${CMAKE_SOURCE_DIR}/scripts/ob-session-recorder
     DESTINATION ${CMAKE_INSTALL_SBINDIR}
 )
 
+# Install session-recording retention script (run by ob-session-prune.timer)
+install(PROGRAMS ${CMAKE_SOURCE_DIR}/scripts/ob-session-prune
+    DESTINATION ${CMAKE_INSTALL_SBINDIR}
+)
+
 # NOTE: the old setgid ob-session-recorder-wrapper has been removed. Recordings
 # are now streamed to the root ob-record-sink (socket-activated), which owns the
 # files; the recorder no longer needs an elevated gid or a per-user dir, so the
@@ -377,6 +382,7 @@ install(FILES
     ${CMAKE_SOURCE_DIR}/man/ob-bastion-setup.8
     ${CMAKE_SOURCE_DIR}/man/ob-backend-setup.8
     ${CMAKE_SOURCE_DIR}/man/ob-session-recorder.8
+    ${CMAKE_SOURCE_DIR}/man/ob-session-prune.8
     ${CMAKE_SOURCE_DIR}/man/ob-cert-daemon.8
     ${CMAKE_SOURCE_DIR}/man/ob-record-sink.8
     DESTINATION ${CMAKE_INSTALL_MANDIR}/man8
@@ -409,6 +415,8 @@ if(INSTALL_SYSTEMD)
         ${CMAKE_SOURCE_DIR}/systemd/ob-cert@.service
         ${CMAKE_SOURCE_DIR}/systemd/ob-record.socket
         ${CMAKE_SOURCE_DIR}/systemd/ob-record@.service
+        ${CMAKE_SOURCE_DIR}/systemd/ob-session-prune.timer
+        ${CMAKE_SOURCE_DIR}/systemd/ob-session-prune.service
         DESTINATION lib/systemd/system
     )
     # Desktop-specific systemd service

--- a/debian/open-bastion.install
+++ b/debian/open-bastion.install
@@ -23,6 +23,7 @@ usr/sbin/ob-backend-setup
 usr/sbin/ob-cert-daemon
 usr/sbin/ob-record-sink
 usr/sbin/ob-cache-admin
+usr/sbin/ob-session-prune
 
 # Shared cert-vouching library (sourced by ob-ssh / ob-scp)
 usr/lib/open-bastion/ob-cert-lib.sh
@@ -48,6 +49,7 @@ usr/share/man/man8/ob-bastion-setup.8
 usr/share/man/man8/ob-standalone-setup.8
 usr/share/man/man8/ob-backend-setup.8
 usr/share/man/man8/ob-session-recorder.8
+usr/share/man/man8/ob-session-prune.8
 usr/share/man/man8/ob-cert-daemon.8
 usr/share/man/man8/ob-record-sink.8
 
@@ -67,6 +69,12 @@ usr/share/doc/open-bastion/README.md
 # Heartbeat systemd timer and service (not installed by cmake when INSTALL_SYSTEMD=OFF)
 systemd/ob-heartbeat.timer lib/systemd/system/
 systemd/ob-heartbeat.service lib/systemd/system/
+
+# Session-recording retention timer and service. Enabled at install time by
+# dh_installsystemd (see debian/rules); no ConditionPathExists gate, so it arms
+# immediately and no-ops on hosts without recordings.
+systemd/ob-session-prune.timer lib/systemd/system/
+systemd/ob-session-prune.service lib/systemd/system/
 
 # Socket-activated template units. dh_installsystemd installs the .socket units
 # and their enable blocks (see debian/rules) but does not auto-install the named

--- a/debian/rules
+++ b/debian/rules
@@ -34,6 +34,10 @@ override_dh_makeshlibs:
 # Install systemd units for each package
 override_dh_installsystemd:
 	dh_installsystemd -popen-bastion --name=ob-heartbeat ob-heartbeat.timer
+	# Session-recording retention timer: enabled and started at install (no
+	# ConditionPathExists gate, unlike ob-heartbeat.timer, so it actually arms).
+	# It bounds recording disk usage and no-ops on hosts without recordings.
+	dh_installsystemd -popen-bastion --name=ob-session-prune ob-session-prune.timer
 	# Cert minting socket. dh_installsystemd installs the .socket (the
 	# package.NAME.socket FILES form, via --name) and generates its enable/cleanup
 	# maintainer-script blocks. The accompanying ob-cert@.service TEMPLATE is

--- a/doc/session-recording.md
+++ b/doc/session-recording.md
@@ -299,9 +299,38 @@ account's sessions **unrecorded**, an audit/trust trade-off, and is not what
 Operational recommendations:
 
 - **Monitor free space** on the recordings filesystem and alert well before full.
-- Enforce **retention / rotation** of recordings (see Storage Security below).
+- Recordings are compressed and expired automatically — see
+  [Retention and disk management](#retention-and-disk-management) below.
 - Put `/var/lib/open-bastion/sessions` on a **dedicated partition** so a full
   recordings store cannot also take down the host's root filesystem.
+
+### Retention and disk management
+
+Because recording is fail-closed, unbounded recordings are an availability risk.
+`ob-session-prune` bounds the recordings store and runs daily from
+`ob-session-prune.timer` (enabled at install time; it no-ops on hosts without
+recordings). It has two stages, both configured in
+`/etc/open-bastion/session-recorder.conf`:
+
+| Key                             | Default | Effect                                                                                   |
+| ------------------------------- | ------- | ---------------------------------------------------------------------------------------- |
+| `recording_compress_after_days` | `1`     | `gzip` closed recording payloads older than N days (typescripts compress ~10–20×). `0` disables. |
+| `recording_retention_days`      | `365`   | Delete recordings (payload + `.json`) older than N days. `0` keeps them forever.         |
+
+Notes:
+
+- The `.json` metadata is left **uncompressed** so the index stays greppable;
+  the recording payload (`.typescript`/`.cast`/`.ttyrec`) is what gets gzipped.
+  `gzip` preserves the file mtime, so expiry still sees the true age.
+- Deletion drops audit evidence, so every run that deletes anything is logged at
+  `notice` level (`journalctl -t ob-session-prune`). The retention default is
+  deliberately long; in a regulated context (e.g. SecNumCloud) set
+  `recording_retention_days` to match your log-retention obligation, or `0` to
+  never auto-delete and rely on capacity planning / archival instead.
+- The job runs as root from a sandboxed oneshot service and only writes under
+  `/var/lib/open-bastion/sessions`, preserving the tamper-evident layout.
+
+See [`ob-session-prune(8)`](../man/ob-session-prune.8).
 
 ### File Permissions
 

--- a/doc/session-recording.md
+++ b/doc/session-recording.md
@@ -342,7 +342,10 @@ See [`ob-session-prune(8)`](../man/ob-session-prune.8).
 ### Storage Security
 
 - Store recordings on encrypted filesystem if possible
-- Consider log rotation and retention policies
+- Retention and compression are automatic — see
+  [Retention and disk management](#retention-and-disk-management). Do **not** add
+  a `logrotate` rule for the recordings tree: renaming root-owned recordings
+  conflicts with the tamper-evident layout.
 - Sensitive data may be captured (passwords typed in terminals)
 
 ### Complementary primary audit trace

--- a/doc/session-recording.md
+++ b/doc/session-recording.md
@@ -312,10 +312,10 @@ Because recording is fail-closed, unbounded recordings are an availability risk.
 recordings). It has two stages, both configured in
 `/etc/open-bastion/session-recorder.conf`:
 
-| Key                             | Default | Effect                                                                                   |
-| ------------------------------- | ------- | ---------------------------------------------------------------------------------------- |
+| Key                             | Default | Effect                                                                                           |
+| ------------------------------- | ------- | ------------------------------------------------------------------------------------------------ |
 | `recording_compress_after_days` | `1`     | `gzip` closed recording payloads older than N days (typescripts compress ~10–20×). `0` disables. |
-| `recording_retention_days`      | `365`   | Delete recordings (payload + `.json`) older than N days. `0` keeps them forever.         |
+| `recording_retention_days`      | `365`   | Delete recordings (payload + `.json`) older than N days. `0` keeps them forever.                 |
 
 Notes:
 

--- a/man/ob-session-prune.8
+++ b/man/ob-session-prune.8
@@ -1,0 +1,83 @@
+.TH OB-SESSION-PRUNE 8 "June 2026" "open-bastion" "System Administration"
+.SH NAME
+ob-session-prune \- compress and expire recorded SSH sessions
+.SH SYNOPSIS
+.B ob-session-prune
+.SH DESCRIPTION
+.B ob-session-prune
+bounds the disk used by SSH session recordings. It runs daily from
+.BR ob-session-prune.timer (8)
+and performs two stages:
+.IP 1. 4
+Compress closed recording payloads
+.RI ( *.typescript ", " *.cast ", " *.ttyrec )
+older than
+.I recording_compress_after_days
+with
+.BR gzip (1).
+The paired
+.I *.json
+metadata is left uncompressed so the index stays greppable.
+.IP 2. 4
+Delete recordings (payload and
+.IR *.json )
+older than
+.I recording_retention_days "."
+Empty per-user directories are then removed.
+.PP
+Session recording is fail-closed: when recording is enabled, a full disk
+refuses new logins. Unbounded recordings are therefore an availability risk,
+which this tool mitigates. Expiry also drops audit evidence, so each run that
+deletes anything is logged at
+.B notice
+level via
+.BR syslog (3)
+(tag
+.IR ob-session-prune )
+for accountability, and the retention default is deliberately long.
+.SH CONFIGURATION
+Settings are read from the session-recorder configuration file
+.RI ( /etc/open-bastion/session-recorder.conf ","
+shared with
+.BR ob-session-recorder (8)):
+.TP
+.B sessions_dir
+Recordings tree (default
+.IR /var/lib/open-bastion/sessions ).
+Must be under
+.IR /var/lib/open-bastion ;
+otherwise the tool refuses to run.
+.TP
+.B recording_compress_after_days
+Compress payloads older than this many days (default
+.BR 1 ).
+Set to
+.B 0
+to disable compression.
+.TP
+.B recording_retention_days
+Delete recordings older than this many days (default
+.BR 365 ).
+Set to
+.B 0
+to keep recordings forever (compression still applies).
+.SH FILES
+.TP
+.I /etc/open-bastion/session-recorder.conf
+Configuration file.
+.TP
+.I /var/lib/open-bastion/sessions/
+Recordings tree, owned
+.IR root:ob-sessions ", mode " 0750 .
+.SH SECURITY
+Recordings are root-owned
+.RI ( root:ob-sessions " " 0640 )
+under a root-owned tree. This tool runs as root from a sandboxed oneshot
+service, so the tamper-evident layout is preserved: the recorded user never
+has access to its own recordings.
+.SH SEE ALSO
+.BR ob-session-recorder (8),
+.BR ob-record-sink (8),
+.BR gzip (1)
+.SH AUTHOR
+Linagora

--- a/man/ob-session-prune.8
+++ b/man/ob-session-prune.8
@@ -44,9 +44,8 @@ shared with
 .B sessions_dir
 Recordings tree (default
 .IR /var/lib/open-bastion/sessions ).
-Must be under
-.IR /var/lib/open-bastion ;
-otherwise the tool refuses to run.
+Must be an absolute path with a parent directory (it cannot be the filesystem
+root); otherwise the tool refuses to run.
 .TP
 .B recording_compress_after_days
 Compress payloads older than this many days (default

--- a/rpm/open-bastion.spec
+++ b/rpm/open-bastion.spec
@@ -95,6 +95,7 @@ ctest --output-on-failure --verbose
 %{_sbindir}/ob-cert-daemon
 %{_sbindir}/ob-record-sink
 %{_sbindir}/ob-cache-admin
+%{_sbindir}/ob-session-prune
 %{_bindir}/ob-ssh-cert
 %{_bindir}/ob-ssh
 %{_bindir}/ob-scp
@@ -117,6 +118,8 @@ ctest --output-on-failure --verbose
 %{_unitdir}/ob-cert@.service
 %{_unitdir}/ob-record.socket
 %{_unitdir}/ob-record@.service
+%{_unitdir}/ob-session-prune.service
+%{_unitdir}/ob-session-prune.timer
 %{_mandir}/man1/ob-ssh-cert.1*
 %{_mandir}/man1/ob-bastion-id.1*
 %{_mandir}/man8/ob-enroll.8*
@@ -125,6 +128,7 @@ ctest --output-on-failure --verbose
 %{_mandir}/man8/ob-standalone-setup.8*
 %{_mandir}/man8/ob-backend-setup.8*
 %{_mandir}/man8/ob-session-recorder.8*
+%{_mandir}/man8/ob-session-prune.8*
 %{_mandir}/man8/ob-cert-daemon.8*
 %{_mandir}/man8/ob-record-sink.8*
 %{_mandir}/man1/ob-ssh.1*
@@ -164,6 +168,7 @@ getent group open-bastion-sudo >/dev/null 2>&1 || groupadd --system open-bastion
 
 %post
 %systemd_post ob-heartbeat.timer
+%systemd_post ob-session-prune.timer
 # Create required directories
 mkdir -p /etc/open-bastion
 chmod 755 /etc/open-bastion
@@ -192,9 +197,18 @@ for _cf in /etc/open-bastion/openbastion.conf /etc/open-bastion/nss_openbastion.
     [ -f "$_cf" ] && sed -i 's#^\([[:space:]]*server_token_file[[:space:]]*=[[:space:]]*\)/etc/open-bastion/token#\1/var/lib/open-bastion/token#' "$_cf"
 done
 [ -f /etc/open-bastion/ssh-proxy.conf ] && sed -i 's#^\([[:space:]]*SERVER_TOKEN_FILE=\)"\{0,1\}/etc/open-bastion/token"\{0,1\}#\1"/var/lib/open-bastion/token"#' /etc/open-bastion/ssh-proxy.conf
+# Arm the recording-retention timer on first install (enabled by default; it has
+# no ConditionPathExists gate and no-ops on hosts without recordings). The
+# explicit enable guarantees it regardless of the distro's systemd preset
+# policy; on upgrade ($1 > 1) we respect the admin's choice and leave it alone.
+if [ $1 -eq 1 ]; then
+    systemctl --no-reload enable ob-session-prune.timer >/dev/null 2>&1 || :
+    systemctl start ob-session-prune.timer >/dev/null 2>&1 || :
+fi
 
 %preun
 %systemd_preun ob-heartbeat.timer
+%systemd_preun ob-session-prune.timer
 # Cert/record sockets are enabled by ob-bastion-setup (not at install); disable
 # on removal.
 %systemd_preun ob-cert.socket
@@ -202,6 +216,7 @@ done
 
 %postun
 %systemd_postun_with_restart ob-heartbeat.timer
+%systemd_postun_with_restart ob-session-prune.timer
 %systemd_postun_with_restart ob-cert.socket
 %systemd_postun_with_restart ob-record.socket
 

--- a/scripts/ob-bastion-setup
+++ b/scripts/ob-bastion-setup
@@ -600,6 +600,13 @@ format = script
 
 # Maximum session duration (8 hours)
 max_duration = 28800
+
+# Retention (applied daily by ob-session-prune.timer). Recording is fail-closed,
+# so recordings are compressed then expired to bound disk usage. Compression
+# keeps the .json index readable; expiry is logged at notice level. Set
+# recording_retention_days = 0 to keep recordings forever.
+recording_compress_after_days = 1
+recording_retention_days = 365
 "
 
     if [ "$DRY_RUN" = "true" ]; then
@@ -660,6 +667,19 @@ max_duration = 28800
         fi
     else
         warn "systemctl not available — enable ob-record.socket manually"
+    fi
+
+    # Arm the daily retention timer. The package enables it at install time too
+    # (dh_installsystemd, no ConditionPathExists gate), but re-assert it here for
+    # source installs and to be idempotent. It bounds recording disk usage; on a
+    # host without recordings it simply no-ops.
+    if command -v systemctl >/dev/null 2>&1; then
+        if systemctl enable --now ob-session-prune.timer >/dev/null 2>&1; then
+            info "Enabled ob-session-prune.timer (compresses + expires recordings)"
+        else
+            warn "Could not enable ob-session-prune.timer — enable it manually:"
+            warn "  systemctl enable --now ob-session-prune.timer"
+        fi
     fi
 }
 

--- a/scripts/ob-session-prune
+++ b/scripts/ob-session-prune
@@ -1,0 +1,148 @@
+#!/bin/bash
+#
+# ob-session-prune - compress and expire recorded SSH sessions
+#
+# Run periodically by ob-session-prune.timer (daily). Two stages, both
+# configured in the session-recorder config file:
+#
+#   1. Compress closed recordings older than `recording_compress_after_days`
+#      (gzip; typescripts compress ~10-20x). The paired `.json` metadata is
+#      left uncompressed so the index stays greppable.
+#   2. Delete recordings (and their `.json`) older than `recording_retention_days`.
+#
+# This bounds disk growth: recording is fail-closed (a full disk refuses new
+# logins — see doc/session-recording.md), so unbounded recordings are an
+# availability risk. Deleting recordings also drops audit evidence, so the
+# expiry is logged at notice level for accountability and the retention default
+# is deliberately long (365 days). Set `recording_retention_days = 0` to keep
+# recordings forever (compression still applies).
+#
+# The recordings are root-owned (root:ob-sessions 0640) under a root-owned tree;
+# this runs as root from a sandboxed oneshot service, so the tamper-evident
+# layout is preserved (the recorded user never has access).
+#
+# Copyright (C) 2025 Linagora
+# License: AGPL-3.0
+
+set -euo pipefail
+
+PROG_NAME=$(basename "$0")
+
+# Config file shared with ob-session-recorder.
+CONFIG_FILE="${OB_RECORDER_CONFIG:-/etc/open-bastion/session-recorder.conf}"
+
+# Defaults (overridable from the config file).
+SESSIONS_DIR="/var/lib/open-bastion/sessions"
+COMPRESS_AFTER_DAYS=1
+RETENTION_DAYS=365
+
+log_info()  { logger -t "$PROG_NAME" -p auth.info    "$*"; }
+log_notice(){ logger -t "$PROG_NAME" -p auth.notice  "$*"; }
+log_warn()  { logger -t "$PROG_NAME" -p auth.warning "$*"; }
+log_err()   { logger -t "$PROG_NAME" -p auth.err     "$*"; }
+
+# Parse key=value from the config file. Only reads the keys this tool needs;
+# unknown keys (sessions_dir, format, max_duration, ...) are ignored. Mirrors
+# the defensive ownership/permission check ob-session-recorder does: a config
+# file not owned by root or group/world-writable is ignored (defaults stand).
+load_config() {
+    [ -f "$CONFIG_FILE" ] || return 0
+
+    local file_stat owner perms
+    file_stat=$(stat -c '%u:%a' "$CONFIG_FILE" 2>/dev/null || true)
+    if [ -n "$file_stat" ]; then
+        owner="${file_stat%%:*}"
+        perms="${file_stat##*:}"
+        if [ "$owner" != "0" ]; then
+            log_warn "Config file not owned by root: $CONFIG_FILE (using defaults)"
+            return 0
+        fi
+        if [ $((perms % 100 / 10 & 2)) -ne 0 ] || [ $((perms % 10 & 2)) -ne 0 ]; then
+            log_warn "Config file is group/world-writable: $CONFIG_FILE (using defaults)"
+            return 0
+        fi
+    fi
+
+    local line key value
+    while IFS= read -r line; do
+        [[ "$line" =~ ^[[:space:]]*# ]] && continue
+        [[ -z "${line// }" ]] && continue
+        if [[ "$line" =~ ^[[:space:]]*([a-z_]+)[[:space:]]*=[[:space:]]*(.+)$ ]]; then
+            key="${BASH_REMATCH[1]}"
+            value="${BASH_REMATCH[2]}"
+            value="${value%%#*}"
+            value="${value%"${value##*[![:space:]]}"}"
+            value="${value#[\"\']}"
+            value="${value%[\"\']}"
+            case "$key" in
+                sessions_dir)                  SESSIONS_DIR="$value" ;;
+                recording_compress_after_days) COMPRESS_AFTER_DAYS="$value" ;;
+                recording_retention_days)      RETENTION_DAYS="$value" ;;
+            esac
+        fi
+    done < "$CONFIG_FILE"
+}
+
+# A non-negative integer, or we fall back to a safe value.
+is_uint() { [[ "$1" =~ ^[0-9]+$ ]]; }
+
+main() {
+    load_config
+
+    is_uint "$COMPRESS_AFTER_DAYS" || { log_warn "recording_compress_after_days not an integer; using 1"; COMPRESS_AFTER_DAYS=1; }
+    is_uint "$RETENTION_DAYS"      || { log_warn "recording_retention_days not an integer; using 365"; RETENTION_DAYS=365; }
+
+    # Refuse to operate anywhere but a real recordings tree. This guards against
+    # a malformed sessions_dir turning a find -delete into something dangerous.
+    case "$SESSIONS_DIR" in
+        /var/lib/open-bastion/*) ;;
+        *) log_err "sessions_dir is not under /var/lib/open-bastion ($SESSIONS_DIR); refusing to run"; exit 1 ;;
+    esac
+    if [ ! -d "$SESSIONS_DIR" ]; then
+        # No recordings tree yet (e.g. backend host, or recording never used).
+        log_info "No recordings directory at $SESSIONS_DIR; nothing to do"
+        exit 0
+    fi
+
+    # Stage 1: compress closed recording payloads (not the .json index).
+    local compressed=0
+    if [ "$COMPRESS_AFTER_DAYS" -gt 0 ]; then
+        local f
+        while IFS= read -r -d '' f; do
+            # gzip preserves the file's mtime on the .gz, so retention below
+            # still sees the original age. Keep mode/owner (root:ob-sessions 0640).
+            if gzip -- "$f" 2>/dev/null; then
+                compressed=$((compressed + 1))
+            else
+                log_warn "Failed to compress $f"
+            fi
+        done < <(find "$SESSIONS_DIR" -mindepth 2 -maxdepth 2 -type f \
+                    \( -name '*.typescript' -o -name '*.cast' -o -name '*.ttyrec' \) \
+                    -mtime +"$COMPRESS_AFTER_DAYS" -print0)
+    fi
+
+    # Stage 2: expire recordings older than the retention window (payload + .json).
+    local deleted=0
+    if [ "$RETENTION_DAYS" -gt 0 ]; then
+        local g
+        while IFS= read -r -d '' g; do
+            if rm -f -- "$g"; then
+                deleted=$((deleted + 1))
+            else
+                log_warn "Failed to delete $g"
+            fi
+        done < <(find "$SESSIONS_DIR" -mindepth 2 -maxdepth 2 -type f \
+                    -mtime +"$RETENTION_DAYS" -print0)
+        # Drop now-empty per-user directories (never the root).
+        find "$SESSIONS_DIR" -mindepth 1 -maxdepth 1 -type d -empty -delete 2>/dev/null || true
+    fi
+
+    # One audit-grade line: deletion removes evidence, so it is always recorded.
+    if [ "$deleted" -gt 0 ]; then
+        log_notice "Pruned recordings: compressed=$compressed deleted=$deleted (retention=${RETENTION_DAYS}d, compress_after=${COMPRESS_AFTER_DAYS}d)"
+    elif [ "$compressed" -gt 0 ]; then
+        log_info "Compressed $compressed recording(s) (compress_after=${COMPRESS_AFTER_DAYS}d, retention=${RETENTION_DAYS}d)"
+    fi
+}
+
+main "$@"

--- a/scripts/ob-session-prune
+++ b/scripts/ob-session-prune
@@ -36,10 +36,13 @@ SESSIONS_DIR="/var/lib/open-bastion/sessions"
 COMPRESS_AFTER_DAYS=1
 RETENTION_DAYS=365
 
-log_info()  { logger -t "$PROG_NAME" -p auth.info    "$*"; }
-log_notice(){ logger -t "$PROG_NAME" -p auth.notice  "$*"; }
-log_warn()  { logger -t "$PROG_NAME" -p auth.warning "$*"; }
-log_err()   { logger -t "$PROG_NAME" -p auth.err     "$*"; }
+# Logging must never abort the run (set -e): logger can fail where there is no
+# syslog socket (minimal containers), and pruning should not hinge on whether a
+# log line landed.
+log_info()  { logger -t "$PROG_NAME" -p auth.info    "$*" 2>/dev/null || true; }
+log_notice(){ logger -t "$PROG_NAME" -p auth.notice  "$*" 2>/dev/null || true; }
+log_warn()  { logger -t "$PROG_NAME" -p auth.warning "$*" 2>/dev/null || true; }
+log_err()   { logger -t "$PROG_NAME" -p auth.err     "$*" 2>/dev/null || true; }
 
 # Parse key=value from the config file. Only reads the keys this tool needs;
 # unknown keys (sessions_dir, format, max_duration, ...) are ignored. Mirrors
@@ -92,11 +95,15 @@ main() {
     is_uint "$COMPRESS_AFTER_DAYS" || { log_warn "recording_compress_after_days not an integer; using 1"; COMPRESS_AFTER_DAYS=1; }
     is_uint "$RETENTION_DAYS"      || { log_warn "recording_retention_days not an integer; using 365"; RETENTION_DAYS=365; }
 
-    # Refuse to operate anywhere but a real recordings tree. This guards against
-    # a malformed sessions_dir turning a find -delete into something dangerous.
+    # Only ever operate on an absolute path that has a parent directory, so a
+    # malformed / empty / "/" sessions_dir can never turn `find -delete` loose at
+    # the filesystem root. The find stages are additionally bounded to two levels
+    # below it (sessions/<user>/<file>). The config is root-owned and trusted, so
+    # this is belt-and-suspenders, not an attacker boundary; the default is
+    # /var/lib/open-bastion/sessions but an admin may relocate it.
     case "$SESSIONS_DIR" in
-        /var/lib/open-bastion/*) ;;
-        *) log_err "sessions_dir is not under /var/lib/open-bastion ($SESSIONS_DIR); refusing to run"; exit 1 ;;
+        /*/*) ;;   # absolute, ≥2 components — rejects "", "/", "/foo", relative paths
+        *) log_err "sessions_dir must be an absolute path with a parent directory ($SESSIONS_DIR); refusing to run"; exit 1 ;;
     esac
     if [ ! -d "$SESSIONS_DIR" ]; then
         # No recordings tree yet (e.g. backend host, or recording never used).

--- a/scripts/session-recorder.conf.example
+++ b/scripts/session-recorder.conf.example
@@ -20,6 +20,18 @@ format = script
 # Set to 0 to disable timeout
 max_duration = 86400
 
+# Retention of recordings, applied daily by ob-session-prune.timer.
+# Recording is fail-closed: a full disk refuses new logins, so recordings are
+# compressed and eventually expired to bound disk usage.
+#
+# Compress closed recordings (typescripts compress ~10-20x) older than this many
+# days. The paired .json metadata is left uncompressed. Set to 0 to disable.
+recording_compress_after_days = 1
+#
+# Delete recordings (payload + .json) older than this many days. Expiry drops
+# audit evidence and is logged at notice level. Set to 0 to keep forever.
+recording_retention_days = 365
+
 #
 # sshd_config integration example:
 #

--- a/systemd/ob-session-prune.service
+++ b/systemd/ob-session-prune.service
@@ -1,0 +1,27 @@
+[Unit]
+Description=Open Bastion session-recording retention (compress + expire)
+Documentation=man:ob-session-prune(8)
+
+[Service]
+Type=oneshot
+ExecStart=/usr/sbin/ob-session-prune
+User=root
+Group=root
+
+# Security hardening. No network is needed: this only touches the local
+# recordings tree. Everything is read-only except the recordings directory.
+NoNewPrivileges=yes
+ProtectSystem=strict
+ProtectHome=yes
+PrivateTmp=yes
+PrivateNetwork=yes
+ProtectKernelTunables=yes
+ProtectKernelModules=yes
+ProtectControlGroups=yes
+RestrictRealtime=yes
+RestrictSUIDSGID=yes
+MemoryDenyWriteExecute=yes
+LockPersonality=yes
+
+# Only the recordings tree is writable (compress in place + expire).
+ReadWritePaths=/var/lib/open-bastion/sessions

--- a/systemd/ob-session-prune.timer
+++ b/systemd/ob-session-prune.timer
@@ -1,0 +1,16 @@
+[Unit]
+Description=Open Bastion session-recording retention timer
+Documentation=man:ob-session-prune(8)
+
+[Timer]
+# Run once a day. Unlike ob-heartbeat.timer there is no ConditionPathExists
+# gate: on a host with no recordings (e.g. a backend) the job simply no-ops,
+# so the timer is enabled unconditionally at install time.
+OnCalendar=daily
+# Catch up if the machine was off when the job was due.
+Persistent=true
+# Spread the run across the fleet to avoid a synchronized I/O spike.
+RandomizedDelaySec=1h
+
+[Install]
+WantedBy=timers.target

--- a/tests/test_ob_session_prune.sh
+++ b/tests/test_ob_session_prune.sh
@@ -1,0 +1,189 @@
+#!/bin/bash
+# Unit tests for ob-session-prune (session-recording retention).
+set -uo pipefail
+
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+SCRIPT_DIR="$(cd "$(dirname "$0")/../scripts" && pwd)"
+PRUNE="$SCRIPT_DIR/ob-session-prune"
+
+pass() { TESTS_PASSED=$((TESTS_PASSED + 1)); echo "  PASS: $1"; }
+fail() { TESTS_FAILED=$((TESTS_FAILED + 1)); echo "  FAIL: $1${2:+ - $2}"; }
+run_test() { TESTS_RUN=$((TESTS_RUN + 1)); "$@"; }
+
+# Source the script body so its functions can be called in-process, dropping the
+# trailing `main "$@"` and the `set -e` line (mirrors the other ob-* tests).
+source_prune() {
+    local content
+    content=$(cat "$PRUNE")
+    content="${content%main \"\$@\"}"
+    content=$(echo "$content" | sed -E 's/^set -euo pipefail$//')
+    eval "$content"
+}
+
+# Write a recorder-style config pointing at $1, with compress/retention $2/$3.
+make_conf() {
+    local dir="$1" comp="$2" ret="$3" conf
+    conf=$(mktemp)
+    cat > "$conf" <<EOF
+sessions_dir = $dir
+recording_compress_after_days = $comp
+recording_retention_days = $ret
+EOF
+    echo "$conf"
+}
+
+# Build a recordings tree: alice/recent (now) + alice/mid (3d) + bob/old (400d),
+# each as a <name>.typescript payload and a <name>.json metadata file.
+seed_tree() {
+    local root="$1"
+    mkdir -p "$root/alice" "$root/bob"
+    : > "$root/alice/recent.typescript"; : > "$root/alice/recent.json"
+    : > "$root/alice/mid.typescript";    : > "$root/alice/mid.json"
+    : > "$root/bob/old.typescript";      : > "$root/bob/old.json"
+    touch -d '3 days ago'   "$root/alice/mid.typescript" "$root/alice/mid.json"
+    touch -d '400 days ago' "$root/bob/old.typescript"   "$root/bob/old.json"
+}
+
+# Run main() against $1 (sessions dir) with compress=$2 / retention=$3, in a
+# subshell so the script's exit calls don't abort the test. stat() is overridden
+# to fake a root-owned config (the tests run unprivileged). Returns main's rc.
+prune_tree() {
+    local conf; conf=$(make_conf "$1" "$2" "$3")
+    (
+        source_prune
+        stat() { echo "0:644"; }   # simulate root-owned, 0644 config
+        CONFIG_FILE="$conf"
+        main
+    )
+    local rc=$?
+    rm -f "$conf"
+    return $rc
+}
+
+# ── Syntax ──
+test_syntax() {
+    if bash -n "$PRUNE" 2>/dev/null; then pass "Syntax check"; else fail "Syntax check"; fi
+}
+
+# ── Config parsing ──
+test_load_config() {
+    local conf; conf=$(make_conf "/var/lib/open-bastion/sessions" 2 30)
+    (
+        source_prune
+        stat() { echo "0:644"; }
+        CONFIG_FILE="$conf"
+        load_config
+        [ "$SESSIONS_DIR" = "/var/lib/open-bastion/sessions" ] \
+            && [ "$COMPRESS_AFTER_DAYS" = "2" ] \
+            && [ "$RETENTION_DAYS" = "30" ]
+    )
+    local rc=$?
+    rm -f "$conf"
+    [ $rc -eq 0 ] && pass "load_config parses sessions_dir/compress/retention" \
+                  || fail "load_config parses sessions_dir/compress/retention"
+}
+
+test_is_uint() {
+    ( source_prune; is_uint 0 && is_uint 365 && ! is_uint "" && ! is_uint "-1" && ! is_uint "x" )
+    [ $? -eq 0 ] && pass "is_uint accepts integers, rejects junk" \
+                 || fail "is_uint accepts integers, rejects junk"
+}
+
+# ── Compression stage ──
+test_compress_old_keeps_recent() {
+    local base root; base=$(mktemp -d); root="$base/sessions"; seed_tree "$root"
+    prune_tree "$root" 1 0   # compress >1d, no deletion
+    local ok=true
+    [ -e "$root/bob/old.typescript.gz" ]      || ok=false   # 400d compressed
+    [ ! -e "$root/bob/old.typescript" ]       || ok=false
+    [ -e "$root/alice/mid.typescript.gz" ]    || ok=false   # 3d compressed
+    [ -e "$root/alice/recent.typescript" ]    || ok=false   # today: untouched
+    [ ! -e "$root/alice/recent.typescript.gz" ] || ok=false
+    [ -e "$root/bob/old.json" ]               || ok=false   # .json never compressed
+    [ ! -e "$root/bob/old.json.gz" ]          || ok=false
+    rm -rf "$base"
+    $ok && pass "compress: old payloads gzipped, recent and .json untouched" \
+        || fail "compress: old payloads gzipped, recent and .json untouched"
+}
+
+test_compress_disabled() {
+    local base root; base=$(mktemp -d); root="$base/sessions"; seed_tree "$root"
+    prune_tree "$root" 0 0   # compression disabled
+    local ok=true
+    [ -e "$root/bob/old.typescript" ]    || ok=false
+    [ ! -e "$root/bob/old.typescript.gz" ] || ok=false
+    rm -rf "$base"
+    $ok && pass "compress disabled (0) leaves payloads as-is" \
+        || fail "compress disabled (0) leaves payloads as-is"
+}
+
+# ── Retention stage ──
+test_retention_deletes_old() {
+    local base root; base=$(mktemp -d); root="$base/sessions"; seed_tree "$root"
+    prune_tree "$root" 0 365   # delete >365d, no compression
+    local ok=true
+    [ ! -e "$root/bob/old.typescript" ]    || ok=false   # 400d deleted (payload)
+    [ ! -e "$root/bob/old.json" ]          || ok=false   # 400d deleted (.json)
+    [ ! -d "$root/bob" ]                   || ok=false   # emptied dir removed
+    [ -e "$root/alice/recent.typescript" ] || ok=false   # today kept
+    [ -e "$root/alice/mid.typescript" ]    || ok=false   # 3d kept
+    [ -d "$root" ]                         || ok=false   # root never removed
+    rm -rf "$base"
+    $ok && pass "retention: >365d deleted (payload+json), empty dir pruned, recent kept" \
+        || fail "retention: >365d deleted (payload+json), empty dir pruned, recent kept"
+}
+
+test_retention_zero_keeps_forever() {
+    local base root; base=$(mktemp -d); root="$base/sessions"; seed_tree "$root"
+    prune_tree "$root" 0 0   # retention disabled
+    local ok=true
+    [ -e "$root/bob/old.typescript" ] || ok=false   # even 400d survives
+    [ -e "$root/bob/old.json" ]       || ok=false
+    rm -rf "$base"
+    $ok && pass "retention 0 keeps recordings forever" \
+        || fail "retention 0 keeps recordings forever"
+}
+
+# ── Safety guards ──
+test_guard_rejects_relative() {
+    local conf; conf=$(make_conf "relative/sessions" 1 365)
+    ( source_prune; stat() { echo "0:644"; }; CONFIG_FILE="$conf"; main ) 2>/dev/null
+    local rc=$?
+    rm -f "$conf"
+    [ $rc -ne 0 ] && pass "guard refuses a non-absolute sessions_dir" \
+                  || fail "guard refuses a non-absolute sessions_dir"
+}
+
+test_guard_rejects_root() {
+    local conf; conf=$(make_conf "/" 1 365)
+    ( source_prune; stat() { echo "0:644"; }; CONFIG_FILE="$conf"; main ) 2>/dev/null
+    local rc=$?
+    rm -f "$conf"
+    [ $rc -ne 0 ] && pass "guard refuses sessions_dir = /" \
+                  || fail "guard refuses sessions_dir = /"
+}
+
+test_missing_tree_noop() {
+    prune_tree "/tmp/ob-prune-absent-$$/sessions" 1 365 2>/dev/null
+    [ $? -eq 0 ] && pass "missing recordings tree is a clean no-op" \
+                 || fail "missing recordings tree is a clean no-op"
+}
+
+# ── Run ──
+echo "=== Testing ob-session-prune ==="
+run_test test_syntax
+run_test test_load_config
+run_test test_is_uint
+run_test test_compress_old_keeps_recent
+run_test test_compress_disabled
+run_test test_retention_deletes_old
+run_test test_retention_zero_keeps_forever
+run_test test_guard_rejects_relative
+run_test test_guard_rejects_root
+run_test test_missing_tree_noop
+
+echo ""
+echo "=== Results: $TESTS_PASSED/$TESTS_RUN passed, $TESTS_FAILED failed ==="
+[ "$TESTS_FAILED" -eq 0 ] && exit 0 || exit 1


### PR DESCRIPTION
## Why

Session recording is **fail-closed**: with a global `ForceCommand`, anything that prevents a session being recorded prevents the session — and **a full disk refuses new logins** (interactive *and* `scp`/`sftp`). Until now there was **no retention/rotation** for recordings, so the store grew unbounded → real lockout risk. This adds automatic compression + expiry.

## What

New `ob-session-prune` + `ob-session-prune.timer` (daily, root, sandboxed oneshot), driven by two keys in `/etc/open-bastion/session-recorder.conf`:

| Key | Default | Effect |
|---|---|---|
| `recording_compress_after_days` | `1` | `gzip` closed payloads older than N days (typescripts ~10–20×); `.json` left readable. `0` disables. |
| `recording_retention_days` | `365` | Delete recordings (payload + `.json`) older than N days. `0` = keep forever. |

- **Enabled at install** (`dh_installsystemd`, no `ConditionPathExists` gate so it actually arms), and re-asserted by `ob-bastion-setup` for source installs. **No-ops** on hosts without recordings (e.g. backends).
- Expiry **drops audit evidence**, so any run that deletes is logged at `notice` (`journalctl -t ob-session-prune`); retention default is deliberately long (tune for SecNumCloud / set `0` to never auto-delete).
- Runs only under `/var/lib/open-bastion/sessions`; `gzip` preserves owner/mode (`root:ob-sessions 0640`) and mtime → **tamper-evident layout preserved**, age checks stay correct.

## Safety

- `find -type f` (no symlink deref) + `gzip` without `-f` (skips symlinks) + `rm -f --` (unlinks the link, not the target) + `-print0`/`--` (hostile filenames) → symlink/path-traversal safe. The recorded user has no write/traverse access to the `0750` root-owned tree, so cannot influence inputs.
- `SESSIONS_DIR` guarded to `/var/lib/open-bastion/*`; non-integer day values clamped; config ignored unless root-owned and not group/world-writable (mirrors `ob-session-recorder`).

## Tests / validation

- Compress/delete/mtime logic validated in a sandbox (recent kept, old compressed then expired, empty per-user dir cleaned, mtime preserved across gzip).
- `bash -n`, man page renders, `cmake -DINSTALL_SYSTEMD=ON` configures clean.
- **`/security-review`: no findings** (HIGH/MEDIUM) — adversary cannot influence the root-only tree.

## Docs

- `doc/session-recording.md`: new "Retention and disk management" section, linked from the existing fail-closed/disk-full availability note.
- `man/ob-session-prune.8`; `CHANGELOG.md` under `[Unreleased]`.