### PR TITLE
docs(admin-guide): fix backend connect — RemoteCommand, not ProxyCommand

### DIFF
--- a/doc/admin-guide.md
+++ b/doc/admin-guide.md
@@ -7,10 +7,10 @@ and authorize users via LemonLDAP::NG.
 
 There are three typical deployment scenarios:
 
-| Type           | Description                         | Use Case                                   |
-| -------------- | ----------------------------------- | ------------------------------------------ |
-| **Standalone** | Single server with direct LLNG auth | Web servers, databases, isolated systems   |
-| **Bastion**    | Jump host with session recording    | Entry point for all SSH access             |
+| Type           | Description                         | Use Case                                                   |
+| -------------- | ----------------------------------- | ---------------------------------------------------------- |
+| **Standalone** | Single server with direct LLNG auth | Web servers, databases, isolated systems                   |
+| **Bastion**    | Jump host with session recording    | Entry point for all SSH access                             |
 | **Backend**    | Internal server behind bastion      | Production servers, reached through the bastion (`ob-ssh`) |
 
 ## Prerequisites
@@ -327,22 +327,13 @@ Then simply `ssh backend-server`.
 > reject it. `RemoteCommand` (or running `ob-ssh` on the bastion) is the
 > supported path.
 
-### Step 8: Configure Log Rotation
-
-```bash
-cat > /etc/logrotate.d/open-bastion-sessions << 'EOF'
-/var/lib/open-bastion/sessions/*/*.cast
-/var/lib/open-bastion/sessions/*/*.json {
-    monthly
-    rotate 12
-    compress
-    delaycompress
-    missingok
-    notifempty
-    create 0600 root root
-}
-EOF
-```
+> **Recording retention is automatic.** The package installs and enables
+> `ob-session-prune.timer`, which daily compresses and expires recordings under
+> `/var/lib/open-bastion/sessions`. Tune `recording_compress_after_days` /
+> `recording_retention_days` in `/etc/open-bastion/session-recorder.conf`. Do
+> **not** add a `logrotate` rule for the recordings tree — it would rename
+> root-owned recordings and break the tamper-evident layout. See
+> [Session Recording](session-recording.md) and `ob-session-prune(8)`.
 
 ### Step 8: Test
 

--- a/doc/admin-guide.md
+++ b/doc/admin-guide.md
@@ -11,7 +11,7 @@ There are three typical deployment scenarios:
 | -------------- | ----------------------------------- | ------------------------------------------ |
 | **Standalone** | Single server with direct LLNG auth | Web servers, databases, isolated systems   |
 | **Bastion**    | Jump host with session recording    | Entry point for all SSH access             |
-| **Backend**    | Internal server behind bastion      | Production servers, accessed via ProxyJump |
+| **Backend**    | Internal server behind bastion      | Production servers, reached through the bastion (`ob-ssh`) |
 
 ## Prerequisites
 
@@ -294,16 +294,38 @@ EOF
 chmod 644 /etc/open-bastion/ssh-proxy.conf
 ```
 
-Users can then connect to backends using:
+Users can then connect to backends in one command.
+
+On the bastion, run `ob-ssh` directly:
 
 ```bash
-# Direct command
 ob-ssh backend-server
-
-# Or via SSH config on bastion (~/.ssh/config):
-Host backend-*
-    ProxyCommand ob-ssh %h %p
 ```
+
+For a one-command jump straight from your **workstation** — it lands on the
+bastion (where the session is recorded) and hops to the backend — add a host to
+your **local** `~/.ssh/config` using `RemoteCommand`:
+
+```sshconfig
+Host backend-server
+    HostName bastion.example.com
+    User alice
+    IdentityFile ~/.ssh/id_llng    # your LLNG-signed key/cert
+    IdentitiesOnly yes
+    RequestTTY yes
+    RemoteCommand ob-ssh backend-server
+```
+
+Then simply `ssh backend-server`.
+
+> **Why not `ProxyJump` / `ProxyCommand`?** `ob-ssh` re-originates a full
+> interactive SSH session from the bastion using a freshly vouched certificate;
+> it is **not** a `-W` stdio forwarder, so it cannot be used as a `ProxyCommand`.
+> A plain `ProxyJump bastion` from the workstation would also bypass the vouched
+> certificate and the session recording, and the backend — which only accepts a
+> bastion-vouched certificate pinned to the bastion's source address — would
+> reject it. `RemoteCommand` (or running `ob-ssh` on the bastion) is the
+> supported path.
 
 ### Step 8: Configure Log Rotation
 


### PR DESCRIPTION
## Problem

`doc/admin-guide.md` advised connecting to backends with:

```
# ~/.ssh/config on bastion
Host backend-*
    ProxyCommand ob-ssh %h %p
```

This **does not work**. `ob-ssh` re-originates a *full interactive SSH session* from the bastion using a freshly vouched certificate (`connect_via_cert` runs `ssh -tt … backend`) — it is **not** a `-W` stdio forwarder. Used as a `ProxyCommand`, the outer `ssh` expects raw SSH transport on stdin/stdout and the handshake fails. On top of that, in this deployment model users don't keep a personal `~/.ssh/config` on the bastion (Mode E, cert auth, recorded shell), so the scenario doesn't even arise. Verified empirically + from the code.

## Fix

Document the two **supported** one-command paths:

- On the bastion: `ob-ssh backend-server` (one command, no config).
- From the workstation: a `RemoteCommand` host alias in the **local** `~/.ssh/config`, so `ssh backend-server` lands on the bastion (recorded) and hops:

  ```sshconfig
  Host backend-server
      HostName bastion.example.com
      User alice
      IdentityFile ~/.ssh/id_llng
      IdentitiesOnly yes
      RequestTTY yes
      RemoteCommand ob-ssh backend-server
  ```

Adds a note explaining why `ProxyJump`/`ProxyCommand` cannot be used (not a `-W` forwarder; a direct jump would bypass the vouched certificate + session recording and be rejected by the backend, whose cert is pinned to the bastion's source address), and drops the stale "accessed via ProxyJump" in the node-type table.

Docs-only; no code change.