### PR TITLE
feat: add ob-sftp bastion file-transfer connector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`ob-sftp` bastion file-transfer connector.** The `sftp` counterpart of
+  `ob-ssh` / `ob-scp`: run on a bastion, it mints a short-lived,
+  LLNG-signed certificate (via the shared `ob-cert-lib.sh`) and opens an
+  interactive or batch SFTP session to a backend — no user SSH key on the
+  bastion and no agent forwarding. Connects to a single endpoint
+  (`[user@]backend[:path]`); options after the connector's own flags pass
+  straight through to `sftp(1)`. See `ob-sftp(1)`.
+
 - **Session-recording retention (`ob-session-prune`).** A new daily timer
   (`ob-session-prune.timer`, enabled at install) bounds the recordings store,
   which matters because recording is fail-closed — a full disk refuses new

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -198,17 +198,20 @@ install(FILES ${CMAKE_SOURCE_DIR}/scripts/session-recorder.conf.example
     DESTINATION ${CMAKE_INSTALL_SYSCONFDIR}/open-bastion
 )
 
-# Shared cert-vouching library, sourced by ob-ssh / ob-scp. Installed to a
-# fixed (non-multiarch) /usr/lib/open-bastion path that the scripts look up.
+# Shared cert-vouching library, sourced by ob-ssh / ob-scp / ob-sftp. Installed
+# to a fixed (non-multiarch) /usr/lib/open-bastion path that the scripts look up.
 install(FILES ${CMAKE_SOURCE_DIR}/scripts/ob-cert-lib.sh
     DESTINATION lib/open-bastion
 )
 
-# Bastion-to-backend SSH / SCP connectors (cert vouching).
+# Bastion-to-backend SSH / SCP / SFTP connectors (cert vouching).
 install(PROGRAMS ${CMAKE_SOURCE_DIR}/scripts/ob-ssh
     DESTINATION ${CMAKE_INSTALL_BINDIR}
 )
 install(PROGRAMS ${CMAKE_SOURCE_DIR}/scripts/ob-scp
+    DESTINATION ${CMAKE_INSTALL_BINDIR}
+)
+install(PROGRAMS ${CMAKE_SOURCE_DIR}/scripts/ob-sftp
     DESTINATION ${CMAKE_INSTALL_BINDIR}
 )
 
