### PR TITLE
feat(ob-builder): declare service keys (service accounts)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Documentation
 
+- **Service-account security model documented.** `doc/service-accounts.md` now
+  spells out that ob-builder deposits the fingerprint only, so the public key
+  must still be authorized at the SSH layer (`authorized_keys`, or the
+  `ob-service-account-keys` `AuthorizedKeysCommand` helper for Mode E); that
+  service accounts use direct key auth (no `ob-ssh`), so a native ProxyJump hop
+  through the bastion is **not session-recorded**; and that service-account sudo
+  is granted locally with **no LLNG token, even in Mode E**. New EBIOS risks
+  R-S24 (sudo without token) and R-S25 (unrecorded ProxyJump hop) in
+  `doc/security/99-risk-reduce.md`. `local-test/deploy-shell.sh` gained an
+  end-to-end service-account check on the standalone VM.
 - **Backend access guidance corrected.** The admin guide showed a
   `ProxyCommand`/`ProxyJump` snippet for reaching a backend in one command, but
   `ob-ssh` re-originates a full interactive session (it is not a `-W` stdio

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   bastion and no agent forwarding. Connects to a single endpoint
   (`[user@]backend[:path]`); options after the connector's own flags pass
   straight through to `sftp(1)`. See `ob-sftp(1)`.
-
+- **`ob-builder` can declare service accounts.** The builder now collects
+  SSH-key-only local accounts (ansible, backup, CI/CD, …) — interactively or via
+  a `service_accounts:` list in the `--config` YAML — validates each entry
+  (name, `SHA256:`/`MD5:` fingerprint, absolute shell/home) at build time, and
+  bakes them into both outputs: the shell installer writes
+  `/etc/open-bastion/service-accounts.conf` (`0600 root:root`) and the Ansible
+  role carries them as `ob_service_accounts_content` (overridable per
+  host/group). `service_accounts_file` is set in the generated
+  `openbastion.conf`. No PAM-module change — `src/service_account.c` already
+  parses that file. See `doc/service-accounts.md` and `ob-builder(1)`.
 - **Session-recording retention (`ob-session-prune`).** A new daily timer
   (`ob-session-prune.timer`, enabled at install) bounds the recordings store,
   which matters because recording is fail-closed — a full disk refuses new

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   host/group). `service_accounts_file` is set in the generated
   `openbastion.conf`. No PAM-module change — `src/service_account.c` already
   parses that file. See `doc/service-accounts.md` and `ob-builder(1)`.
+  Validated end-to-end on a Mode E VM (`local-test/deploy-shell.sh`). ob-builder
+  warns when an account would be unusable on the target: a `home`/`shell` outside
+  the approved lists (silently dropped by the PAM module) or a missing fixed
+  `uid`/`gid` (NSS cannot resolve it for sshd's pre-auth lookup, so it is
+  unreachable over SSH unless it already exists locally). `doc/service-accounts.md`
+  documents these requirements (including not reusing a system username).
 - **Session-recording retention (`ob-session-prune`).** A new daily timer
   (`ob-session-prune.timer`, enabled at install) bounds the recordings store,
   which matters because recording is fail-closed — a full disk refuses new

--- a/admin-builder/README.md
+++ b/admin-builder/README.md
@@ -30,7 +30,8 @@ This launches an interactive questionnaire:
 5. OIDC client_secret mode (`none`, `prompt`, or `embedded`)
 6. Server group and policy
 7. Target role (`bastion`, `standalone`, or `backend`)
-8. Auto-launch enrollment/setup on target (`yes`, `no`, or `prompt`)
+8. Service accounts — optional SSH-key-only local accounts (ansible, backup, …)
+9. Auto-launch enrollment/setup on target (`yes`, `no`, or `prompt`)
 
 ## Quick Start (Non-Interactive with Config File)
 
@@ -54,7 +55,24 @@ ansible_auto_approve: no # yes = Ansible role can approve device codes via LLNG 
 apt_url: https://linagora.github.io/open-bastion
 apt_suite: trixie
 apt_component: main
+
+# Optional SSH-key-only local accounts (no OIDC), rendered into
+# /etc/open-bastion/service-accounts.conf (0600) on every target.
+# service_accounts:
+#   - name: ansible
+#     key_fingerprint: "SHA256:..."   # ssh-keygen -lf key.pub
+#     sudo_allowed: true
+#     sudo_nopasswd: true
+#     shell: /bin/bash
+#     home: /var/lib/ansible
+#     gecos: Ansible Automation
+#   - name: backup
+#     key_fingerprint: "SHA256:..."
+#     sudo_allowed: false
 ```
+
+See [`doc/service-accounts.md`](../doc/service-accounts.md) for the full schema
+and how service accounts are matched and created on the target.
 
 Generate the artifacts:
 

--- a/admin-builder/README.md
+++ b/admin-builder/README.md
@@ -58,17 +58,18 @@ apt_component: main
 
 # Optional SSH-key-only local accounts (no OIDC), rendered into
 # /etc/open-bastion/service-accounts.conf (0600) on every target.
+# Use a dedicated name (not a system user), a home under /home or /var/home, and
+# a fixed uid+gid (required so NSS can resolve the account for sshd pre-auth).
 # service_accounts:
-#   - name: ansible
+#   - name: ci-ansible
 #     key_fingerprint: "SHA256:..."   # ssh-keygen -lf key.pub
 #     sudo_allowed: true
 #     sudo_nopasswd: true
 #     shell: /bin/bash
-#     home: /var/lib/ansible
+#     home: /home/ci-ansible
 #     gecos: Ansible Automation
-#   - name: backup
-#     key_fingerprint: "SHA256:..."
-#     sudo_allowed: false
+#     uid: 6001
+#     gid: 6001
 ```
 
 See [`doc/service-accounts.md`](../doc/service-accounts.md) for the full schema

--- a/admin-builder/lib/validators.sh
+++ b/admin-builder/lib/validators.sh
@@ -45,6 +45,33 @@ is_valid_client_id() {
     [[ "$s" =~ ^[A-Za-z0-9._-]+$ ]]
 }
 
+# is_valid_service_username <s>
+# Mirrors validate_username() in src/service_account.c: first char a lowercase
+# letter or underscore, then lowercase letters, digits, underscore or hyphen.
+is_valid_service_username() {
+    [[ "$1" =~ ^[a-z_][a-z0-9_-]*$ ]]
+}
+
+# is_valid_fingerprint <s>
+# Mirrors validate_fingerprint() in src/service_account.c: must start with
+# SHA256: or MD5:, and contain only base64-ish characters (alnum : + / =).
+is_valid_fingerprint() {
+    local s="$1"
+    [[ "$s" == SHA256:* || "$s" == MD5:* ]] || return 1
+    [[ "$s" =~ ^[A-Za-z0-9:+/=]+$ ]]
+}
+
+# is_valid_abs_path <s>
+# Light sanity check for shell / home values: an absolute path with no
+# whitespace or shell metacharacters (the authoritative approved-list check
+# happens on the target in src/service_account.c). Empty is allowed (means
+# "use the default" on the target).
+is_valid_abs_path() {
+    local s="$1"
+    [ -z "$s" ] && return 0
+    [[ "$s" =~ ^/[A-Za-z0-9._/-]+$ ]]
+}
+
 # is_valid_scenario <s>
 is_valid_scenario() {
     case "$1" in

--- a/admin-builder/man/ob-builder.1
+++ b/admin-builder/man/ob-builder.1
@@ -13,7 +13,8 @@ Open Bastion against a LemonLDAP::NG SSO.
 .PP
 The builder asks a short questionnaire (security scenario, SSO URL,
 OIDC client_id and client_secret handling, target role, server group,
-auto-launch policy, optional bastion whitelist for backends) and then
+auto-launch policy, optional bastion whitelist for backends, and optional
+service accounts) and then
 fetches the SSH CA public key and JWKS from the chosen SSO. The generated
 artefacts deposit
 .IR /etc/open-bastion/openbastion.conf ,
@@ -72,6 +73,26 @@ Show help.
 .TP
 .B \-V ", " \-\-version
 Print the builder version.
+.SH SERVICE ACCOUNTS
+The builder can declare SSH-key-only local accounts (ansible, backup, CI/CD,
+\&...) that authenticate by SSH key fingerprint without OIDC. The questionnaire
+prompts for them interactively; a
+.B \-\-config
+YAML provides them under a
+.B service_accounts:
+list (keys:
+.IR name ", " key_fingerprint ", " sudo_allowed ", " sudo_nopasswd ", "
+.IR shell ", " home ", " gecos ", " uid ", " gid ).
+Each entry is validated at build time and rendered into
+.I /etc/open-bastion/service-accounts.conf
+(\fB0600 root:root\fR) on the target, with
+.B service_accounts_file
+set in
+.IR openbastion.conf .
+They apply to every role. See
+.BR open-bastion (7)
+and the project's
+.I doc/service-accounts.md .
 .SH FILES
 .TP
 .I /usr/share/open-bastion-builder/templates/

--- a/admin-builder/ob-builder
+++ b/admin-builder/ob-builder
@@ -104,6 +104,13 @@ DISABLE_SESSION_RECORDER=""
 # rendered into /etc/open-bastion/service-accounts.conf on the target.
 SERVICE_ACCOUNTS_RECORDS=()
 _OB_SA_US=$'\x1f'
+# Module defaults from include/config.h (DEFAULT_APPROVED_HOME_PREFIXES /
+# DEFAULT_APPROVED_SHELLS). A service account whose home/shell falls outside
+# these is SILENTLY DROPPED at load by pam_openbastion unless the target's
+# openbastion.conf widens approved_home_prefixes / approved_shells — so we warn
+# about it at build time. Keep in sync with config.h.
+_OB_SA_DEFAULT_HOME_PREFIXES="/home /var/home"
+_OB_SA_DEFAULT_SHELLS="/bin/bash /bin/sh /usr/bin/bash /usr/bin/sh /bin/zsh /usr/bin/zsh /bin/dash /usr/bin/dash /bin/fish /usr/bin/fish"
 
 # Derived values populated after the questionnaire.
 PAM_MODE=""
@@ -164,16 +171,17 @@ SERVICE ACCOUNTS (--config YAML):
   rendered into /etc/open-bastion/service-accounts.conf (0600) on the target and
   apply to every role. Example:
     service_accounts:
-      - name: ansible
-        key_fingerprint: "SHA256:…"   # from: ssh-keygen -lf key.pub
+      - name: ci-ansible            # dedicated name (not an existing system user)
+        key_fingerprint: "SHA256:…" # from: ssh-keygen -lf key.pub
         sudo_allowed: true
         sudo_nopasswd: true
         shell: /bin/bash
-        home: /var/lib/ansible
+        home: /home/ci-ansible      # under an approved prefix (/home, /var/home)
         gecos: Ansible Automation
-      - name: backup
-        key_fingerprint: "SHA256:…"
-        sudo_allowed: false
+        uid: 6001                   # fixed uid+gid → NSS-resolvable → reachable over SSH
+        gid: 6001
+  Notes: use a dedicated (non-system) name, a home under /home or /var/home, and
+  a fixed uid+gid, or the account is dropped / unreachable. See doc/service-accounts.md.
 
 EXAMPLES:
   # Fully interactive bastion bootstrap (default Linagora APT keyring)
@@ -441,6 +449,45 @@ validate_service_account_record() {
     return 0
 }
 