@@ -226,7 +229,7 @@ install(FILES ${CMAKE_SOURCE_DIR}/scripts/ssh-proxy.conf.example
 # Replaces the old `sudo ob-bastion-cert-helper` bridge. ob-cert-daemon (root,
 # socket-activated) holds the server token and derives the certificate's user
 # from the connection's SO_PEERCRED; ob-cert-request is the unprivileged client
-# that ob-ssh / ob-scp invoke — no sudo, no setuid.
+# that ob-ssh / ob-scp / ob-sftp invoke — no sudo, no setuid.
 add_executable(ob-cert-daemon src/ob-cert-daemon.c src/ob_cert_proto.c)
 target_include_directories(ob-cert-daemon PRIVATE
     ${CMAKE_SOURCE_DIR}/include
@@ -400,6 +403,7 @@ install(FILES
     ${CMAKE_SOURCE_DIR}/man/ob-ssh-cert.1
     ${CMAKE_SOURCE_DIR}/man/ob-ssh.1
     ${CMAKE_SOURCE_DIR}/man/ob-scp.1
+    ${CMAKE_SOURCE_DIR}/man/ob-sftp.1
     ${CMAKE_SOURCE_DIR}/man/ob-bastion-id.1
     ${CMAKE_SOURCE_DIR}/man/ob-cert-request.1
     ${CMAKE_SOURCE_DIR}/man/ob-record-connect.1

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ The module supports two authentication methods:
   - Certificate-based proof of connection origin (LLNG-signed ephemeral SSH cert, ~120 s)
   - Backends only accept SSH from authorized bastions (`allowed_bastions` + `source-address` critical option)
   - No agent forwarding or user key on the bastion required
-  - `ob-ssh` / `ob-scp` scripts for seamless bastion connections and file transfers
+  - `ob-ssh` / `ob-scp` / `ob-sftp` scripts for seamless bastion connections and file transfers
 - **[Session recording](doc/session-recording.md)** (optional):
   - Record all terminal I/O for audit compliance
   - Multiple formats: script, asciinema, ttyrec

--- a/debian/open-bastion.install
+++ b/debian/open-bastion.install
@@ -25,13 +25,14 @@ usr/sbin/ob-record-sink
 usr/sbin/ob-cache-admin
 usr/sbin/ob-session-prune
 
-# Shared cert-vouching library (sourced by ob-ssh / ob-scp)
+# Shared cert-vouching library (sourced by ob-ssh / ob-scp / ob-sftp)
 usr/lib/open-bastion/ob-cert-lib.sh
 
 # User scripts
 usr/bin/ob-ssh-cert
 usr/bin/ob-ssh
 usr/bin/ob-scp
+usr/bin/ob-sftp
 usr/bin/ob-bastion-id
 usr/bin/ob-cert-request
 usr/bin/ob-record-connect
@@ -40,6 +41,7 @@ usr/bin/ob-record-connect
 usr/share/man/man1/ob-ssh-cert.1
 usr/share/man/man1/ob-ssh.1
 usr/share/man/man1/ob-scp.1
+usr/share/man/man1/ob-sftp.1
 usr/share/man/man1/ob-bastion-id.1
 usr/share/man/man1/ob-cert-request.1
 usr/share/man/man1/ob-record-connect.1

--- a/doc/admin-guide.md
+++ b/doc/admin-guide.md
@@ -862,6 +862,8 @@ journalctl -u sshd | grep "SSH key policy"
 | `ob-enroll -g GROUP`  | Enroll with specific server group             |
 | `ob-session-recorder` | Record SSH session (ForceCommand)             |
 | `ob-ssh HOST`         | Connect to backend via bastion ephemeral cert |
+| `ob-scp SRC DEST`     | Copy files to/from/between backends via bastion |
+| `ob-sftp HOST`        | SFTP session to a backend via bastion ephemeral cert |
 
 ## CrowdSec Integration
 

--- a/doc/ansible-quickstart.md
+++ b/doc/ansible-quickstart.md
@@ -198,7 +198,8 @@ ansible-playbook -i inventory.yml playbook.yml --limit web-1
    listed bastion).
 
 After the play, users connect with their SSO certificate to a bastion, then hop
-to any backend with `ob-ssh <backend>` (or copy files with `ob-scp`); the
+to any backend with `ob-ssh <backend>` (or transfer files with `ob-scp` /
+`ob-sftp`); the
 bastion mints a short-lived, CA-signed certificate for each hop. No user key
 ever lands on the bastion or the backends.
 

--- a/doc/design/bastion-cert-vouching.md
+++ b/doc/design/bastion-cert-vouching.md
@@ -114,6 +114,8 @@ user cert with:
 
 - `scripts/ob-ssh`: ephemeral keypair → `/pam/bastion-cert` → `CertificateFile`
   connect; drop `SendEnv=LLNG_BASTION_JWT`.
+- `scripts/ob-scp`, `scripts/ob-sftp`: same minting flow (via the shared
+  `ob-cert-lib.sh`) for `scp`/`sftp` file transfers through the bastion.
 - `src/pam_openbastion.c`: read `bastion_id` from the presented cert (extend existing
   `ob_ssh_cert_info` parsing) and enforce `allowed_bastions`; remove the
   `bastion_jwt` env path. `src/bastion_jwt.c` becomes cert-extension reading (or is

--- a/doc/shell-quickstart.md
+++ b/doc/shell-quickstart.md
@@ -167,7 +167,8 @@ finish.
 ## What you get
 
 After both steps, users connect with their SSO certificate to the bastion, then
-hop to any backend with `ob-ssh <backend>` (or copy files with `ob-scp`); the
+hop to any backend with `ob-ssh <backend>` (or transfer files with `ob-scp` /
+`ob-sftp`); the
 bastion mints a short-lived, CA-signed certificate for each hop. No user key
 ever lands on the bastion or the backends, and each backend rejects any cert not
 vouched by an allowed bastion.

--- a/man/ob-scp.1
+++ b/man/ob-scp.1
@@ -78,10 +78,12 @@ $ ob-scp -r dwho@backend1:/etc/app dwho@backend2:/etc/app
 .fi
 .SH SEE ALSO
 .BR ob-ssh (1),
+.BR ob-sftp (1),
 .BR ob-cert-request (1),
 .BR ob-cert-daemon (8),
 .BR ob-bastion-setup (8),
 .BR scp (1),
+.BR sftp (1),
 .BR ssh (1)
 .SH COPYRIGHT
 Copyright (C) 2025 Linagora.

--- a/man/ob-sftp.1
+++ b/man/ob-sftp.1
@@ -1,0 +1,93 @@
+.TH OB-SFTP 1 "June 2026" "open-bastion" "User Commands"
+.SH NAME
+ob-sftp \- bastion SFTP to a backend with LLNG certificate vouching
+.SH SYNOPSIS
+.B ob-sftp
+[\fIOPTIONS\fR] [\fIsftp-options\fR] [\fIuser@\fR]\fIbackend\fR[:\fIpath\fR]
+.SH DESCRIPTION
+.B ob-sftp
+is the
+.BR sftp (1)
+counterpart of
+.BR ob-ssh (1)
+and
+.BR ob-scp (1).
+Run on a bastion by a user already authenticated to it, it mints a short-lived,
+LemonLDAP::NG-signed certificate for this user and runs
+.B sftp
+with it, so an interactive or batch SFTP session can be opened to a backend:
+.IP \(bu 2
+interactive:  \fBob-sftp\fR user@backend
+.IP \(bu 2
+with a path:  \fBob-sftp\fR user@backend:/remote/dir
+.IP \(bu 2
+batch mode:   \fBob-sftp\fR \-b script.sftp user@backend
+.PP
+The destination is a single [\fIuser@\fR]\fIbackend\fR[:\fIpath\fR] endpoint.
+Unlike
+.BR ob-scp (1)
+there is no backend-to-backend case: SFTP connects to one remote endpoint, and
+a single vouched certificate authenticates as exactly one principal.
+.PP
+No SSH key of the user's own on the bastion and no agent forwarding are needed:
+the ephemeral private key lives in tmpfs and is wiped when
+.B ob-sftp
+exits.
+.SH OPTIONS
+Options consumed by ob-sftp itself must come first:
+.TP
+.BR \-c ", " \-\-config " " \fIFILE\fR
+Use alternate configuration file (default: /etc/open-bastion/ssh-proxy.conf)
+.TP
+.BR \-d ", " \-\-debug
+Enable debug output to stderr
+.TP
+.BR \-h ", " \-\-help
+Show help message and exit
+.TP
+.BR \-V ", " \-\-version
+Show version and exit
+.PP
+Any further options are passed straight through to
+.BR sftp (1)
+(for example \fB\-r\fR, \fB\-P\fR \fIPORT\fR, \fB\-b\fR \fIFILE\fR, \fB\-C\fR).
+.SH CONFIGURATION
+Shares \fI/etc/open-bastion/ssh-proxy.conf\fR with
+.BR ob-ssh (1);
+see that page for the keys.
+.SH FILES
+.TP
+.I /etc/open-bastion/ssh-proxy.conf
+Configuration file (world-readable; contains no secret)
+.TP
+.I /usr/lib/open-bastion/ob-cert-lib.sh
+Shared cert-vouching library sourced by ob-ssh, ob-scp and ob-sftp
+.SH EXIT STATUS
+.TP
+.B 0
+Success
+.TP
+.B 1
+Error (configuration, no valid voucher, or no destination endpoint)
+.PP
+Otherwise the exit status of the underlying
+.BR sftp (1).
+.SH EXAMPLES
+.nf
+$ ob-sftp dwho@backend1
+$ ob-sftp dwho@backend1:/var/log
+$ ob-sftp -b commands.sftp dwho@backend1
+.fi
+.SH SEE ALSO
+.BR ob-ssh (1),
+.BR ob-scp (1),
+.BR ob-cert-request (1),
+.BR ob-cert-daemon (8),
+.BR ob-bastion-setup (8),
+.BR sftp (1),
+.BR ssh (1)
+.SH COPYRIGHT
+Copyright (C) 2025 Linagora.
+License: AGPL-3.0
+.SH AUTHORS
+Xavier Guimard <xguimard@linagora.com>

--- a/man/ob-ssh.1
+++ b/man/ob-ssh.1
@@ -145,6 +145,7 @@ $ ob-ssh admin@backend-web01 2222
 .fi
 .SH SEE ALSO
 .BR ob-scp (1),
+.BR ob-sftp (1),
 .BR ob-cert-request (1),
 .BR ob-cert-daemon (8),
 .BR ob-bastion-setup (8),

--- a/rpm/open-bastion.spec
+++ b/rpm/open-bastion.spec
@@ -99,6 +99,7 @@ ctest --output-on-failure --verbose
 %{_bindir}/ob-ssh-cert
 %{_bindir}/ob-ssh
 %{_bindir}/ob-scp
+%{_bindir}/ob-sftp
 %{_bindir}/ob-cert-request
 %{_bindir}/ob-record-connect
 %{_bindir}/ob-bastion-id
@@ -133,6 +134,7 @@ ctest --output-on-failure --verbose
 %{_mandir}/man8/ob-record-sink.8*
 %{_mandir}/man1/ob-ssh.1*
 %{_mandir}/man1/ob-scp.1*
+%{_mandir}/man1/ob-sftp.1*
 %{_mandir}/man1/ob-cert-request.1*
 %{_mandir}/man1/ob-record-connect.1*
 # Hardening templates (session containment - deployed by ob-bastion-setup)

--- a/scripts/ob-cert-lib.sh
+++ b/scripts/ob-cert-lib.sh
@@ -3,7 +3,7 @@
 #
 # ob-cert-lib.sh - shared bastion certificate-vouching helpers
 #
-# Sourced by ob-ssh and ob-scp. Holds the
+# Sourced by ob-ssh, ob-scp and ob-sftp. Holds the
 # common configuration, logging and the LLNG /pam/bastion-cert minting flow so
 # both the SSH and SCP front-ends behave identically.
 #
@@ -279,7 +279,7 @@ mint_ephemeral_cert() {
     fi
     printf '%s\n' "$cert" > "$OB_EPH_DIR/id-cert.pub"
 
-    # Consumed by the sourcing script (ob-ssh / ob-scp), not within this lib.
+    # Consumed by the sourcing script (ob-ssh / ob-scp / ob-sftp), not this lib.
     # shellcheck disable=SC2034
     OB_EPH_KEY="$OB_EPH_DIR/id"
     # shellcheck disable=SC2034

--- a/scripts/ob-sftp
+++ b/scripts/ob-sftp
@@ -1,0 +1,161 @@
+#!/bin/bash
+# shellcheck disable=SC2155
+#
+# ob-sftp - bastion SFTP to a backend with LLNG certificate vouching
+#
+# The sftp counterpart of ob-ssh / ob-scp. Run on a bastion by a user already
+# authenticated to it; the bastion mints a short-lived, LLNG-signed certificate
+# for this user and runs sftp with it, so an interactive or batch SFTP session
+# can be opened to a backend WITHOUT any SSH key of the user's own on the
+# bastion and without agent forwarding.
+#
+#   * interactive:   ob-sftp user@backend
+#   * with a path:   ob-sftp user@backend:/remote/dir
+#   * batch mode:    ob-sftp -b script.sftp user@backend
+#
+# Unlike ob-scp there is no backend<->backend case: sftp connects to a single
+# remote endpoint (one vouched certificate authenticates as one principal).
+#
+# Copyright (C) 2025 Linagora
+# Author: Xavier Guimard <xguimard@linagora.com>
+# License: AGPL-3.0
+
+set -euo pipefail
+
+VERSION="0.2.3"
+PROG_NAME=$(basename "$0")
+
+# Source the shared cert-vouching library: the installed path first, then
+# alongside this script (running from the source tree / tests).
+_OB_LIB="${OB_CERT_LIB:-/usr/lib/open-bastion/ob-cert-lib.sh}"
+if [ ! -r "$_OB_LIB" ]; then
+    _OB_LIB="$(dirname "$(readlink -f "$0")")/ob-cert-lib.sh"
+fi
+if [ ! -r "$_OB_LIB" ]; then
+    echo "[ERROR] cannot find ob-cert-lib.sh (looked at \$OB_CERT_LIB, /usr/lib/open-bastion, and \$0's dir)" >&2
+    exit 1
+fi
+# shellcheck source=scripts/ob-cert-lib.sh
+. "$_OB_LIB"
+
+usage() {
+    cat <<EOF
+Usage: $PROG_NAME [OPTIONS] [sftp-options] [user@]backend[:path]
+
+Open an SFTP session to a backend through the bastion, using an LLNG vouched
+certificate. The destination is a single [user@]backend[:path] endpoint (one
+vouched certificate authenticates as a single principal). No SSH key of your
+own on the bastion and no agent forwarding are needed.
+
+Options (consumed by $PROG_NAME, must come first):
+  -c, --config FILE   Use alternate config file (default: $CONFIG_FILE)
+  -d, --debug         Enable debug output
+  -h, --help          Show this help
+  -V, --version       Show version
+
+Any further options are passed straight to sftp (e.g. -r, -P PORT, -b FILE, -C).
+
+Examples:
+  $PROG_NAME dwho@backend1
+  $PROG_NAME dwho@backend1:/var/log
+  $PROG_NAME -b commands.sftp dwho@backend1
+EOF
+}
+
+# Parse the SFTP destination spec into REMOTE_USER / REMOTE_HOST. Accepts the
+# classic "[user@]host[:path]" form and the "sftp://[user@]host[:port][/path]"
+# URI form. Only the user and host matter for vouching; the path/port are left
+# for sftp itself.
+split_dest_spec() {
+    local spec="$1"
+    spec="${spec#sftp://}"              # drop an optional URI scheme
+    local hostpart="${spec%%[:/]*}"     # host ends at the first ':' or '/'
+    if [[ "$hostpart" == *@* ]]; then
+        REMOTE_USER="${hostpart%%@*}"
+        REMOTE_HOST="${hostpart#*@}"
+    else
+        REMOTE_USER=""
+        REMOTE_HOST="$hostpart"
+    fi
+}
+
+# Parse our own options (must precede sftp args), leaving SFTP_ARGS as the rest.
+SFTP_ARGS=()
+parse_args() {
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            -c|--config) CONFIG_FILE="$2"; shift 2 ;;
+            -d|--debug)
+                # DEBUG is consumed by debug() in ob-cert-lib.sh (sourced above).
+                # shellcheck disable=SC2034
+                DEBUG=true
+                shift ;;
+            -h|--help)   usage; exit 0 ;;
+            -V|--version) echo "$PROG_NAME version $VERSION"; exit 0 ;;
+            --) shift; break ;;
+            *)  break ;;
+        esac
+    done
+    SFTP_ARGS=("$@")
+}
+
+main() {
+    parse_args "$@"
+    load_config
+    validate_config
+
+    if [ "${#SFTP_ARGS[@]}" -lt 1 ]; then
+        error "Need a destination [user@]backend[:path]"
+        usage
+        exit 1
+    fi
+
+    # Walk SFTP_ARGS to find the single destination: skip options and the
+    # argument of any option that consumes the next token, so e.g.
+    # `-b file user@backend` or `-o Foo=bar user@backend` resolve to the host.
+    local default_user="${USER:-$(whoami)}"
+    local dest="" i=0 n=${#SFTP_ARGS[@]}
+    while [ "$i" -lt "$n" ]; do
+        local t="${SFTP_ARGS[$i]}"
+        case "$t" in
+            # sftp options that consume the NEXT token as their argument.
+            -B|-b|-c|-D|-F|-i|-J|-l|-o|-P|-R|-S|-X)
+                i=$((i + 2)); continue ;;
+            --) i=$((i + 1)); dest="${SFTP_ARGS[$i]:-}"; break ;;
+            -*) i=$((i + 1)); continue ;;   # bundled flags / attached values
+            *)  dest="$t"; break ;;          # first positional = the endpoint
+        esac
+    done
+
+    if [ -z "$dest" ]; then
+        error "No [user@]backend[:path] destination found — nothing to vouch for."
+        exit 1
+    fi
+
+    split_dest_spec "$dest"
+    validate_hostname "$REMOTE_HOST"
+    local resolved_user="${REMOTE_USER:-$default_user}"
+
+    debug "Remote user=$resolved_user, vouching via host=$REMOTE_HOST"
+    mint_ephemeral_cert "$resolved_user" "$REMOTE_HOST" || exit 1
+    # Clean the ephemeral key dir on exit. As with ob-ssh we trap EXIT only:
+    # sftp installs its own SIGINT handler (Ctrl-C interrupts the current
+    # transfer and returns to the sftp> prompt rather than killing this proxy),
+    # and the established connection no longer needs the on-disk key, so we let
+    # sftp own the interactive signals and clean up once it returns.
+    # shellcheck disable=SC2064
+    trap "rm -rf '$OB_EPH_DIR'" EXIT
+
+    local rc=0
+    sftp \
+        -i "$OB_EPH_KEY" \
+        -o CertificateFile="$OB_EPH_CERT" \
+        -o IdentitiesOnly=yes \
+        -o StrictHostKeyChecking=accept-new \
+        "${SSH_OPTIONS_ARRAY[@]}" \
+        "${SFTP_ARGS[@]}" || rc=$?
+
+    exit $rc
+}
+
+main "$@"

--- a/systemd/ob-cert.socket
+++ b/systemd/ob-cert.socket
@@ -3,7 +3,7 @@ Description=Open Bastion certificate minting socket
 Documentation=https://github.com/linagora/open-bastion
 
 [Socket]
-# ob-ssh / ob-scp (via ob-cert-request, unprivileged) connect here to obtain a
+# ob-ssh / ob-scp / ob-sftp (via ob-cert-request, unprivileged) connect here to obtain a
 # short-lived vouched certificate. Per-connection activation (Accept=yes) spawns
 # one ob-cert@.service instance per connection.
 ListenStream=/run/open-bastion/cert.sock

--- a/tests/test_ob_sftp.sh
+++ b/tests/test_ob_sftp.sh
@@ -1,0 +1,182 @@
+#!/bin/bash
+#
+# Test suite for ob-sftp (llng bastion SFTP connector)
+#
+# Tests syntax, CLI flags, and offline function logic by sourcing
+# ob-cert-lib.sh (shared library) and ob-sftp itself.
+#
+
+set -u
+
+# Test counters
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# Get script directory
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SFTP_SCRIPT="$SCRIPT_DIR/scripts/ob-sftp"
+LIB="$SCRIPT_DIR/scripts/ob-cert-lib.sh"
+export OB_CERT_LIB="$LIB"
+
+# Temp directory for test files
+TEST_TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TEST_TMPDIR"' EXIT
+
+# Test result tracking
+test_pass() {
+    echo -e "${GREEN}✓${NC} $1"
+    ((TESTS_PASSED++))
+}
+
+test_fail() {
+    echo -e "${RED}✗${NC} $1"
+    if [ -n "${2:-}" ]; then
+        echo -e "  ${YELLOW}Details:${NC} $2"
+    fi
+    ((TESTS_FAILED++))
+}
+
+# Test 1: Syntax check
+test_syntax_check() {
+    if bash -n "$SFTP_SCRIPT" 2>/dev/null; then
+        test_pass "Syntax check: bash -n passes"
+    else
+        test_fail "Syntax check: bash -n failed"
+    fi
+}
+
+# Test 2: --version outputs version string
+test_version_flag() {
+    local output
+    output=$("$SFTP_SCRIPT" --version 2>&1)
+    if [[ "$output" =~ version.*[0-9]+\.[0-9]+\.[0-9]+ ]]; then
+        test_pass "--version outputs version string"
+    else
+        test_fail "--version does not output version string" "Got: $output"
+    fi
+}
+
+# Test 3: --help exits 0 and mentions the destination spec
+test_help_flag() {
+    local output
+    local exit_code
+    output=$("$SFTP_SCRIPT" --help 2>&1)
+    exit_code=$?
+    if [ $exit_code -eq 0 ] && [[ "$output" =~ backend ]] && [[ "$output" =~ Usage ]]; then
+        test_pass "--help exits 0 and documents usage"
+    else
+        test_fail "--help check failed" "Exit code: $exit_code, output: $output"
+    fi
+}
+
+# Test 4: No args exits non-zero.
+# ob-sftp calls load_config+validate_config before the arg count check, and
+# load_config requires the config file to be root-owned; running as non-root
+# with the default config path (/etc/open-bastion/ssh-proxy.conf) will fail
+# the ownership check before we ever reach the arg count. Therefore we assert
+# only that the exit code is non-zero — regardless of whether the error is
+# "need a destination" or "config not found".
+test_no_args() {
+    local exit_code=0
+    "$SFTP_SCRIPT" 2>/dev/null || exit_code=$?
+    if [ "$exit_code" -ne 0 ]; then
+        test_pass "ob-sftp with no args exits non-zero"
+    else
+        test_fail "ob-sftp with no args should exit non-zero" "Exit code: $exit_code"
+    fi
+}
+
+# Test 5: split_dest_spec parses the destination forms correctly.
+# split_dest_spec is defined inside ob-sftp (not the shared lib). Source ob-sftp
+# via the sed-strip approach (removes 'set -euo pipefail' and the 'main "$@"'
+# call). OB_CERT_LIB is exported above so the '. "$_OB_LIB"' line resolves.
+test_split_dest_spec() {
+    local test_script="$TEST_TMPDIR/test_split_dest.sh"
+    cat > "$test_script" <<'TESTSCRIPT'
+#!/bin/bash
+set -u
+source_file="$1"
+
+eval "$(sed -e 's/^set -euo pipefail$//' -e '/^main "\$@"$/d' "$source_file")"
+
+ok=true
+
+# user@host -> REMOTE_USER=dwho, REMOTE_HOST=b1
+split_dest_spec "dwho@b1"
+if [ "$REMOTE_USER" != "dwho" ] || [ "$REMOTE_HOST" != "b1" ]; then
+    echo "FAIL_user_at_host: user=[$REMOTE_USER] host=[$REMOTE_HOST]"
+    ok=false
+fi
+
+# user@host:/path -> REMOTE_USER=dwho, REMOTE_HOST=b1 (path stripped)
+split_dest_spec "dwho@b1:/var/log"
+if [ "$REMOTE_USER" != "dwho" ] || [ "$REMOTE_HOST" != "b1" ]; then
+    echo "FAIL_user_at_host_path: user=[$REMOTE_USER] host=[$REMOTE_HOST]"
+    ok=false
+fi
+
+# host only -> REMOTE_USER="", REMOTE_HOST=b1
+split_dest_spec "b1"
+if [ -n "$REMOTE_USER" ] || [ "$REMOTE_HOST" != "b1" ]; then
+    echo "FAIL_host_only: user=[$REMOTE_USER] host=[$REMOTE_HOST]"
+    ok=false
+fi
+
+# sftp:// URI form -> scheme stripped, host isolated
+split_dest_spec "sftp://dwho@b1:2222/var/log"
+if [ "$REMOTE_USER" != "dwho" ] || [ "$REMOTE_HOST" != "b1" ]; then
+    echo "FAIL_uri: user=[$REMOTE_USER] host=[$REMOTE_HOST]"
+    ok=false
+fi
+
+if $ok; then
+    echo "SPLIT_DEST_SPEC_OK"
+fi
+TESTSCRIPT
+
+    chmod +x "$test_script"
+    local output
+    output=$("$test_script" "$SFTP_SCRIPT" 2>&1)
+
+    if echo "$output" | grep -q "SPLIT_DEST_SPEC_OK"; then
+        test_pass "split_dest_spec: all destination forms parsed correctly"
+    else
+        test_fail "split_dest_spec parsing" "Output: $output"
+    fi
+}
+
+# Main test execution
+echo "=========================================="
+echo "Testing ob-sftp (llng bastion SFTP connector)"
+echo "=========================================="
+echo ""
+
+test_syntax_check
+test_version_flag
+test_help_flag
+test_no_args
+test_split_dest_spec
+
+# Summary
+echo ""
+echo "=========================================="
+echo "Test Summary"
+echo "=========================================="
+echo -e "${GREEN}Passed:${NC} $TESTS_PASSED"
+echo -e "${RED}Failed:${NC} $TESTS_FAILED"
+echo "Total:  $((TESTS_PASSED + TESTS_FAILED))"
+echo ""
+
+if [ $TESTS_FAILED -eq 0 ]; then
+    echo -e "${GREEN}All tests passed!${NC}"
+    exit 0
+else
+    echo -e "${RED}Some tests failed.${NC}"
+    exit 1
+fi