+# Warn (non-fatal) when a service account's home/shell falls outside the module
+# defaults: pam_openbastion silently DROPS such an account at load unless the
+# target widens approved_home_prefixes / approved_shells in openbastion.conf.
+warn_service_account_unapproved() {
+    local rec="$1"
+    local name home shell uid gid pfx ok
+    name=$(_sa_field 1 "$rec"); shell=$(_sa_field 5 "$rec"); home=$(_sa_field 6 "$rec")
+    uid=$(_sa_field 8 "$rec"); gid=$(_sa_field 9 "$rec")
+    # NSS (libnss_openbastion) only synthesizes a service account when it has a
+    # FIXED uid AND gid; sshd's pre-auth getpwnam then succeeds. Without them the
+    # account is unreachable over SSH unless it already exists as a local user.
+    if [ -z "$uid" ] || [ "$uid" = 0 ] || [ -z "$gid" ] || [ "$gid" = 0 ]; then
+        log_warn "service account '$name': no fixed uid/gid. NSS cannot resolve it pre-auth, so"
+        log_warn "  it is reachable over SSH only if the account already exists locally on the target."
+        log_warn "  Set both 'uid' and 'gid' for a self-contained, fleet-consistent service account."
+    fi
+    if [ -n "$home" ]; then
+        ok=0
+        for pfx in $_OB_SA_DEFAULT_HOME_PREFIXES; do
+            case "$home" in "$pfx"/*) ok=1; break ;; esac
+        done
+        if [ "$ok" -ne 1 ]; then
+            log_warn "service account '$name': home '$home' is outside the default approved prefixes ($_OB_SA_DEFAULT_HOME_PREFIXES)."
+            log_warn "  pam_openbastion will DROP this account unless the target's openbastion.conf sets e.g.:"
+            log_warn "    approved_home_prefixes = /home:/var/home:${home%/*}"
+        fi
+    fi
+    if [ -n "$shell" ]; then
+        ok=0
+        for pfx in $_OB_SA_DEFAULT_SHELLS; do
+            [ "$shell" = "$pfx" ] && { ok=1; break; }
+        done
+        if [ "$ok" -ne 1 ]; then
+            log_warn "service account '$name': shell '$shell' is not in the default approved shells."
+            log_warn "  Set 'approved_shells' in the target's openbastion.conf or the account will be dropped."
+        fi
+    fi
+}
+
 # Parse the `service_accounts:` block of a YAML config file into
 # SERVICE_ACCOUNTS_RECORDS. Independent of yq (the flat parsers can't read a
 # list). Recognises the documented block-list form:
@@ -560,6 +607,10 @@ _render_service_accounts_conf() {
         [ -n "$uid" ] && [ "$uid" != 0 ] && printf 'uid = %s\n' "$uid"
         [ -n "$gid" ] && [ "$gid" != 0 ] && printf 'gid = %s\n' "$gid"
     done
+    # Explicit success: the loop's last command is a `&&` chain that is false
+    # whenever the final account has no gid (the common case), which would make
+    # this function return non-zero and trip `set -e` in the caller.
+    return 0
 }
 
 # Interactively collect service accounts into SERVICE_ACCOUNTS_RECORDS. Loops
@@ -597,8 +648,9 @@ collect_service_accounts_interactive() {
             is_valid_abs_path "$home" && break
             log_warn "Home must be an absolute path (e.g. /var/lib/$name) or empty."
         done
-        uid=$(ask "  Fixed UID (optional, 0/empty = auto)" "")
-        gid=$(ask "  Fixed GID (optional, 0/empty = auto)" "")
+        explain "Set a fixed uid+gid for an SSH-reachable account: NSS resolves it only when both are set (sshd checks the user before auth). Leave empty only if the account already exists locally on the target."
+        uid=$(ask "  Fixed UID (recommended; empty = auto)" "")
+        gid=$(ask "  Fixed GID (recommended; empty = auto)" "")
 
         rec=$(_sa_pack "$name" "$fp" "$sudo_allowed" "$sudo_nopasswd" "$shell" "$home" "$gecos" "$uid" "$gid")
         if validate_service_account_record "$rec"; then
@@ -893,6 +945,7 @@ validate_inputs() {
         local -A _seen_sa=()
         for _rec in "${SERVICE_ACCOUNTS_RECORDS[@]}"; do
             validate_service_account_record "$_rec" || die "Invalid service account in config"
+            warn_service_account_unapproved "$_rec"
             _name=$(_sa_field 1 "$_rec")
             [ -n "${_seen_sa[$_name]:-}" ] && die "Duplicate service account name: $_name"
             _seen_sa[$_name]=1

--- a/admin-builder/ob-builder
+++ b/admin-builder/ob-builder
@@ -96,6 +96,15 @@ ENABLE_HARDENING=""
 ENABLE_AUDIT_TRACE=""
 DISABLE_SESSION_RECORDER=""
 
+# Service accounts (SSH-key-only local accounts: ansible, backup, …). Each entry
+# is one account encoded as a single record whose fields are joined by the ASCII
+# Unit Separator (US, \x1f) in this fixed order:
+#   name, key_fingerprint, sudo_allowed, sudo_nopasswd, shell, home, gecos, uid, gid
+# Populated from the questionnaire or from the YAML `service_accounts:` list, and
+# rendered into /etc/open-bastion/service-accounts.conf on the target.
+SERVICE_ACCOUNTS_RECORDS=()
+_OB_SA_US=$'\x1f'
+
 # Derived values populated after the questionnaire.
 PAM_MODE=""
 BUILD_DATE=""
@@ -147,7 +156,24 @@ QUESTIONNAIRE (asked when no --config is given):
   5. OIDC client_secret mode (none | prompt)
   6. Server group + policy (fixed | modifiable)
   7. Target role: bastion | standalone | backend
-  8. Auto-launch enroll/setup on the target? (yes | no | prompt)
+  8. Service accounts (SSH-key-only local accounts: ansible, backup, …)
+  9. Auto-launch enroll/setup on the target? (yes | no | prompt)
+
+SERVICE ACCOUNTS (--config YAML):
+  Declare SSH-key-only local accounts under a 'service_accounts:' list. They are
+  rendered into /etc/open-bastion/service-accounts.conf (0600) on the target and
+  apply to every role. Example:
+    service_accounts:
+      - name: ansible
+        key_fingerprint: "SHA256:…"   # from: ssh-keygen -lf key.pub
+        sudo_allowed: true
+        sudo_nopasswd: true
+        shell: /bin/bash
+        home: /var/lib/ansible
+        gecos: Ansible Automation
+      - name: backup
+        key_fingerprint: "SHA256:…"
+        sudo_allowed: false
 
 EXAMPLES:
   # Fully interactive bastion bootstrap (default Linagora APT keyring)
@@ -251,6 +277,11 @@ load_config() {
         log_info "yq not found, using awk-based parser (flat keys only)"
         _load_config_awk "$f"
     fi
+
+    # Service accounts are a nested list, which neither flat parser handles.
+    # Parse them with a dedicated, yq-independent block scanner so behaviour is
+    # identical whether or not yq is installed.
+    _parse_service_accounts_block "$f"
 
     # When loading config we run non-interactively unless a missing value
     # forces a prompt. The prompts library checks OB_BUILDER_NON_INTERACTIVE.
@@ -361,11 +392,223 @@ _load_config_awk() {
                 apt_url)             [ "$APT_URL"       = "$DEFAULT_APT_URL"       ] && APT_URL="$val" ;;
                 apt_suite)           [ "$APT_SUITE"     = "$DEFAULT_APT_SUITE"     ] && APT_SUITE="$val" ;;
                 apt_component)       [ "$APT_COMPONENT" = "$DEFAULT_APT_COMPONENT" ] && APT_COMPONENT="$val" ;;
+                # Service-account list keys: consumed by _parse_service_accounts_block,
+                # ignored here (they only appear nested under `service_accounts:`).
+                service_accounts|name|key_fingerprint|fingerprint|sudo_allowed|sudo_nopasswd|shell|home|gecos|uid|gid) : ;;
                 *) log_warn "Unknown config key '$key' (ignored)" ;;
             esac
         fi
     done < "$f"
     return 0
+}
+
+# ─────────────────────────────────────────────────────────────────────────
+# Service-account helpers.
+# A record packs the 9 fields (in the fixed order documented next to
+# SERVICE_ACCOUNTS_RECORDS) joined by the Unit Separator. _sa_pack builds one;
+# _sa_field N extracts the Nth field (1-based) from a record.
+# ─────────────────────────────────────────────────────────────────────────
+_sa_pack() {
+    local IFS="$_OB_SA_US"
+    printf '%s' "$*"
+}
+_sa_field() {
+    local n="$1" rec="$2"
+    local -a _parts
+    IFS="$_OB_SA_US" read -r -a _parts <<< "$rec"
+    printf '%s' "${_parts[$((n - 1))]:-}"
+}
+
+# Validate one packed record. Mirrors the authoritative checks in
+# src/service_account.c so a bad value is caught at build time rather than
+# failing the PAM module load on the target.
+validate_service_account_record() {
+    local rec="$1"
+    local name fp sudo_allowed sudo_nopasswd shell home uid gid
+    name=$(_sa_field 1 "$rec");          fp=$(_sa_field 2 "$rec")
+    sudo_allowed=$(_sa_field 3 "$rec");   sudo_nopasswd=$(_sa_field 4 "$rec")
+    shell=$(_sa_field 5 "$rec");          home=$(_sa_field 6 "$rec")
+    uid=$(_sa_field 8 "$rec");            gid=$(_sa_field 9 "$rec")
+
+    is_valid_service_username "$name" || { log_error "Invalid service-account name: '$name'"; return 1; }
+    is_valid_fingerprint "$fp"        || { log_error "Invalid key_fingerprint for '$name' (must be SHA256:… or MD5:…): '$fp'"; return 1; }
+    case "$sudo_allowed"  in true|false) ;; *) log_error "service account '$name': sudo_allowed must be true/false"; return 1 ;; esac
+    case "$sudo_nopasswd" in true|false) ;; *) log_error "service account '$name': sudo_nopasswd must be true/false"; return 1 ;; esac
+    is_valid_abs_path "$shell" || { log_error "service account '$name': shell must be an absolute path: '$shell'"; return 1; }
+    is_valid_abs_path "$home"  || { log_error "service account '$name': home must be an absolute path: '$home'"; return 1; }
+    if [ -n "$uid" ] && ! [[ "$uid" =~ ^[0-9]+$ ]]; then log_error "service account '$name': uid must be numeric: '$uid'"; return 1; fi
+    if [ -n "$gid" ] && ! [[ "$gid" =~ ^[0-9]+$ ]]; then log_error "service account '$name': gid must be numeric: '$gid'"; return 1; fi
+    return 0
+}
+
+# Parse the `service_accounts:` block of a YAML config file into
+# SERVICE_ACCOUNTS_RECORDS. Independent of yq (the flat parsers can't read a
+# list). Recognises the documented block-list form:
+#
+#   service_accounts:
+#     - name: ansible
+#       key_fingerprint: "SHA256:…"
+#       sudo_allowed: true
+#       shell: /bin/bash
+#       home: /var/lib/ansible
+#       gecos: Ansible Automation
+#
+# A `- name:` line opens a new account; subsequent more-indented `key: value`
+# lines add fields; a line at the block's indent or shallower (or another
+# top-level key) ends the block.
+_parse_service_accounts_block() {
+    local f="$1"
+    local in_block=0 line key val
+    local name fp sudo_allowed sudo_nopasswd shell home gecos uid gid
+    _sa_reset_fields() { name=""; fp=""; sudo_allowed="false"; sudo_nopasswd="false"; shell=""; home=""; gecos=""; uid=""; gid=""; }
+    local have_acct=0
+    _sa_flush() {
+        [ "$have_acct" = 1 ] || return 0
+        SERVICE_ACCOUNTS_RECORDS+=("$(_sa_pack "$name" "$fp" "$sudo_allowed" "$sudo_nopasswd" "$shell" "$home" "$gecos" "$uid" "$gid")")
+        have_acct=0
+    }
+    _sa_reset_fields
+
+    while IFS= read -r line || [ -n "$line" ]; do
+        line="${line%$'\r'}"
+        case "$line" in
+            ''|\#*) continue ;;
+        esac
+        if [ "$in_block" = 0 ]; then
+            [[ "$line" =~ ^service_accounts[[:space:]]*:[[:space:]]*$ ]] && in_block=1
+            continue
+        fi
+        # In block. A non-indented line ends it.
+        if [[ "$line" =~ ^[^[:space:]] ]]; then
+            _sa_flush
+            in_block=0
+            continue
+        fi
+        # New list item: "- name: value"
+        if [[ "$line" =~ ^[[:space:]]*-[[:space:]]*name[[:space:]]*:[[:space:]]*(.*)$ ]]; then
+            _sa_flush
+            _sa_reset_fields
+            have_acct=1
+            val="${BASH_REMATCH[1]}"
+            val=$(_sa_unquote "$val")
+            name="$val"
+            continue
+        fi
+        # Field line: "  key: value"
+        if [[ "$line" =~ ^[[:space:]]+([a-zA-Z_]+)[[:space:]]*:[[:space:]]*(.*)$ ]]; then
+            key="${BASH_REMATCH[1]}"
+            val=$(_sa_unquote "${BASH_REMATCH[2]}")
+            case "$key" in
+                name)            name="$val" ;;
+                key_fingerprint|fingerprint) fp="$val" ;;
+                sudo_allowed)    sudo_allowed=$(_sa_normbool "$val") ;;
+                sudo_nopasswd)   sudo_nopasswd=$(_sa_normbool "$val") ;;
+                shell)           shell="$val" ;;
+                home)            home="$val" ;;
+                gecos)           gecos="$val" ;;
+                uid)             uid="$val" ;;
+                gid)             gid="$val" ;;
+            esac
+        fi
+    done < "$f"
+    _sa_flush
+    return 0
+}
+
+# Strip a YAML inline comment (" #…"), surrounding whitespace and matching quotes.
+_sa_unquote() {
+    local v="$1"
+    v="${v%% #*}"
+    v="${v#"${v%%[![:space:]]*}"}"
+    v="${v%"${v##*[![:space:]]}"}"
+    case "$v" in
+        \"*\") v="${v#\"}"; v="${v%\"}" ;;
+        \'*\') v="${v#\'}"; v="${v%\'}" ;;
+    esac
+    printf '%s' "$v"
+}
+
+# Normalise a YAML boolean-ish value to true/false.
+_sa_normbool() {
+    case "$1" in
+        true|True|TRUE|yes|Yes|YES|1)  printf 'true' ;;
+        *)                              printf 'false' ;;
+    esac
+}
+
+# Render SERVICE_ACCOUNTS_RECORDS into service-accounts.conf INI text on stdout.
+# key_fingerprint, sudo_allowed and sudo_nopasswd are always emitted; gecos /
+# shell / home / uid / gid only when set (uid/gid only when non-zero).
+_render_service_accounts_conf() {
+    local rec name fp sudo_allowed sudo_nopasswd shell home gecos uid gid
+    printf '# Open Bastion service accounts\n'
+    printf '# Generated by ob-builder %s on %s\n' "$VERSION" "$BUILD_DATE"
+    printf '# SSH-key-only local accounts (no OIDC). See ob-builder(1) and doc/service-accounts.md.\n'
+    for rec in "${SERVICE_ACCOUNTS_RECORDS[@]}"; do
+        name=$(_sa_field 1 "$rec");          fp=$(_sa_field 2 "$rec")
+        sudo_allowed=$(_sa_field 3 "$rec");   sudo_nopasswd=$(_sa_field 4 "$rec")
+        shell=$(_sa_field 5 "$rec");          home=$(_sa_field 6 "$rec")
+        gecos=$(_sa_field 7 "$rec")
+        uid=$(_sa_field 8 "$rec");            gid=$(_sa_field 9 "$rec")
+        printf '\n[%s]\n' "$name"
+        printf 'key_fingerprint = %s\n' "$fp"
+        printf 'sudo_allowed = %s\n' "$sudo_allowed"
+        printf 'sudo_nopasswd = %s\n' "$sudo_nopasswd"
+        [ -n "$gecos" ] && printf 'gecos = %s\n' "$gecos"
+        [ -n "$shell" ] && printf 'shell = %s\n' "$shell"
+        [ -n "$home" ]  && printf 'home = %s\n' "$home"
+        [ -n "$uid" ] && [ "$uid" != 0 ] && printf 'uid = %s\n' "$uid"
+        [ -n "$gid" ] && [ "$gid" != 0 ] && printf 'gid = %s\n' "$gid"
+    done
+}
+
+# Interactively collect service accounts into SERVICE_ACCOUNTS_RECORDS. Loops
+# until the admin declines to add another. Each field is validated on entry.
+collect_service_accounts_interactive() {
+    explain "Service accounts are SSH-key-only local accounts (no SSO), e.g. 'ansible' or 'backup'. They are matched by the SSH key fingerprint and created automatically on the target. Leave this off if you don't need any."
+    ask_yesno "Define service accounts on this target?" "n" || return 0
+
+    while :; do
+        local name fp sudo_allowed="false" sudo_nopasswd="false" shell home gecos uid gid rec
+        while :; do
+            name=$(ask "  Account name (lowercase; empty to finish)" "")
+            [ -z "$name" ] && return 0
+            is_valid_service_username "$name" && break
+            log_warn "Invalid name. Start with a lowercase letter or '_', then [a-z0-9_-]."
+        done
+        while :; do
+            explain "Get it with: ssh-keygen -lf key.pub  → use the 'SHA256:…' field."
+            fp=$(ask "  SSH key fingerprint (SHA256:… or MD5:…)" "")
+            is_valid_fingerprint "$fp" && break
+            log_warn "Invalid fingerprint. Must start with SHA256: or MD5: and be base64-ish."
+        done
+        ask_yesno "  Allow sudo for '$name'?" "n" && sudo_allowed="true"
+        if [ "$sudo_allowed" = "true" ]; then
+            ask_yesno "  Sudo without password (NOPASSWD)?" "n" && sudo_nopasswd="true"
+        fi
+        gecos=$(ask "  Description / GECOS (optional)" "")
+        while :; do
+            shell=$(ask "  Login shell (optional, absolute path)" "")
+            is_valid_abs_path "$shell" && break
+            log_warn "Shell must be an absolute path (e.g. /bin/bash) or empty."
+        done
+        while :; do
+            home=$(ask "  Home directory (optional, absolute path)" "")
+            is_valid_abs_path "$home" && break
+            log_warn "Home must be an absolute path (e.g. /var/lib/$name) or empty."
+        done
+        uid=$(ask "  Fixed UID (optional, 0/empty = auto)" "")
+        gid=$(ask "  Fixed GID (optional, 0/empty = auto)" "")
+
+        rec=$(_sa_pack "$name" "$fp" "$sudo_allowed" "$sudo_nopasswd" "$shell" "$home" "$gecos" "$uid" "$gid")
+        if validate_service_account_record "$rec"; then
+            SERVICE_ACCOUNTS_RECORDS+=("$rec")
+            log_info "Added service account '$name' (${#SERVICE_ACCOUNTS_RECORDS[@]} total)."
+        else
+            log_warn "Service account '$name' rejected; not added."
+        fi
+        ask_yesno "Add another service account?" "n" || break
+    done
 }
 
 # ─────────────────────────────────────────────────────────────────────────
@@ -530,6 +773,13 @@ EOF
         DISABLE_SESSION_RECORDER=$(ask_choice "Disable session recording on this bastion/standalone (--disable-session-recorder)?" "yes|no" "no")
     fi
 
+    # q7d. Service accounts (SSH-key-only local accounts). Applies to every role.
+    # Only prompt when none were supplied (e.g. via a partial config); a config
+    # that already defined service_accounts skips the interactive loop.
+    if [ "${#SERVICE_ACCOUNTS_RECORDS[@]}" -eq 0 ]; then
+        collect_service_accounts_interactive
+    fi
+
     # q8. Auto-launch enroll/setup
     if [ -z "$AUTO_ENROLL_SETUP" ]; then
         explain "Once the configs are deposited and the open-bastion package is installed, the target still needs to run ob-enroll then ob-*-setup. Choose whether the installer runs them automatically, skips them entirely, or asks the admin before each step."
@@ -636,6 +886,19 @@ validate_inputs() {
     : "${ANSIBLE_AUTO_APPROVE:=no}"
     case "$ANSIBLE_AUTO_APPROVE" in yes|no) ;; *) die "Invalid ansible_auto_approve: $ANSIBLE_AUTO_APPROVE" ;; esac
 
+    # Validate every service-account record (covers the YAML config path; the
+    # interactive loop validates as it goes). Reject duplicate account names.
+    if [ "${#SERVICE_ACCOUNTS_RECORDS[@]}" -gt 0 ]; then
+        local _rec _name
+        local -A _seen_sa=()
+        for _rec in "${SERVICE_ACCOUNTS_RECORDS[@]}"; do
+            validate_service_account_record "$_rec" || die "Invalid service account in config"
+            _name=$(_sa_field 1 "$_rec")
+            [ -n "${_seen_sa[$_name]:-}" ] && die "Duplicate service account name: $_name"
+            _seen_sa[$_name]=1
+        done
+    fi
+
     if [ -z "$REPO_KEYRING" ]; then
         if [ -f "$DEFAULT_REPO_KEYRING" ]; then
             REPO_KEYRING="$DEFAULT_REPO_KEYRING"
@@ -665,6 +928,7 @@ print_recap() {
   Audit trace:         $ENABLE_AUDIT_TRACE
   Session recording:   $([ "$TARGET_ROLE" = "backend" ] && echo "n/a (backend role)" || { [ "$DISABLE_SESSION_RECORDER" = "yes" ] && echo "disabled (opt-out)" || echo "enabled"; })
   Allowed bastions:    ${ALLOWED_BASTIONS:-<any in same group>}
+  Service accounts:    $([ "${#SERVICE_ACCOUNTS_RECORDS[@]}" -gt 0 ] && { _names=""; for _r in "${SERVICE_ACCOUNTS_RECORDS[@]}"; do _names="${_names:+$_names, }$(_sa_field 1 "$_r")"; done; echo "$_names"; } || echo "<none>")
   Ansible auto-approve: $ANSIBLE_AUTO_APPROVE
   APT repo:            $APT_URL  (suite=$APT_SUITE component=$APT_COMPONENT)
   Repo keyring:        $REPO_KEYRING
@@ -971,6 +1235,29 @@ build_placeholder_map() {
     ph_set ENABLE_HARDENING_BOOL         "$_harden_bool"
     ph_set ENABLE_AUDIT_TRACE_BOOL       "$_audit_bool"
     ph_set DISABLE_SESSION_RECORDER_BOOL "$_norec_bool"
+
+    # Service accounts. Applies to every role. The shell installer embeds the
+    # rendered service-accounts.conf base64-encoded and writes it at 0600; the
+    # Ansible role carries it as a YAML block scalar in defaults. The
+    # openbastion.conf gets an explicit service_accounts_file directive (the C
+    # default is already that path, so the line is documentation/clarity).
+    local _sa_enabled_bool="false" _sa_conf="" _sa_conf_b64="" _sa_file_line="" _sa_defaults_yaml
+    if [ "${#SERVICE_ACCOUNTS_RECORDS[@]}" -gt 0 ]; then
+        _sa_enabled_bool="true"
+        _sa_conf=$(_render_service_accounts_conf)
+        _sa_conf_b64=$(base64_string "$_sa_conf")
+        _sa_file_line=$'# Service accounts (SSH-key-only local accounts)\nservice_accounts_file = /etc/open-bastion/service-accounts.conf'
+        # YAML block scalar: indent every conf line by two spaces under `|`.
+        local _indented
+        _indented=$(printf '%s\n' "$_sa_conf" | sed 's/^/  /')
+        _sa_defaults_yaml=$'ob_service_accounts_enabled: true\nob_service_accounts_content: |\n'"$_indented"
+    else
+        _sa_defaults_yaml='ob_service_accounts_enabled: false'$'\n''ob_service_accounts_content: ""'
+    fi
+    ph_set SERVICE_ACCOUNTS_ENABLED_BOOL  "$_sa_enabled_bool"
+    ph_set SERVICE_ACCOUNTS_CONF_B64      "$_sa_conf_b64"
+    ph_set SERVICE_ACCOUNTS_FILE_LINE     "$_sa_file_line"
+    ph_set SERVICE_ACCOUNTS_DEFAULTS_YAML "$_sa_defaults_yaml"
 
     # Ansible-only: device-code auto-approval via LLNG session cookie.
     local _auto_approve_bool="false" _vars_prompt_block=""

--- a/admin-builder/ob-builder
+++ b/admin-builder/ob-builder
@@ -111,6 +111,12 @@ _OB_SA_US=$'\x1f'
 # about it at build time. Keep in sync with config.h.
 _OB_SA_DEFAULT_HOME_PREFIXES="/home /var/home"
 _OB_SA_DEFAULT_SHELLS="/bin/bash /bin/sh /usr/bin/bash /usr/bin/sh /bin/zsh /usr/bin/zsh /bin/dash /usr/bin/dash /bin/fish /usr/bin/fish"
+# Common Debian/Linux system users. A service account that reuses one of these is
+# still ACCEPTED (NSS `files` resolves it, PAM authorizes it by name), but the
+# existing account is used as-is — its shell/home/uid are NOT overridden by the
+# config (pam_openbastion only applies those when it CREATES the account). Most
+# of these ship with /usr/sbin/nologin, which breaks the login. We warn, not block.
+_OB_SA_SYSTEM_NAMES="root daemon bin sys sync games man lp mail news uucp proxy www-data backup list irc gnats nobody ftp sshd messagebus systemd-network systemd-resolve systemd-timesync _apt tss tcpdump"
 
 # Derived values populated after the questionnaire.
 PAM_MODE=""
@@ -457,6 +463,18 @@ warn_service_account_unapproved() {
     local name home shell uid gid pfx ok
     name=$(_sa_field 1 "$rec"); shell=$(_sa_field 5 "$rec"); home=$(_sa_field 6 "$rec")
     uid=$(_sa_field 8 "$rec"); gid=$(_sa_field 9 "$rec")
+    # Reserved system name: still accepted, but the existing account is used as-is
+    # (the config's shell/home/uid apply only to accounts ob-bastion creates).
+    for pfx in $_OB_SA_SYSTEM_NAMES; do
+        if [ "$name" = "$pfx" ]; then
+            log_warn "service account '$name' is a well-known system account. It is still accepted"
+            log_warn "  (matched by key fingerprint), but the EXISTING local account is used as-is —"
+            log_warn "  its shell/home/uid are NOT overridden by this config. Many system accounts use"
+            log_warn "  /usr/sbin/nologin, which breaks the login. Prefer a dedicated name (e.g. ob$name),"
+            log_warn "  or ensure '$name' already has a usable login shell on the target."
+            break
+        fi
+    done
     # NSS (libnss_openbastion) only synthesizes a service account when it has a
     # FIXED uid AND gid; sshd's pre-auth getpwnam then succeeds. Without them the
     # account is unreachable over SSH unless it already exists as a local user.

--- a/admin-builder/templates/ansible/role/defaults/main.yml.in
+++ b/admin-builder/templates/ansible/role/defaults/main.yml.in
@@ -52,6 +52,13 @@ ob_enable_hardening: @@ENABLE_HARDENING_BOOL@@
 ob_enable_audit_trace: @@ENABLE_AUDIT_TRACE_BOOL@@
 ob_disable_session_recorder: @@DISABLE_SESSION_RECORDER_BOOL@@
 
+# ── Service accounts (SSH-key-only local accounts) ────────────────────────────
+# Baked in at build time. ob_service_accounts_content is the full INI body of
+# /etc/open-bastion/service-accounts.conf (see doc/service-accounts.md). Override
+# per host/group via host_vars/group_vars to vary which accounts reach which
+# servers. Empty content + enabled:false means no service accounts are deployed.
+@@SERVICE_ACCOUNTS_DEFAULTS_YAML@@
+
 # ── Device-code auto-approval (Ansible-only, opt-in at build time) ───────────
 # When ob_ansible_auto_approve is true AND ob_llng_cookie is non-empty, the
 # enrollment task auto-approves the user_code via the LLNG /device endpoint

--- a/admin-builder/templates/ansible/role/tasks/main.yml.in
+++ b/admin-builder/templates/ansible/role/tasks/main.yml.in
@@ -85,5 +85,17 @@
     mode: '0600'
   notify: Restart sshd
 
+# Service accounts (SSH-key-only local accounts). Deployed only when enabled at
+# build time (or overridden via host_vars/group_vars). 0600 root:root, as the
+# PAM module requires.
+- name: Deploy service-accounts.conf
+  ansible.builtin.copy:
+    content: "{{ ob_service_accounts_content }}"
+    dest: /etc/open-bastion/service-accounts.conf
+    owner: root
+    group: root
+    mode: '0600'
+  when: ob_service_accounts_enabled | default(false)
+
 - name: Dispatch role-specific tasks
   ansible.builtin.include_tasks: "{{ ob_role }}.yml"

--- a/admin-builder/templates/ansible/role/templates/openbastion.conf.j2
+++ b/admin-builder/templates/ansible/role/templates/openbastion.conf.j2
@@ -50,6 +50,11 @@ log_level = warn
 audit_enabled = true
 audit_to_syslog = true
 
+# ── Service accounts (SSH-key-only local accounts) ─────────────────────────────
+{% if ob_service_accounts_enabled | default(false) %}
+service_accounts_file = /etc/open-bastion/service-accounts.conf
+{% endif %}
+
 # ── Backend: "accept only this bastion" ───────────────────────────────────────
 # Enforcement is NOT in this file. The old LLNG_BASTION_JWT transport was broken
 # (pam_getenv can't read a SendEnv var). It is replaced by certificate vouching:

--- a/admin-builder/templates/shell/installer.sh.in
+++ b/admin-builder/templates/shell/installer.sh.in
@@ -456,6 +456,9 @@ step_config() {
         log_info "[DRY-RUN]   client_id    = ${CLIENT_ID}"
         log_info "[DRY-RUN]   server_group = ${SERVER_GROUP}"
         log_info "[DRY-RUN]   client_secret= <$([ -n "${CLIENT_SECRET}" ] && echo 'set' || echo 'empty')>"
+        if [ -n "@@SERVICE_ACCOUNTS_CONF_B64@@" ]; then
+            log_info "[DRY-RUN] Would write /etc/open-bastion/service-accounts.conf (0600)"
+        fi
         log_info "[DRY-RUN] Would write /etc/ssh/open-bastion_ca.pub"
         if [ -n "@@KRL_B64@@" ]; then
             log_info "[DRY-RUN] Would write /etc/ssh/revoked_keys (KRL)"
@@ -491,6 +494,19 @@ OB_CONF_EOF
     chown root:root "${_conf_tmp}"
     mv -f "${_conf_tmp}" /etc/open-bastion/openbastion.conf
     log_info "Written: /etc/open-bastion/openbastion.conf (0600 root:root)"
+
+    # Deposit service-accounts.conf (SSH-key-only local accounts), if any were
+    # defined at build time. Embedded base64 to survive any characters; written
+    # 0600 root:root like the main config.
+    if [ -n "@@SERVICE_ACCOUNTS_CONF_B64@@" ]; then
+        local _sa_tmp
+        _sa_tmp=$(mktemp /etc/open-bastion/service-accounts.conf.XXXXXX)
+        printf '%s' "@@SERVICE_ACCOUNTS_CONF_B64@@" | base64 -d > "${_sa_tmp}"
+        chmod 0600 "${_sa_tmp}"
+        chown root:root "${_sa_tmp}"
+        mv -f "${_sa_tmp}" /etc/open-bastion/service-accounts.conf
+        log_info "Written: /etc/open-bastion/service-accounts.conf (0600 root:root)"
+    fi
 
     # Deposit SSH CA public key
     base64 -d > /etc/ssh/open-bastion_ca.pub.tmp << 'OB_CA_EOF'

--- a/admin-builder/templates/shell/openbastion.conf.in
+++ b/admin-builder/templates/shell/openbastion.conf.in
@@ -20,4 +20,6 @@ server_group = ##SERVER_GROUP##
 log_level = warn
 audit_enabled = true
 
+@@SERVICE_ACCOUNTS_FILE_LINE@@
+
 @@BASTION_BACKEND_BLOCK@@

--- a/doc/security/99-risk-reduce.md
+++ b/doc/security/99-risk-reduce.md
@@ -2,12 +2,12 @@
 
 ## Matrice des Risques Résiduels (Mode E)
 
-| Impact ↓ / Probabilité → | 1 - Très improbable                                         | 2 - Peu probable | 3 - Probable | 4 - Très probable |
-| ------------------------ | ----------------------------------------------------------- | ---------------- | ------------ | ----------------- |
-| **4 - Critique**         | R-S4, R-SA2                                                 | R-SA1            |              |                   |
-| **3 - Important**        | R5, R-S5, R-S11, R-S23                                      | R-S6             |              |                   |
-| **2 - Limité**           | R-S7, R-S9, R-S10, R-S12, R-S16, R-S17, R-S20, R-S21, R-S22 | R6, R-S8         |              |                   |
-| **1 - Négligeable**      | R0, R13, R-S14, R-S15, R-S19                                | R-S3, R-S18      |              |                   |
+| Impact ↓ / Probabilité → | 1 - Très improbable                                                | 2 - Peu probable | 3 - Probable | 4 - Très probable |
+| ------------------------ | ------------------------------------------------------------------ | ---------------- | ------------ | ----------------- |
+| **4 - Critique**         | R-S4, R-SA2                                                        | R-SA1            |              |                   |
+| **3 - Important**        | R5, R-S5, R-S11, R-S23, R-S24                                      | R-S6             |              |                   |
+| **2 - Limité**           | R-S7, R-S9, R-S10, R-S12, R-S16, R-S17, R-S20, R-S21, R-S22, R-S25 | R6, R-S8         |              |                   |
+| **1 - Négligeable**      | R0, R13, R-S14, R-S15, R-S19                                       | R-S3, R-S18      |              |                   |
 
 > **Note :** R-S3 et R-S15 ont été descendus d'un cran sur l'axe Impact grâce au **binding fingerprint SSH** introduit dans le plugin PamAccess ≥ 0.1.16. La vérification est effectuée côté LLNG à la fois sur `/pam/authorize` (à chaque ouverture de session SSH, phase PAM `account`) et sur `/pam/verify` (à chaque utilisation d'un token PAM pour sudo ou ré-authentification) : tant que l'empreinte de la clef SSH n'est pas présente, active et non révoquée dans la session persistante LLNG, ni la session SSH ni l'escalade sudo ne sont autorisées, indépendamment de la fraîcheur de la KRL locale. Voir [02-ssh-connection.md](02-ssh-connection.md) pour les détails.
 
@@ -284,3 +284,50 @@ Pistes pour réduire I à 1 :
 2. **Étendre les règles auditd** : ajouter `-S sendto -S sendmsg` (volumétrie acceptée pour bastion à faible trafic), `-S io_uring_enter` (rare en pratique), puis activer `-e 2` (locked rules) en production pour empêcher `auditctl -D` à chaud par un attaquant qui aurait obtenu root.
 3. **eBPF-based tracing** (Falco, sysdig) : alternative ou complément à auditd qui couvre des événements moins accessibles via syscalls (par ex. opérations sur file descriptors mémoire, écritures `pwrite` sur sockets). Plus coûteux en CPU mais plus expressif.
 4. **Signature cryptographique du recording à la clôture** : `gpg --detach-sign` ou similaire avec clé privée hors du bastion (HSM ou serveur de signature distant), pour détecter toute altération a posteriori. Complète R-S18 plutôt que R-S21 stricto sensu, mais participe à la même propriété d'intégrité.
+
+## Pistes d'Amélioration - Comptes de service
+
+Les comptes de service (`service-accounts.conf`) s'authentifient par **clé SSH
+directe**, en **local** sur chaque serveur, hors du modèle SSO/vouching. Ce sont
+des dérogations volontaires au contrôle centralisé : utiles pour l'automatisation
+(ansible, sauvegarde, CI/CD), mais ils ouvrent deux écarts à tracer.
+
+### R-S24 _(P=1, I=3)_ - Sudo de compte de service hors token SSO
+
+Le droit sudo d'un compte de service provient **uniquement** de
+`service-accounts.conf` (`sudo_allowed` / `sudo_nopasswd`) : `pam_openbastion`
+l'accorde localement et renvoie un succès **sans aucun appel LLNG**, **y compris
+en Mode E** où un humain doit présenter un token LLNG frais. Une clé de service
+avec `sudo_allowed` (a fortiori `sudo_nopasswd`) est donc un **privilège local
+permanent qui échappe à la porte sudo gouvernée par le SSO**.
+
+Pistes :
+
+1. **Minimiser** : n'accorder `sudo_allowed` qu'aux comptes qui en ont
+   réellement besoin ; préférer `sudo_nopasswd = false` et des règles `sudoers`
+   restreintes à des commandes précises plutôt qu'un sudo total.
+2. **Inventaire et rotation** : traiter chaque clé de service comme un secret de
+   longue durée (coffre-fort, rotation périodique, révocation à la sortie d'un
+   prestataire/outil). Recoupe le compte de secours de [R-S17](#r-s17-_p1-i2_---verrouillage-total-lockout).
+3. **Audit dédié** : journaliser/alerter sur l'usage sudo des comptes de service
+   (auditd `-k` distinct), puisqu'il n'apparaît pas dans les logs d'autorisation
+   LLNG.
+
+### R-S25 _(P=1, I=2)_ - Hop de compte de service via ProxyJump non enregistré
+
+Un compte de service ne peut pas utiliser `ob-ssh` (pas de voucher SSO), mais un
+`ssh -J bastion compte@backend` natif fonctionne s'il est configuré des deux
+côtés et que le bastion autorise le forwarding TCP. Or le `ForceCommand`
+(enregistreur de session) **ne couvre pas le canal `direct-tcpip`** : un tel hop
+**n'est pas enregistré** sur le bastion.
+
+Pistes :
+
+1. **Accès direct** : faire pointer les comptes de service directement sur les
+   serveurs cibles (la traçabilité repose alors sur l'auditd/les logs de la
+   cible) plutôt que de les relayer par le bastion.
+2. **`AllowTcpForwarding no` sur le bastion** : interdire explicitement le
+   forwarding pour fermer le canal de hop non enregistré (à arbitrer selon les
+   usages légitimes de forwarding sur le parc).
+3. **Ne pas configurer les comptes de service sur le bastion** lui-même quand ils
+   n'y ont pas de tâche locale, pour retirer la première marche du ProxyJump.

--- a/doc/service-accounts.md
+++ b/doc/service-accounts.md
@@ -135,6 +135,76 @@ paths) at build time, then:
 
 Service accounts apply to every role (bastion, backend, standalone).
 
+> **ob-builder deposits the fingerprint, not the public key.** The generated
+> `service-accounts.conf` carries `key_fingerprint` only. That is what
+> `pam_openbastion` checks, but it is **not** enough for `sshd` to accept the
+> connection — you must also authorize the public key at the SSH layer (next
+> section). This is an explicit, documented manual step.
+
+## Authorizing the public key at the SSH layer
+
+`pam_openbastion` validates the fingerprint **after** `sshd` has already accepted
+the public key. So `sshd` must be told the key is acceptable, by one of:
+
+- **`authorized_keys` (PAM modes A–D).** Put the public key in
+  `~<name>/.ssh/authorized_keys` (mode `0600`, owned by the account). Because the
+  service account is auto-created only on first login, you must **pre-create the
+  account and its `~/.ssh/authorized_keys`** (e.g. `useradd -m`, then drop the
+  key) — there is no home directory to read the file from otherwise.
+
+- **`AuthorizedKeysCommand` (required for Mode E, works in all modes).** Mode E
+  sets `AuthorizedKeysFile none`, so `authorized_keys` is ignored. Use the
+  `ob-service-account-keys` helper, which serves a public key from
+  `/etc/open-bastion/service-accounts.d/<name>.pub` (`root:root 0644`) and does
+  **not** depend on the account already existing:
+
+  ```
+  # /etc/ssh/sshd_config.d/09-open-bastion-service-keys.conf
+  AuthorizedKeysCommand /usr/local/sbin/ob-service-account-keys %u
+  AuthorizedKeysCommandUser nobody
+  ```
+
+  Drop each account's public key at `/etc/open-bastion/service-accounts.d/<name>.pub`
+  and reload `sshd`. The mere presence of the `.pub` lets `sshd` present the key;
+  `pam_openbastion` still re-validates the SHA256 fingerprint against
+  `service-accounts.conf` (which is `0600` and unreadable by the
+  `AuthorizedKeysCommandUser`), so an orphan `.pub` is accepted by `sshd` but
+  still rejected by PAM.
+
+`ExposeAuthInfo yes` must be set (the setups do this) so the fingerprint reaches
+the PAM module.
+
+## Reaching servers through a bastion (no ProxyJump recording)
+
+Service accounts authenticate by **direct SSH key**, independently of the bastion
+certificate-vouching used by human users. Consequences:
+
+- A service account does **not** use `ob-ssh`: that path needs an SSO-issued
+  bastion voucher, which a key-only account never obtains. So the seamless,
+  recorded bastion→backend hop is **not** available to service accounts.
+- The intended pattern is therefore to point service accounts **directly at the
+  servers they automate** (where their account is configured), not to relay
+  through the bastion.
+- A native `ssh -J bastion backup@backend` (ProxyJump) _can_ work if `backup` is
+  a configured service account on **both** the bastion and the backend and the
+  bastion permits TCP forwarding. **But the bastion's session recorder
+  (`ForceCommand`) does not cover the forwarded `direct-tcpip` channel**, so such
+  a hop is **not recorded**. Treat this as a deliberate audit bypass: if you need
+  service-account activity audited, run it against the target directly (the
+  target's own logs/auditd apply) rather than tunnelling through the bastion.
+
+## Sudo bypasses the SSO token (including in Mode E)
+
+A service account's sudo rights come **entirely** from `service-accounts.conf`
+(`sudo_allowed` / `sudo_nopasswd`): `pam_openbastion` grants them locally and
+returns success **without any LLNG call** — even in Mode E, where human users
+must present a fresh LLNG token to use sudo. A service key with `sudo_allowed`
+(especially `sudo_nopasswd`) is therefore a **standing local privilege that
+escapes the SSO-gated sudo model**. Grant it sparingly, prefer no sudo or
+tightly-scoped `sudoers` rules, and rotate/inventory these keys like any other
+long-lived credential. (You still need a `sudoers` entry permitting the account;
+PAM authorizes the _attempt_, `sudoers` authorizes _which commands_.)
+
 ## Per-Server Control
 
 Since the configuration file is local to each server, you control which service accounts

--- a/doc/service-accounts.md
+++ b/doc/service-accounts.md
@@ -114,12 +114,21 @@ ssh-keygen -lf /path/to/key.pub
 6. Account is created automatically if it doesn't exist
 7. sudo permissions are enforced based on configuration
 
-> **Do not reuse an existing system username.** `shell`, `home`, `uid` and `gid`
-> are applied only when the account is **created**. If the name already exists
-> (e.g. the Debian system users `backup`, `www-data`, `nobody`), the existing
-> account is used as-is — typically with `/usr/sbin/nologin`, which breaks the
-> login ("This account is currently not available."). Pick a dedicated name such
-> as `obdeploy`, `obbackup` or `ci-runner`.
+> **Reusing an existing account is allowed — but its own shell/home apply.**
+> `shell`, `home`, `uid` and `gid` from `service-accounts.conf` are applied only
+> when `pam_openbastion` **creates** the account. If the name already exists
+> locally, it is matched by fingerprint and authorized, but the **existing**
+> passwd entry is used unchanged. So:
+>
+> - A **dedicated new name** (e.g. `obdeploy`, `obbackup`, `ci-runner`) with a
+>   fixed `uid`/`gid` is the simplest, self-contained choice.
+> - An **existing account** (e.g. attaching a key to a real functional account)
+>   works **only if it already has a usable login shell**. Most Debian system
+>   users (`backup`, `www-data`, `nobody`, …) ship with `/usr/sbin/nologin`, so a
+>   login is refused ("This account is currently not available."). To use such a
+>   name, give the account a real shell yourself (e.g. `usermod -s /bin/sh
+>   backup`) — Open Bastion will not modify an existing system account for you.
+>   `ob-builder` warns when a name matches a well-known system account.
 
 ## Generating with ob-builder
 

--- a/doc/service-accounts.md
+++ b/doc/service-accounts.md
@@ -97,6 +97,44 @@ ssh-keygen -lf /path/to/key.pub
 6. Account is created automatically if it doesn't exist
 7. sudo permissions are enforced based on configuration
 
+## Generating with ob-builder
+
+Instead of hand-writing `service-accounts.conf` on each server, you can declare
+service accounts once in [`ob-builder`](../admin-builder/README.md) and have them
+baked into the generated shell installer and/or Ansible role.
+
+**Interactive:** the questionnaire asks whether to define service accounts and
+loops over name / fingerprint / sudo / shell / home for each.
+
+**Non-interactive (`--config`):** add a `service_accounts:` list to the YAML:
+
+```yaml
+service_accounts:
+  - name: ansible
+    key_fingerprint: "SHA256:abc123def456..."
+    sudo_allowed: true
+    sudo_nopasswd: true
+    shell: /bin/bash
+    home: /var/lib/ansible
+    gecos: Ansible Automation
+  - name: backup
+    key_fingerprint: "SHA256:xyz789..."
+    sudo_allowed: false
+    shell: /bin/sh
+```
+
+ob-builder validates each entry (name, fingerprint format, absolute shell/home
+paths) at build time, then:
+
+- the **shell installer** writes `/etc/open-bastion/service-accounts.conf`
+  (`0600 root:root`) and sets `service_accounts_file` in `openbastion.conf`;
+- the **Ansible role** carries the accounts as `ob_service_accounts_content`
+  (overridable per host/group via `host_vars` / `group_vars` to vary which
+  accounts reach which servers) and deploys the file when
+  `ob_service_accounts_enabled` is true.
+
+Service accounts apply to every role (bastion, backend, standalone).
+
 ## Per-Server Control
 
 Since the configuration file is local to each server, you control which service accounts

--- a/doc/service-accounts.md
+++ b/doc/service-accounts.md
@@ -42,6 +42,23 @@ shell = /bin/sh
 home = /var/lib/backup
 ```
 
+> **⚠️ `home` and `shell` must be within the approved lists, or the account is
+> silently dropped.** `pam_openbastion` validates each account at load and
+> **discards** any whose `home` is not under `approved_home_prefixes` (default
+> `/home:/var/home`) or whose `shell` is not in `approved_shells` (default:
+> `/bin/bash`, `/bin/sh`, `/bin/zsh`, `/bin/dash`, `/bin/fish` and their
+> `/usr/bin` variants). A dropped account is not recognized as a service account,
+> so its login falls through to LLNG and is refused with "user not found". The
+> `/var/lib/...` homes above therefore require widening the prefix list:
+>
+> ```ini
+> # /etc/open-bastion/openbastion.conf
+> approved_home_prefixes = /home:/var/home:/var/lib
+> ```
+>
+> Either keep service-account homes under `/home` (works out of the box) or set
+> `approved_home_prefixes` accordingly.
+
 **Security requirements for this file:**
 
 - Owned by root (uid 0)
@@ -82,10 +99,10 @@ ssh-keygen -lf /path/to/key.pub
 | `sudo_allowed`    | No       | Allow sudo access (default: false)                 |
 | `sudo_nopasswd`   | No       | Sudo without password (default: false)             |
 | `gecos`           | No       | User description                                   |
-| `shell`           | No       | Login shell (must be in approved_shells)           |
-| `home`            | No       | Home directory (must match approved_home_prefixes) |
-| `uid`             | No       | Fixed UID (0 = auto-assign)                        |
-| `gid`             | No       | Fixed GID (0 = auto-assign)                        |
+| `shell`           | No       | Login shell — must be in `approved_shells` (default: common shells) or the account is dropped |
+| `home`            | No       | Home directory — must be under `approved_home_prefixes` (default `/home:/var/home`) or the account is dropped |
+| `uid`             | See note | Fixed UID. **Required (with `gid`) for SSH-reachable accounts** — NSS resolves them only when both are set; `0` = auto-assign (works only if the account already exists locally) |
+| `gid`             | See note | Fixed GID. See `uid` |
 
 ## How It Works
 
@@ -96,6 +113,13 @@ ssh-keygen -lf /path/to/key.pub
 5. If fingerprint matches, account is authorized locally (no LLNG call needed)
 6. Account is created automatically if it doesn't exist
 7. sudo permissions are enforced based on configuration
+
+> **Do not reuse an existing system username.** `shell`, `home`, `uid` and `gid`
+> are applied only when the account is **created**. If the name already exists
+> (e.g. the Debian system users `backup`, `www-data`, `nobody`), the existing
+> account is used as-is — typically with `/usr/sbin/nologin`, which breaks the
+> login ("This account is currently not available."). Pick a dedicated name such
+> as `obdeploy`, `obbackup` or `ci-runner`.
 
 ## Generating with ob-builder
 
@@ -110,21 +134,28 @@ loops over name / fingerprint / sudo / shell / home for each.
 
 ```yaml
 service_accounts:
-  - name: ansible
+  - name: ci-ansible          # avoid system names like 'ansible' only if they exist; use a dedicated name
     key_fingerprint: "SHA256:abc123def456..."
     sudo_allowed: true
     sudo_nopasswd: true
     shell: /bin/bash
-    home: /var/lib/ansible
+    home: /home/ci-ansible    # under an approved prefix (/home, /var/home)
     gecos: Ansible Automation
-  - name: backup
+    uid: 6001                 # fixed uid+gid → NSS-resolvable → reachable over SSH
+    gid: 6001
+  - name: obbackup
     key_fingerprint: "SHA256:xyz789..."
     sudo_allowed: false
     shell: /bin/sh
+    home: /home/obbackup
+    uid: 6002
+    gid: 6002
 ```
 
 ob-builder validates each entry (name, fingerprint format, absolute shell/home
-paths) at build time, then:
+paths) at build time — and **warns** when a `home`/`shell` falls outside the
+module defaults (it would otherwise be silently dropped on the target; see the
+warning above) — then:
 
 - the **shell installer** writes `/etc/open-bastion/service-accounts.conf`
   (`0600 root:root`) and sets `service_accounts_file` in `openbastion.conf`;
@@ -173,6 +204,24 @@ the public key. So `sshd` must be told the key is acceptable, by one of:
 
 `ExposeAuthInfo yes` must be set (the setups do this) so the fingerprint reaches
 the PAM module.
+
+### The account must be resolvable (fixed `uid`/`gid`)
+
+`sshd` runs `getpwnam(<user>)` **before** authentication and refuses unknown
+users ("Invalid user"). A brand-new service account therefore has to be
+resolvable up front, which `nss_openbastion` does — **but only when the account
+has a fixed `uid` *and* `gid`** (`nss/libnss_openbastion.c`); otherwise NSS skips
+it and the login is refused before PAM ever runs. So, for an SSH-reachable
+service account that does not already exist as a local user:
+
+- set both `uid` and `gid` (also gives stable, fleet-consistent ownership), **or**
+- pre-create the account locally (`useradd`), in which case the `files` NSS
+  source resolves it.
+
+`ob-builder` warns at build time when a service account lacks `uid`/`gid`. The
+auto-create-on-first-login behaviour fills in the home directory etc. during the
+session phase, but it cannot help sshd's pre-auth lookup — hence this
+requirement.
 
 ## Reaching servers through a bastion (no ProxyJump recording)
 

--- a/local-test/README.md
+++ b/local-test/README.md
@@ -88,6 +88,16 @@ the cookie land in `local-test/.work/` (git-ignored).
 4. **Verify.** With the dwho SSO cert: log into the bastion, `getent passwd dwho`
    (NSS), `ob-ssh` hop to a backend, `ob-scp` bastion→backend and
    backend→backend (`scp -3`).
+5. **Service account (shell path).** `deploy-shell.sh` also declares a `backup`
+   service account in the standalone `ob-builder` config (fingerprint = a
+   lab-generated key), so the generated installer deposits a matching
+   `service-accounts.conf`. Because `ob-builder` writes only the fingerprint, the
+   harness performs the **documented manual SSH-layer step** before setup locks
+   port 22 — it installs the `ob-service-account-keys` `AuthorizedKeysCommand`
+   helper + `service-accounts.d/backup.pub` (this also covers Mode E's
+   `AuthorizedKeysFile none`). Then it asserts `backup` logs in with its key,
+   with no SSO and no bastion certificate. See
+   [`doc/service-accounts.md`](../doc/service-accounts.md).
 
 ## Lab-only quirks
 

--- a/local-test/deploy-shell.sh
+++ b/local-test/deploy-shell.sh
@@ -42,6 +42,7 @@ phase "Bootstrap VMs (incl. package install — shell path uses --skip-install)"
 for v in "${ALL_VMS[@]}"; do bootstrap_vm "$v" 1; done
 get_cookie
 mint_dwho_cert   # so the connection-phase + standalone assertions actually run
+[ -n "$STANDALONE_VM" ] && gen_service_key   # lab key for the service-account check
 
 # ── Phase 1: bastion installer — enrol, read bastion_id, then setup ──────────
 phase "Phase 1 — bastion (ob-builder --output-shell, scenario=$SCENARIO)"
@@ -82,8 +83,27 @@ done
 if [ -n "$STANDALONE_VM" ]; then
     phase "Phase 3 — standalone (ob-builder --output-shell, scenario=$SCENARIO)"
     sed "s/^scenario:.*/scenario: $SCENARIO/" "$CONFIG_DIR/build-standalone.yml" > "$WORK/build-standalone.yml"
+    # Exercise the ob-builder service-keys feature: declare a 'backup' service
+    # account whose fingerprint is the lab key's, so the generated installer
+    # deposits a matching service-accounts.conf. (verify_service_accounts then
+    # logs in as backup with that key.)
+    if [ -n "$SVC_FP" ]; then
+        cat >> "$WORK/build-standalone.yml" <<EOF
+
+service_accounts:
+  - name: backup
+    key_fingerprint: "$SVC_FP"
+    sudo_allowed: false
+    shell: /bin/bash
+    home: /var/lib/backup
+    gecos: Lab Backup Service Account
+EOF
+    fi
     obbuild --config "$WORK/build-standalone.yml" --output-shell "$WORK/boot-standalone.sh" >"$WORK/gen-standalone.log" 2>&1 \
-        && ok "generated standalone installer" || { bad "ob-builder standalone failed"; cat "$WORK/gen-standalone.log"; }
+        && ok "generated standalone installer (incl. service account)" || { bad "ob-builder standalone failed"; cat "$WORK/gen-standalone.log"; }
+    # SSH-layer authorization for the service account — the documented manual step
+    # ob-builder does not do. Must run before setup locks port 22.
+    provision_service_helper "$STANDALONE_VM"
     get_cookie   # refresh before enrolling: the initial cookie may have expired by now (short lab TTLs)
     ( approve_device "${IP[$STANDALONE_VM]}" ) &
     run_installer "$STANDALONE_VM" "$WORK/boot-standalone.sh" >"$WORK/$STANDALONE_VM.log" 2>&1
@@ -94,4 +114,5 @@ fi
 
 verify_e2e
 verify_standalone
+verify_service_accounts
 summary

--- a/local-test/deploy-shell.sh
+++ b/local-test/deploy-shell.sh
@@ -83,20 +83,23 @@ done
 if [ -n "$STANDALONE_VM" ]; then
     phase "Phase 3 — standalone (ob-builder --output-shell, scenario=$SCENARIO)"
     sed "s/^scenario:.*/scenario: $SCENARIO/" "$CONFIG_DIR/build-standalone.yml" > "$WORK/build-standalone.yml"
-    # Exercise the ob-builder service-keys feature: declare a 'backup' service
-    # account whose fingerprint is the lab key's, so the generated installer
-    # deposits a matching service-accounts.conf. (verify_service_accounts then
-    # logs in as backup with that key.)
+    # Exercise the ob-builder service-keys feature: declare a service account
+    # ($SVC_NAME, a non-system name) whose fingerprint is the lab key's, so the
+    # generated installer deposits a matching service-accounts.conf.
+    # verify_service_accounts then logs in as $SVC_NAME with that key. home is
+    # under /home (an approved prefix) so pam_openbastion does not drop it.
     if [ -n "$SVC_FP" ]; then
         cat >> "$WORK/build-standalone.yml" <<EOF
 
 service_accounts:
-  - name: backup
+  - name: $SVC_NAME
     key_fingerprint: "$SVC_FP"
     sudo_allowed: false
     shell: /bin/bash
-    home: /var/lib/backup
-    gecos: Lab Backup Service Account
+    home: /home/$SVC_NAME
+    gecos: Lab Deploy Service Account
+    uid: 6100
+    gid: 6100
 EOF
     fi
     obbuild --config "$WORK/build-standalone.yml" --output-shell "$WORK/boot-standalone.sh" >"$WORK/gen-standalone.log" 2>&1 \

--- a/local-test/lib.sh
+++ b/local-test/lib.sh
@@ -46,6 +46,10 @@ LLNG="${LLNG:-$(command -v llng || true)}"; [ -n "$LLNG" ] || LLNG="$HOME/bin/ll
 # service-accounts.conf matches this very key (see deploy-shell.sh).
 SVC_KEY="${OB_SVC_KEY:-$WORK/svc_backup}"
 SVC_FP=""
+# Service-account username for the check. Must NOT collide with a system user
+# (e.g. 'backup', 'www-data'): pam_openbastion only sets shell/home when it
+# CREATES the account, so an existing system user (nologin) would break login.
+SVC_NAME="${OB_SVC_NAME:-obdeploy}"
 
 SSH_BASE=(-o IdentityAgent=none -o IdentitiesOnly=yes
           -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null
@@ -317,19 +321,19 @@ provision_service_helper(){
     scp "${SSH_BASE[@]}" "$helper" "debian@$ip:/tmp/ob-service-account-keys" >/dev/null 2>&1 \
         || { bad "$v: could not copy service helper"; return 0; }
     local pub; pub=$(cat "$SVC_KEY.pub")
-    if dssh "$ip" "sudo OB_SVC_PUB='$pub' bash -s" <<'BS' >/dev/null 2>&1
+    if dssh "$ip" "sudo OB_SVC_PUB='$pub' OB_SVC_NAME='$SVC_NAME' bash -s" <<'BS' >/dev/null 2>&1
 set -e
 install -m 0755 -o root -g root /tmp/ob-service-account-keys /usr/local/sbin/ob-service-account-keys
 mkdir -p /etc/open-bastion/service-accounts.d
-printf '%s\n' "$OB_SVC_PUB" > /etc/open-bastion/service-accounts.d/backup.pub
-chown root:root /etc/open-bastion/service-accounts.d/backup.pub
-chmod 0644 /etc/open-bastion/service-accounts.d/backup.pub
+printf '%s\n' "$OB_SVC_PUB" > "/etc/open-bastion/service-accounts.d/${OB_SVC_NAME}.pub"
+chown root:root "/etc/open-bastion/service-accounts.d/${OB_SVC_NAME}.pub"
+chmod 0644 "/etc/open-bastion/service-accounts.d/${OB_SVC_NAME}.pub"
 cat > /etc/ssh/sshd_config.d/09-open-bastion-service-keys.conf <<'CONF'
 AuthorizedKeysCommand /usr/local/sbin/ob-service-account-keys %u
 AuthorizedKeysCommandUser nobody
 CONF
 BS
-    then ok "$v: provisioned service-account SSH authorization (backup.pub + AuthorizedKeysCommand)"
+    then ok "$v: provisioned service-account SSH authorization (${SVC_NAME}.pub + AuthorizedKeysCommand)"
     else bad "$v: failed to provision service-account SSH authorization"; fi
 }
 
@@ -338,7 +342,7 @@ BS
 verify_service_accounts(){
     local v="${1:-$STANDALONE_VM}"
     [ -n "$v" ] || return 0
-    phase "Assertions — service account 'backup' on $v (direct key auth)"
+    phase "Assertions — service account '$SVC_NAME' on $v (direct key auth)"
     if [ -z "$SVC_FP" ] || [ ! -f "$SVC_KEY" ]; then
         skip "service-account check — no lab service key (gen_service_key not run)"
         return 0
@@ -350,9 +354,9 @@ verify_service_accounts(){
     # Exit 0 ⇒ sshd accepted the key (AuthorizedKeysCommand) AND pam_openbastion
     # matched the fingerprint in service-accounts.conf and authorized the account
     # (auto-creating it). A wrong/unknown key would fail with 255.
-    if "${S[@]}" "backup@$ip" true >/dev/null 2>&1; then
-        ok "service account 'backup' logs in with its key (fingerprint matched, no SSO)"
+    if "${S[@]}" "$SVC_NAME@$ip" true >/dev/null 2>&1; then
+        ok "service account '$SVC_NAME' logs in with its key (fingerprint matched, no SSO)"
     else
-        bad "service account 'backup' login failed — see sshd/pam logs on $v"
+        bad "service account '$SVC_NAME' login failed — see sshd/pam logs on $v"
     fi
 }

--- a/local-test/lib.sh
+++ b/local-test/lib.sh
@@ -41,6 +41,12 @@ SSO_USER="${OB_SSO_USER:-dwho}"; SSO_PASS="${OB_SSO_PASS:-dwho}"
 
 LLNG="${LLNG:-$(command -v llng || true)}"; [ -n "$LLNG" ] || LLNG="$HOME/bin/llng"
 
+# Service-account lab key. Generated once per run; SVC_FP is its SHA256
+# fingerprint, injected into the standalone ob-builder config so the deployed
+# service-accounts.conf matches this very key (see deploy-shell.sh).
+SVC_KEY="${OB_SVC_KEY:-$WORK/svc_backup}"
+SVC_FP=""
+
 SSH_BASE=(-o IdentityAgent=none -o IdentitiesOnly=yes
           -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null
           -o ConnectTimeout=8 -i "$SSH_KEY")
@@ -281,5 +287,72 @@ verify_standalone(){
             "${D[@]}" "dwho@$s" 'grep -q pam_openbastion /etc/pam.d/sudo'
         check "standalone /etc/pam.d/sudo-i requires LLNG token (pam_openbastion)" \
             "${D[@]}" "dwho@$s" 'grep -q pam_openbastion /etc/pam.d/sudo-i'
+    fi
+}
+
+# ── service-account verification ──────────────────────────────────────────────
+# Validates the ob-builder service-keys feature end-to-end: ob-builder deposits
+# service-accounts.conf (fingerprint only), and we perform the documented manual
+# SSH-layer authorization (the ob-service-account-keys AuthorizedKeysCommand
+# helper, which also covers Mode E's `AuthorizedKeysFile none`), then assert the
+# 'backup' service account logs in with its own key — no SSO, no bastion cert.
+
+# Generate the lab service key once and compute its SHA256 fingerprint.
+gen_service_key(){
+    [ -f "$SVC_KEY" ] || ssh-keygen -t ed25519 -f "$SVC_KEY" -N "" -C "oblab-svc-backup" -q
+    SVC_FP=$(ssh-keygen -lf "$SVC_KEY.pub" 2>/dev/null | awk '{print $2}')
+}
+
+# Provision the SSH-layer authorization for the 'backup' service account on <vm>.
+# This is the manual step ob-builder deliberately does NOT do (it only writes the
+# fingerprint to service-accounts.conf): deploy the ob-service-account-keys
+# AuthorizedKeysCommand helper + the account's public key so sshd will present
+# it. Works in all PAM modes, including Mode E (AuthorizedKeysFile none). MUST
+# run while the debian mgmt user can still SSH — i.e. before *-setup locks port 22.
+provision_service_helper(){
+    local v="$1" ip="${IP[$1]}"
+    local helper="$REPO_ROOT/scripts/ob-service-account-keys"
+    [ -f "$helper" ] || { skip "service helper missing ($helper)"; return 0; }
+    [ -n "$SVC_FP" ] || { skip "service key not generated"; return 0; }
+    scp "${SSH_BASE[@]}" "$helper" "debian@$ip:/tmp/ob-service-account-keys" >/dev/null 2>&1 \
+        || { bad "$v: could not copy service helper"; return 0; }
+    local pub; pub=$(cat "$SVC_KEY.pub")
+    if dssh "$ip" "sudo OB_SVC_PUB='$pub' bash -s" <<'BS' >/dev/null 2>&1
+set -e
+install -m 0755 -o root -g root /tmp/ob-service-account-keys /usr/local/sbin/ob-service-account-keys
+mkdir -p /etc/open-bastion/service-accounts.d
+printf '%s\n' "$OB_SVC_PUB" > /etc/open-bastion/service-accounts.d/backup.pub
+chown root:root /etc/open-bastion/service-accounts.d/backup.pub
+chmod 0644 /etc/open-bastion/service-accounts.d/backup.pub
+cat > /etc/ssh/sshd_config.d/09-open-bastion-service-keys.conf <<'CONF'
+AuthorizedKeysCommand /usr/local/sbin/ob-service-account-keys %u
+AuthorizedKeysCommandUser nobody
+CONF
+BS
+    then ok "$v: provisioned service-account SSH authorization (backup.pub + AuthorizedKeysCommand)"
+    else bad "$v: failed to provision service-account SSH authorization"; fi
+}
+
+# Assert the 'backup' service account authenticates with its key (direct,
+# no SSO/cert). Run after the target is deployed (service-accounts.conf present).
+verify_service_accounts(){
+    local v="${1:-$STANDALONE_VM}"
+    [ -n "$v" ] || return 0
+    phase "Assertions — service account 'backup' on $v (direct key auth)"
+    if [ -z "$SVC_FP" ] || [ ! -f "$SVC_KEY" ]; then
+        skip "service-account check — no lab service key (gen_service_key not run)"
+        return 0
+    fi
+    local ip="${IP[$v]}"
+    local S=(ssh -i "$SVC_KEY" -o IdentityAgent=none -o IdentitiesOnly=yes
+             -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null
+             -o NumberOfPasswordPrompts=0 -o ConnectTimeout=15)
+    # Exit 0 ⇒ sshd accepted the key (AuthorizedKeysCommand) AND pam_openbastion
+    # matched the fingerprint in service-accounts.conf and authorized the account
+    # (auto-creating it). A wrong/unknown key would fail with 255.
+    if "${S[@]}" "backup@$ip" true >/dev/null 2>&1; then
+        ok "service account 'backup' logs in with its key (fingerprint matched, no SSO)"
+    else
+        bad "service account 'backup' login failed — see sshd/pam logs on $v"
     fi
 }

--- a/tests/test_ob_builder_service_accounts.sh
+++ b/tests/test_ob_builder_service_accounts.sh
@@ -1,0 +1,182 @@
+#!/bin/bash
+#
+# Test suite for ob-builder service-account support.
+#
+# Sources ob-builder (with `set -euo pipefail` and the `main "$@"` call
+# stripped) and exercises the service-account parsing, validation and INI
+# rendering helpers directly. OB_BUILDER_LIB_DIR / OB_BUILDER_SHARE are exported
+# so ob-builder's lib/template auto-detection short-circuits.
+#
+
+set -u
+
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BUILDER="$SCRIPT_DIR/admin-builder/ob-builder"
+export OB_BUILDER_LIB_DIR="$SCRIPT_DIR/admin-builder/lib"
+export OB_BUILDER_SHARE="$SCRIPT_DIR/admin-builder"
+
+TEST_TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TEST_TMPDIR"' EXIT
+
+test_pass() { echo -e "${GREEN}✓${NC} $1"; ((TESTS_PASSED++)); }
+test_fail() {
+    echo -e "${RED}✗${NC} $1"
+    [ -n "${2:-}" ] && echo -e "  ${YELLOW}Details:${NC} $2"
+    ((TESTS_FAILED++))
+}
+
+# Source ob-builder definitions into THIS shell (functions + globals), with the
+# top-level `set -euo pipefail` and the final `main "$@"` removed so nothing
+# runs and a failing helper does not kill the harness.
+# shellcheck disable=SC1090
+eval "$(sed -e 's/^set -euo pipefail$//' -e '/^main "\$@"$/d' "$BUILDER")"
+BUILD_DATE="2026-01-01T00:00:00Z"
+
+# Test 1: syntax check
+test_syntax() {
+    if bash -n "$BUILDER" 2>/dev/null; then
+        test_pass "Syntax check: bash -n passes"
+    else
+        test_fail "Syntax check failed"
+    fi
+}
+
+# Test 2: validators mirror the C rules
+test_validators() {
+    local ok=true
+    is_valid_service_username "ansible"  || ok=false
+    is_valid_service_username "_svc-1"   || ok=false
+    is_valid_service_username "Ansible"  && ok=false   # uppercase first char
+    is_valid_service_username "1svc"     && ok=false   # leading digit
+    is_valid_fingerprint "SHA256:abcDEF123+/="  || ok=false
+    is_valid_fingerprint "MD5:aa:bb:cc"  || ok=false
+    is_valid_fingerprint "abc123"        && ok=false   # no prefix
+    is_valid_fingerprint "SHA256:bad spaces" && ok=false
+    is_valid_abs_path ""                 || ok=false   # empty OK
+    is_valid_abs_path "/bin/bash"        || ok=false
+    is_valid_abs_path "relative/path"    && ok=false
+    $ok && test_pass "validators: username / fingerprint / path" \
+         || test_fail "validators returned wrong result"
+}
+
+# Test 3: parse a YAML service_accounts block
+test_parse_block() {
+    local cfg="$TEST_TMPDIR/cfg.yml"
+    cat > "$cfg" <<'YML'
+deployment_slug: demo
+portal_url: https://sso.example.com
+service_accounts:
+  - name: ansible
+    key_fingerprint: "SHA256:abc123"
+    sudo_allowed: true
+    sudo_nopasswd: true
+    shell: /bin/bash
+    home: /var/lib/ansible
+    gecos: Ansible Automation
+  - name: backup
+    key_fingerprint: "SHA256:xyz789"
+    sudo_allowed: false
+    shell: /bin/sh
+auto_enroll_setup: prompt
+YML
+    SERVICE_ACCOUNTS_RECORDS=()
+    _parse_service_accounts_block "$cfg"
+
+    local ok=true
+    [ "${#SERVICE_ACCOUNTS_RECORDS[@]}" -eq 2 ] || { ok=false; echo "  count=${#SERVICE_ACCOUNTS_RECORDS[@]}"; }
+    [ "$(_sa_field 1 "${SERVICE_ACCOUNTS_RECORDS[0]}")" = "ansible" ] || ok=false
+    [ "$(_sa_field 2 "${SERVICE_ACCOUNTS_RECORDS[0]}")" = "SHA256:abc123" ] || ok=false
+    [ "$(_sa_field 3 "${SERVICE_ACCOUNTS_RECORDS[0]}")" = "true" ] || ok=false
+    [ "$(_sa_field 5 "${SERVICE_ACCOUNTS_RECORDS[0]}")" = "/bin/bash" ] || ok=false
+    [ "$(_sa_field 7 "${SERVICE_ACCOUNTS_RECORDS[0]}")" = "Ansible Automation" ] || ok=false
+    [ "$(_sa_field 1 "${SERVICE_ACCOUNTS_RECORDS[1]}")" = "backup" ] || ok=false
+    [ "$(_sa_field 3 "${SERVICE_ACCOUNTS_RECORDS[1]}")" = "false" ] || ok=false
+    $ok && test_pass "parse: service_accounts block → 2 records, fields correct" \
+         || test_fail "parse: block parsing wrong"
+}
+
+# Test 4: a config with no service_accounts yields zero records
+test_parse_none() {
+    local cfg="$TEST_TMPDIR/none.yml"
+    cat > "$cfg" <<'YML'
+deployment_slug: demo
+portal_url: https://sso.example.com
+YML
+    SERVICE_ACCOUNTS_RECORDS=()
+    _parse_service_accounts_block "$cfg"
+    [ "${#SERVICE_ACCOUNTS_RECORDS[@]}" -eq 0 ] \
+        && test_pass "parse: no service_accounts → 0 records" \
+        || test_fail "parse: expected 0 records, got ${#SERVICE_ACCOUNTS_RECORDS[@]}"
+}
+
+# Test 5: record validation
+test_record_validation() {
+    local ok=true
+    validate_service_account_record "$(_sa_pack ansible SHA256:abc true false /bin/bash /var/lib/ansible '' '' '')" || ok=false
+    validate_service_account_record "$(_sa_pack BadName SHA256:abc false false '' '' '' '' '')" && ok=false
+    validate_service_account_record "$(_sa_pack svc nofingerprint false false '' '' '' '' '')" && ok=false
+    validate_service_account_record "$(_sa_pack svc SHA256:abc false false relpath '' '' '' '')" && ok=false
+    $ok && test_pass "validate_service_account_record: accepts valid, rejects bad" \
+         || test_fail "record validation wrong"
+}
+
+# Test 6: INI rendering
+test_render_conf() {
+    SERVICE_ACCOUNTS_RECORDS=(
+        "$(_sa_pack ansible SHA256:abc123 true true /bin/bash /var/lib/ansible 'Ansible Automation' '' '')"
+        "$(_sa_pack backup SHA256:xyz789 false false /bin/sh '' '' '' '')"
+    )
+    local out
+    out=$(_render_service_accounts_conf)
+    local ok=true
+    grep -q '^\[ansible\]$'                      <<<"$out" || ok=false
+    grep -q '^key_fingerprint = SHA256:abc123$'  <<<"$out" || ok=false
+    grep -q '^sudo_allowed = true$'              <<<"$out" || ok=false
+    grep -q '^sudo_nopasswd = true$'             <<<"$out" || ok=false
+    grep -q '^gecos = Ansible Automation$'       <<<"$out" || ok=false
+    grep -q '^home = /var/lib/ansible$'          <<<"$out" || ok=false
+    grep -q '^\[backup\]$'                       <<<"$out" || ok=false
+    grep -q '^sudo_allowed = false$'             <<<"$out" || ok=false
+    # backup has no home/gecos → those keys absent in its section is not trivially
+    # grep-able, but the file must not carry an empty 'home =' line anywhere.
+    grep -q '^home = $'                          <<<"$out" && ok=false
+    $ok && test_pass "render: INI output well-formed" \
+         || test_fail "render: INI output wrong" "$out"
+}
+
+echo "=========================================="
+echo "Testing ob-builder service-account support"
+echo "=========================================="
+echo ""
+
+test_syntax
+test_validators
+test_parse_block
+test_parse_none
+test_record_validation
+test_render_conf
+
+echo ""
+echo "=========================================="
+echo "Test Summary"
+echo "=========================================="
+echo -e "${GREEN}Passed:${NC} $TESTS_PASSED"
+echo -e "${RED}Failed:${NC} $TESTS_FAILED"
+echo "Total:  $((TESTS_PASSED + TESTS_FAILED))"
+echo ""
+
+if [ $TESTS_FAILED -eq 0 ]; then
+    echo -e "${GREEN}All tests passed!${NC}"
+    exit 0
+else
+    echo -e "${RED}Some tests failed.${NC}"
+    exit 1
+fi

--- a/tests/test_ob_builder_service_accounts.sh
+++ b/tests/test_ob_builder_service_accounts.sh
@@ -134,9 +134,12 @@ test_render_conf() {
         "$(_sa_pack ansible SHA256:abc123 true true /bin/bash /var/lib/ansible 'Ansible Automation' '' '')"
         "$(_sa_pack backup SHA256:xyz789 false false /bin/sh '' '' '' '')"
     )
-    local out
-    out=$(_render_service_accounts_conf)
+    local out rc
+    out=$(_render_service_accounts_conf); rc=$?
     local ok=true
+    # Must return 0 even when the last account has no uid/gid — otherwise the
+    # `$(...)` assignment trips `set -e` in ob-builder (regression guard).
+    [ "$rc" -eq 0 ] || { ok=false; echo "  non-zero return: $rc"; }
     grep -q '^\[ansible\]$'                      <<<"$out" || ok=false
     grep -q '^key_fingerprint = SHA256:abc123$'  <<<"$out" || ok=false
     grep -q '^sudo_allowed = true$'              <<<"$out" || ok=false


### PR DESCRIPTION
## Summary

`ob-builder` can now declare **service keys** (service-account SSH keys) as part
of the generated deployment artefacts, so admins declare accounts like
`ansible`, `backup` or CI/CD once at build time instead of hand-editing
`/etc/open-bastion/service-accounts.conf` on every server.

**No PAM-module change** — `src/service_account.c` already parses that file; this
PR is entirely in the builder + templates + docs.

## What's new
- **Interactive questionnaire** step (applies to every role): loops over
  name / fingerprint / sudo / shell / home / gecos, validating each field.
- **Non-interactive `--config`**: a `service_accounts:` YAML list, parsed by a
  dedicated, **yq-independent** block scanner so behaviour is identical whether
  or not `yq` is installed (the flat parsers can't read a list).
- **Build-time validation** mirroring `src/service_account.c`: username
  (`^[a-z_][a-z0-9_-]*$`), fingerprint (`SHA256:`/`MD5:` + base64 charset),
  absolute shell/home; duplicate account names rejected.
- **Shell installer** writes `/etc/open-bastion/service-accounts.conf`
  (`0600 root:root`) from an embedded base64 blob and sets
  `service_accounts_file` in `openbastion.conf`.
- **Ansible role** carries the accounts as `ob_service_accounts_content`
  (a YAML block scalar, overridable per host/group via `host_vars`/`group_vars`)
  and deploys the file when `ob_service_accounts_enabled` is true.

## Config example
```yaml
service_accounts:
  - name: ansible
    key_fingerprint: "SHA256:abc123..."   # ssh-keygen -lf key.pub
    sudo_allowed: true
    sudo_nopasswd: true
    shell: /bin/bash
    home: /var/lib/ansible
    gecos: Ansible Automation
  - name: backup
    key_fingerprint: "SHA256:xyz789..."
    sudo_allowed: false
    shell: /bin/sh
```

## Files
- `admin-builder/ob-builder`: record model, YAML block parser, interactive loop,
  validation, INI renderer, placeholder map, recap line, usage text.
- `admin-builder/lib/validators.sh`: `is_valid_service_username`,
  `is_valid_fingerprint`, `is_valid_abs_path`.
- Templates: shell `openbastion.conf.in` + `installer.sh.in` (deposit), Ansible
  `defaults/main.yml.in` + `openbastion.conf.j2` + `tasks/main.yml.in`.
- Docs: `doc/service-accounts.md` (ob-builder integration), `ob-builder(1)`,
  `admin-builder/README.md`, `CHANGELOG.md`.

## Testing
- `tests/test_ob_builder_service_accounts.sh` (picked up by CI's
  `tests/test_ob_*.sh` loop): validators, YAML block parsing (2 accounts +
  none), record validation accept/reject, INI rendering — 6/6 pass.
- End-to-end render check (offline, with a fake work dir): the shell installer
  embeds and deposits the conf and sets `service_accounts_file`; the Ansible
  `defaults/main.yml` is **valid YAML** for both enabled and disabled cases with
  **no leftover `@@…@@` placeholders**.
- `shellcheck --severity=warning` clean on `ob-builder` and `validators.sh`;
  `ob-builder(1)` lints with no `man` warnings.

Closes #167