### PR DESCRIPTION
## Summary

Adds `ob-sftp`, the `sftp` counterpart of `ob-ssh` / `ob-scp`. Run on a bastion
by a user already authenticated to it, it mints a short-lived, LLNG-signed
certificate (via the shared `ob-cert-lib.sh`) and opens an **interactive or
batch SFTP session** to a backend — with no user SSH key on the bastion and no
agent forwarding.

```
ob-sftp dwho@backend1                 # interactive
ob-sftp dwho@backend1:/var/log        # start in a remote dir
ob-sftp -b commands.sftp dwho@backend1  # batch mode
```

Unlike `ob-scp` there is no backend↔backend case: SFTP connects to a single
endpoint (one vouched certificate = one principal). Options after `ob-sftp`'s
own flags (`-c/--config`, `-d/--debug`, `-h`, `-V`) pass straight through to
`sftp(1)`.

## Implementation notes
- New `scripts/ob-sftp` sources the existing transport-agnostic
  `ob-cert-lib.sh`; no functional change to the library (comments only).
- Destination parsing accepts both `[user@]host[:path]` and the
  `sftp://[user@]host[:port][/path]` URI form; the option-skipping walk handles
  `sftp` flags that consume their next token (`-b`, `-o`, `-P`, `-i`, …).
- Cleanup traps **EXIT only** (like `ob-ssh`): `sftp` installs its own SIGINT
  handler, so Ctrl-C interrupts the current transfer and returns to the `sftp>`
  prompt rather than tearing down the proxy; the established connection no
  longer needs the on-disk key. The ephemeral key lives in tmpfs and is wiped
  on exit.

## Packaging / build
- `CMakeLists.txt`: install the binary + `ob-sftp.1` manpage.
- `debian/open-bastion.install` and `rpm/open-bastion.spec`: binary + manpage.
- CI auto-discovers `scripts/ob-*` (syntax + shellcheck) and
  `tests/test_ob_*.sh` (test loop), so no extra wiring was needed.

## Docs
- New `man/ob-sftp.1`; `SEE ALSO` cross-links added in `ob-ssh.1` / `ob-scp.1`.
- `README.md`, `CHANGELOG.md`, `doc/admin-guide.md`,
  `doc/shell-quickstart.md`, `doc/ansible-quickstart.md`,
  `doc/design/bastion-cert-vouching.md` mention `ob-sftp` alongside the
  existing connectors. (Broader doc propagation — Docker demos, French EBIOS
  study — is deferred to the documentation restructure, #166.)

## Testing
- `tests/test_ob_sftp.sh` (mirrors `test_ob_scp.sh`): syntax, `--version`,
  `--help`, no-args, and `split_dest_spec` across all destination forms — 5/5 pass.
- `shellcheck --severity=warning scripts/ob-sftp` clean.
- `bash -n` clean for all `scripts/ob-*`; existing `test_ob_scp.sh` (6/6) and
  `test_ob_ssh.sh` (20/20) still pass.
- `cmake` reconfigures cleanly; `ob-sftp.1` lints with no `man` warnings.

Closes #164
