### PR TITLE
docs: restructure for progressive discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Documentation
 
+- **Docs reorganized for progressive discovery.** `README.md` now leads with a
+  value proposition and a "how it works" overview, promotes the three
+  quick-starts, and points to a theme-organized index. `doc/README.md` is grouped
+  by theme (start here · connections & architecture · access & permissions ·
+  recording & audit · offline & resilience · security & hardening · reference ·
+  EBIOS). New `doc/permissions.md` consolidates **which access control lives
+  SSO-side vs Open-Bastion-side** (with a "where do I set X" map) — previously
+  scattered across the PAM, LLNG, configuration and hardening docs. Cross-links
+  added from `pam-modes`, `llng-configuration` and `service-accounts`. The EBIOS
+  study under `doc/security/` is unchanged.
 - **Service-account security model documented.** `doc/service-accounts.md` now
   spells out that ob-builder deposits the fingerprint only, so the public key
   must still be authorized at the SSH layer (`authorized_keys`, or the

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ enforce them on every server.
 
 - **The SSO decides SSH access** — no SSH keys to install or rotate on each
   server; group membership grants or revokes access fleet-wide.
-- **The SSO decides `sudo` too** — no `sudoers` to maintain per host (local/dual
-  management stays possible when you want it).
+- **The SSO decides `sudo` too** — no `sudoers` to maintain per host
+  _(local/dual management stays possible when you want it)_.
 - **The recorder can't be bypassed** — no escaping the session recorder via
   port-forwarding, while `~/.ssh/config` keeps access _visually_ direct.
 - **Fleet deployment in one command** — `ob-builder --output-ansible <role>` (or
@@ -47,19 +47,20 @@ For the underlying concepts and per-step manual configuration, see
 
 ## How it works
 
-1. A user authenticates to a server — with an LLNG **token** (used as the SSH
-   password) or an **SSO-signed SSH certificate** (self-served via `ob-ssh-cert`).
+1. A user authenticates to a server — with an LLNG **token** _(used as the SSH
+   password)_ or an **SSO-signed SSH certificate** _(self-served via `ob-ssh-cert`)_.
 2. `pam_openbastion` asks LLNG `/pam/authorize` whether this user may access this
    server group, and `sudo` is gated the same way; an encrypted local cache keeps
    this working during an SSO outage.
-3. The **NSS** module resolves SSO users (and key-only service accounts) so the
+3. The **NSS** module resolves SSO users _(and key-only service accounts)_ so the
    system sees them as real Unix accounts; provisioning creates the home on first
    login.
 4. To reach a **backend behind a bastion**, the bastion mints a short-lived,
    LLNG-signed certificate and re-originates the connection with `ob-ssh` /
    `ob-scp` / `ob-sftp` — no user key or agent on the bastion. Backends accept
-   only vouched bastions.
-5. Sessions are **recorded** to a tamper-evident, root-owned store for audit.
+   only vouched bastions.[^1]
+5. Sessions are **recorded** inside the bastion to a tamper-evident, root-owned
+   store for audit.
 
 See [Bastion Architecture](doc/bastion-architecture.md) and the
 [documentation index](doc/README.md) for the details.
@@ -73,7 +74,7 @@ See [Bastion Architecture](doc/bastion-architecture.md) and the
 - Secure communication with SSL/TLS support
 - Easy server enrollment with `ob-enroll` script
 - **[Offline mode](doc/offline-mode.md)**:
-  - Encrypted authorization cache (AES-256-GCM)
+  - Encrypted authorization cache _(AES-256-GCM)_
   - Continue SSH key authentication when LLNG server is unavailable
   - Configurable cache TTL with shorter TTL for high-risk services (sudo, su)
   - Cache brute-force protection with rate limiting
@@ -88,19 +89,19 @@ See [Bastion Architecture](doc/bastion-architecture.md) and the
 - **[Group synchronization](doc/llng-configuration.md#group-synchronization)**:
   - Sync Unix supplementary groups from LLNG on each login
   - Automatic group creation if needed
-  - Local whitelist for defense-in-depth (`allowed_managed_groups`)
+  - Local whitelist for defense-in-depth _(`allowed_managed_groups`)_
   - Groups outside managed pool are never modified
-- **[Service accounts](doc/service-accounts.md)** (ansible, backup, etc.):
+- **[Service accounts](doc/service-accounts.md)** _(ansible, backup, etc.)_:
   - SSH key authentication without OIDC
   - Per-server configuration file
   - Fine-grained sudo permissions
   - Automatic account creation
 - **[Bastion-to-backend authentication](doc/bastion-architecture.md)**:
-  - Certificate-based proof of connection origin (LLNG-signed ephemeral SSH cert, ~120 s)
+  - Certificate-based proof of connection origin _(LLNG-signed ephemeral SSH cert, ~120 s)_
   - Backends only accept SSH from authorized bastions (`allowed_bastions` + `source-address` critical option)
   - No agent forwarding or user key on the bastion required
   - `ob-ssh` / `ob-scp` / `ob-sftp` scripts for seamless bastion connections and file transfers
-- **[Session recording](doc/session-recording.md)** (optional):
+- **[Session recording](doc/session-recording.md)** _(optional)_:
   - Record all terminal I/O for audit compliance
   - Multiple formats: script, asciinema, ttyrec
   - Session metadata with unique IDs
@@ -110,7 +111,7 @@ See [Bastion Architecture](doc/bastion-architecture.md) and the
   - AES-256-GCM encrypted secret storage
   - Webhook notifications for security events
   - Token binding (IP, fingerprint)
-  - [SSH key policy](doc/security.md#ssh-key-policy) enforcement (allowed types, minimum sizes)
+  - [SSH key policy](doc/security.md#ssh-key-policy) enforcement _(allowed types, minimum sizes)_
 - **[CrowdSec integration](doc/crowdsec.md)** (optional):
   - Pre-authentication IP blocking via CrowdSec bouncer
   - Post-authentication failure reporting via CrowdSec watcher
@@ -119,12 +120,10 @@ See [Bastion Architecture](doc/bastion-architecture.md) and the
 - **Monitoring**:
   - Server heartbeat via `ob-heartbeat`
   - Statistics reporting to portal
-- **Desktop SSO** (LightDM integration):
-  - Authenticate workstations via LLNG Single Sign-On
-  - LightDM webkit2-greeter theme with embedded LLNG portal
-  - Offline mode with cached credentials (Argon2id + AES-256-GCM)
-  - Multi-factor authentication support (TOTP, WebAuthn, etc.)
-  - Automatic session and desktop environment selection
+
+Desktop SSO (LightDM workstation login) also exists but is **experimental
+(alpha)** and is deliberately **not** listed among the features above — see the
+clearly-separated **Desktop SSO** section near the end of this README.
 
 ## Installation
 
@@ -172,7 +171,7 @@ The full, theme-organized index is in **[doc/README.md](doc/README.md)**. Highli
 - **Recording & audit** — [Session recording](doc/session-recording.md) · [Audit trace](doc/audit.md)
 - **Offline & resilience** — [Offline mode](doc/offline-mode.md) · [Cache administration](doc/offline-cache-admin.md)
 - **Security & hardening** — [Security features](doc/security.md) · [Hardening](doc/hardening.md) · [CrowdSec](doc/crowdsec.md)
-- **Reference** — [Configuration](doc/configuration.md) · [Desktop SSO](doc/desktop-sso.md) · [Competitors](doc/competitors.md)
+- **Reference** — [Configuration](doc/configuration.md) · [Desktop SSO](doc/desktop-sso.md) _(experimental/alpha)_ · [Competitors](doc/competitors.md)
 - **Security analysis (EBIOS)** — [threat model & risk study](doc/security/00-architecture.md)
 
 ## Troubleshooting
@@ -233,11 +232,19 @@ sudo ob-enroll
 
 ## Requirements
 
-- A LemonLDAP::NG system >= 2.21.0 _(LTS)_ with [additional plugins](https://linagora.github.io/lemonldap-ng-plugins/) installed and enabled
+- A LemonLDAP::NG system >= 2.23.0 with some [additional plugins](https://linagora.github.io/lemonldap-ng-plugins/) installed and enabled
 - libcurl, json-c, OpenSSL, libkeyutils, PAM development headers
 - curl and jq (for enrollment script)
 
-## Desktop SSO (LightDM Integration)
+## Desktop SSO (LightDM) — experimental, alpha
+
+> **⚠️ Experimental — not production-ready.** Unlike the server-side SSH/sudo
+> features above (the validated, supported core of Open Bastion), the LightDM
+> workstation-login greeter is an early **alpha** prototype. Its authentication
+> path has **not** had a security review and there is **no test environment**
+> for it yet. Do **not** rely on it to protect access to a workstation. It is
+> documented here for experimentation only and is intentionally kept separate
+> from the features list.
 
 Open Bastion can authenticate desktop workstations via LemonLDAP::NG Single Sign-On
 using LightDM.
@@ -289,4 +296,8 @@ AGPL-3.0
 
 Xavier Guimard <xguimard@linagora.com>
 
-Copyright (C) 2025 [Linagora](https://linagora.com)
+Copyright (C) [Linagora](https://linagora.com)
+
+---
+
+[^1]: This is optional, of course: you can keep non-Open-Bastion backends and manage them the old way, with SSH keys.

--- a/README.md
+++ b/README.md
@@ -32,13 +32,15 @@ for exactly which control lives where.
 
 ## Quick start
 
-Three quick-starts cover the ways to get going:
+These quick-starts cover the ways to get going — try it, point it at your SSO,
+then deploy:
 
-| Quick-start                                                  | Use it to…                                                                                                                                           |
-| ------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **[Try it in Docker](quick-start/README.md)**                | Spin up a LemonLDAP::NG portal + a self-enrolling SSH server in ~2 minutes and log in with an LLNG token — the fastest way to see Open Bastion work. |
-| **[Deploy a fleet with Ansible](doc/ansible-quickstart.md)** | Generate bastion + backend roles with `ob-builder`, declare your hosts and IPs, and apply with `ansible-playbook` — the path to a real deployment.   |
-| **[Deploy with a shell installer](doc/shell-quickstart.md)** | Generate a self-extracting installer per role with `ob-builder --output-shell`, then `scp` + `sudo`-run it on each host — no Ansible control node.   |
+| Quick-start                                                  | Use it to…                                                                                                                                                 |
+| ------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **[Try it in Docker](quick-start/README.md)**                | Spin up a LemonLDAP::NG portal + a self-enrolling SSH server in ~2 minutes and log in with an LLNG token — the fastest way to see Open Bastion work.       |
+| **[Configure your SSO](doc/llng-configuration.md)**          | On your real LemonLDAP::NG: install the required plugins, and create the OIDC client(s) that carry your machines — the prerequisite before any deployment. |
+| **[Deploy a fleet with Ansible](doc/ansible-quickstart.md)** | Generate bastion + backend roles with `ob-builder`, declare your hosts and IPs, and apply with `ansible-playbook` — the path to a real deployment.         |
+| **[Deploy with a shell installer](doc/shell-quickstart.md)** | Generate a self-extracting installer per role with `ob-builder --output-shell`, then `scp` + `sudo`-run it on each host — no Ansible control node.         |
 
 For the underlying concepts and per-step manual configuration, see
 [PAM Authentication Modes](doc/pam-modes.md), the

--- a/README.md
+++ b/README.md
@@ -47,6 +47,12 @@ For the underlying concepts and per-step manual configuration, see
 
 ## How it works
 
+Each server is first **enrolled** by an administrator — installing the package and
+registering the host with the SSO (`ob-enroll`, or the generated `ob-builder`
+artefacts), which is also what assigns its server group. See the
+[Admin Guide](doc/admin-guide.md) (or the [quick-starts](doc/README.md#start-here))
+for the enrollment step. Once enrolled:
+
 1. A user authenticates to a server — with an LLNG **token** _(used as the SSH
    password)_ or an **SSO-signed SSH certificate** _(self-served via `ob-ssh-cert`)_.
 2. `pam_openbastion` asks LLNG `/pam/authorize` whether this user may access this
@@ -171,64 +177,13 @@ The full, theme-organized index is in **[doc/README.md](doc/README.md)**. Highli
 - **Recording & audit** — [Session recording](doc/session-recording.md) · [Audit trace](doc/audit.md)
 - **Offline & resilience** — [Offline mode](doc/offline-mode.md) · [Cache administration](doc/offline-cache-admin.md)
 - **Security & hardening** — [Security features](doc/security.md) · [Hardening](doc/hardening.md) · [CrowdSec](doc/crowdsec.md)
-- **Reference** — [Configuration](doc/configuration.md) · [Desktop SSO](doc/desktop-sso.md) _(experimental/alpha)_ · [Competitors](doc/competitors.md)
+- **Reference** — [Configuration](doc/configuration.md) · [Troubleshooting](doc/troubleshooting.md) · [Desktop SSO](doc/desktop-sso.md) _(experimental/alpha)_ · [Competitors](doc/competitors.md)
 - **Security analysis (EBIOS)** — [threat model & risk study](doc/security/00-architecture.md)
 
 ## Troubleshooting
 
-### Check Logs
-
-```bash
-# System auth log
-sudo tail -f /var/log/auth.log
-
-# Or journald
-sudo journalctl -u sshd -f
-```
-
-### Enable Debug Mode
-
-In `/etc/open-bastion/openbastion.conf`:
-
-```ini
-log_level = debug
-```
-
-### Test Token Introspection
-
-```bash
-curl -X POST https://auth.example.com/oauth2/introspect \
-  -u "pam-access:secret" \
-  -d "token=<user_token>"
-```
-
-### Test Authorization Endpoint
-
-```bash
-curl -X POST https://auth.example.com/pam/authorize \
-  -H "Authorization: Bearer $(sudo cat /var/lib/open-bastion/token)" \
-  -H "Content-Type: application/json" \
-  -d '{"user": "testuser", "host": "'$(hostname)'", "server_group": "default"}'
-```
-
-### Common Issues
-
-| Issue                        | Cause                 | Solution                                     |
-| ---------------------------- | --------------------- | -------------------------------------------- |
-| `PAM unable to load module`  | Module not in path    | Check `/lib/security/` or `/lib64/security/` |
-| `Token introspection failed` | Wrong credentials     | Verify client_id and client_secret           |
-| `Server not enrolled`        | Missing/invalid token | Run `ob-enroll`                              |
-| `User not authorized`        | Server group rules    | Check LLNG Manager configuration             |
-| `Connection refused`         | Portal unreachable    | Check network and portal_url                 |
-
-### Re-enrollment
-
-If the server token expires or is compromised:
-
-```bash
-sudo rm /var/lib/open-bastion/token
-sudo ob-enroll
-```
+Logs, debug mode, endpoint tests and common issues are collected in
+**[doc/troubleshooting.md](doc/troubleshooting.md)**.
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -1,15 +1,68 @@
 # Open Bastion
 
-**Control SSH access and sudo privileges on your Linux servers through a centralized bastion server.**
+**Control SSH access and sudo privileges on your Linux servers from your SSO —
+no more per-server keys or sudoers.**
 
 Open Bastion integrates your servers with [LemonLDAP::NG](https://lemonldap-ng.org) (LLNG)
-to centrally manage who can SSH into which servers and who can use [sudo](https://en.wikipedia.org/wiki/Sudo).
-Administrators define access rules in the portal, and the PAM/NSS modules enforce them on each server.
+so you manage your Linux administrators as easily as you already manage your SSO
+users. Administrators define access rules once in the portal; the PAM/NSS modules
+enforce them on every server.
 
-The module supports two authentication methods:
+## What Open Bastion gives you
 
-- **Token-based authentication**: Users generate temporary access tokens from the portal to use as SSH passwords
-- **Key-based authorization**: When users connect via SSH keys, the module checks if they're authorized to access this server
+- **The SSO decides SSH access** — no SSH keys to install or rotate on each
+  server; group membership grants or revokes access fleet-wide.
+- **The SSO decides `sudo` too** — no `sudoers` to maintain per host (local/dual
+  management stays possible when you want it).
+- **The recorder can't be bypassed** — no escaping the session recorder via
+  port-forwarding, while `~/.ssh/config` keeps access _visually_ direct.
+- **Fleet deployment in one command** — `ob-builder --output-ansible <role>` (or
+  a self-extracting shell installer), then roll it out to every host.
+- **A "backup" account with access everywhere** — with or without `sudo` — via
+  [service accounts](doc/service-accounts.md).
+- **Self-service onboarding** — a new admin signs their SSH key at the portal and
+  instantly has every right their groups grant.
+- **One-click offboarding** — close the SSO account and access is gone.
+- **Instant role changes** — change someone's groups and, within minutes, old
+  rights drop and new ones apply.
+
+Two layers do this: the **SSO (LLNG) decides** policy centrally, the **PAM/NSS
+modules enforce** it on each server. See [Access & Permissions](doc/permissions.md)
+for exactly which control lives where.
+
+## Quick start
+
+Three quick-starts cover the ways to get going:
+
+| Quick-start                                                  | Use it to…                                                                                                                                           |
+| ------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **[Try it in Docker](quick-start/README.md)**                | Spin up a LemonLDAP::NG portal + a self-enrolling SSH server in ~2 minutes and log in with an LLNG token — the fastest way to see Open Bastion work. |
+| **[Deploy a fleet with Ansible](doc/ansible-quickstart.md)** | Generate bastion + backend roles with `ob-builder`, declare your hosts and IPs, and apply with `ansible-playbook` — the path to a real deployment.   |
+| **[Deploy with a shell installer](doc/shell-quickstart.md)** | Generate a self-extracting installer per role with `ob-builder --output-shell`, then `scp` + `sudo`-run it on each host — no Ansible control node.   |
+
+For the underlying concepts and per-step manual configuration, see
+[PAM Authentication Modes](doc/pam-modes.md), the
+[Configuration Reference](doc/configuration.md), and the
+[Admin Guide](doc/admin-guide.md).
+
+## How it works
+
+1. A user authenticates to a server — with an LLNG **token** (used as the SSH
+   password) or an **SSO-signed SSH certificate** (self-served via `ob-ssh-cert`).
+2. `pam_openbastion` asks LLNG `/pam/authorize` whether this user may access this
+   server group, and `sudo` is gated the same way; an encrypted local cache keeps
+   this working during an SSO outage.
+3. The **NSS** module resolves SSO users (and key-only service accounts) so the
+   system sees them as real Unix accounts; provisioning creates the home on first
+   login.
+4. To reach a **backend behind a bastion**, the bastion mints a short-lived,
+   LLNG-signed certificate and re-originates the connection with `ob-ssh` /
+   `ob-scp` / `ob-sftp` — no user key or agent on the bastion. Backends accept
+   only vouched bastions.
+5. Sessions are **recorded** to a tamper-evident, root-owned store for audit.
+
+See [Bastion Architecture](doc/bastion-architecture.md) and the
+[documentation index](doc/README.md) for the details.
 
 ## Features
 
@@ -19,7 +72,7 @@ The module supports two authentication methods:
 - Token caching to reduce server load
 - Secure communication with SSL/TLS support
 - Easy server enrollment with `ob-enroll` script
-- **[Offline mode](doc/security.md#cache-brute-force-protection)**:
+- **[Offline mode](doc/offline-mode.md)**:
   - Encrypted authorization cache (AES-256-GCM)
   - Continue SSH key authentication when LLNG server is unavailable
   - Configurable cache TTL with shorter TTL for high-risk services (sudo, su)
@@ -109,36 +162,18 @@ make
 sudo make install
 ```
 
-## Quick Start
-
-Three quick-starts cover the ways to get going:
-
-| Quick-start                                                  | Use it to…                                                                                                                                           |
-| ------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **[Try it in Docker](quick-start/README.md)**                | Spin up a LemonLDAP::NG portal + a self-enrolling SSH server in ~2 minutes and log in with an LLNG token — the fastest way to see Open Bastion work. |
-| **[Deploy a fleet with Ansible](doc/ansible-quickstart.md)** | Generate bastion + backend roles with `ob-builder`, declare your hosts and IPs, and apply with `ansible-playbook` — the path to a real deployment.   |
-| **[Deploy with a shell installer](doc/shell-quickstart.md)** | Generate a self-extracting installer per role with `ob-builder --output-shell`, then `scp` + `sudo`-run it on each host — no Ansible control node.   |
-
-For the underlying concepts and per-step manual configuration, see [PAM Authentication Modes](doc/pam-modes.md) and the [Configuration Reference](doc/configuration.md).
-
 ## Documentation
 
-See the full [documentation index](doc/README.md) or jump directly to:
+The full, theme-organized index is in **[doc/README.md](doc/README.md)**. Highlights:
 
-| Document                                                 | Description                                |
-| -------------------------------------------------------- | ------------------------------------------ |
-| [LemonLDAP::NG Configuration](doc/llng-configuration.md) | Server-side LLNG setup and plugins         |
-| [PAM Authentication Modes](doc/pam-modes.md)             | All 4 PAM configurations with examples     |
-| [Configuration Reference](doc/configuration.md)          | All configuration options                  |
-| [Service Accounts](doc/service-accounts.md)              | Ansible, backup, CI/CD accounts            |
-| [Bastion Architecture](doc/bastion-architecture.md)      | Bastion-to-backend certificate vouching    |
-| [Session Recording](doc/session-recording.md)            | SSH session recording for audit            |
-| [CrowdSec Integration](doc/crowdsec.md)                  | IP blocking and alert reporting            |
-| [Security Features](doc/security.md)                     | Key policies, rate limiting, audit         |
-| [Admin Guide](doc/admin-guide.md)                        | Complete administration guide              |
-| [Deployment Builder](admin-builder/README.md)            | Generate shell / Ansible deploy artefacts  |
-| [Ansible Quick-start](doc/ansible-quickstart.md)         | Generate + apply roles, fleet deployment   |
-| [Shell Installer Quick-start](doc/shell-quickstart.md)   | Generate + run a self-extracting installer |
+- **Get started** — [Docker demo](quick-start/README.md) · [Shell](doc/shell-quickstart.md) / [Ansible](doc/ansible-quickstart.md) quick-starts · [Admin guide](doc/admin-guide.md)
+- **Connections & architecture** — [Bastion architecture](doc/bastion-architecture.md) · [PAM modes](doc/pam-modes.md) · [LLNG configuration](doc/llng-configuration.md)
+- **Access & permissions** — [Access & Permissions](doc/permissions.md) (SSO-side vs server-side) · [Service accounts](doc/service-accounts.md)
+- **Recording & audit** — [Session recording](doc/session-recording.md) · [Audit trace](doc/audit.md)
+- **Offline & resilience** — [Offline mode](doc/offline-mode.md) · [Cache administration](doc/offline-cache-admin.md)
+- **Security & hardening** — [Security features](doc/security.md) · [Hardening](doc/hardening.md) · [CrowdSec](doc/crowdsec.md)
+- **Reference** — [Configuration](doc/configuration.md) · [Desktop SSO](doc/desktop-sso.md) · [Competitors](doc/competitors.md)
+- **Security analysis (EBIOS)** — [threat model & risk study](doc/security/00-architecture.md)
 
 ## Troubleshooting
 

--- a/doc/README.md
+++ b/doc/README.md
@@ -60,11 +60,11 @@ Who can do what, where — and which knob lives on the SSO vs the server.
 
 ## Reference
 
-| Document                                    | Description                     |
-| ------------------------------------------- | ------------------------------- |
-| [Configuration reference](configuration.md) | Every `openbastion.conf` key    |
-| [Desktop SSO](desktop-sso.md)               | LightDM greeter + LLNG login    |
-| [Competitors](competitors.md)               | Comparison with other solutions |
+| Document                                    | Description                                             |
+| ------------------------------------------- | ------------------------------------------------------- |
+| [Configuration reference](configuration.md) | Every `openbastion.conf` key                            |
+| [Desktop SSO](desktop-sso.md)               | LightDM greeter + LLNG login **(experimental / alpha)** |
+| [Competitors](competitors.md)               | Comparison with other solutions                         |
 
 ## Security analysis (EBIOS)
 

--- a/doc/README.md
+++ b/doc/README.md
@@ -63,6 +63,7 @@ Who can do what, where — and which knob lives on the SSO vs the server.
 | Document                                    | Description                                             |
 | ------------------------------------------- | ------------------------------------------------------- |
 | [Configuration reference](configuration.md) | Every `openbastion.conf` key                            |
+| [Troubleshooting](troubleshooting.md)       | Logs, debug mode, endpoint tests, common issues         |
 | [Desktop SSO](desktop-sso.md)               | LightDM greeter + LLNG login **(experimental / alpha)** |
 | [Competitors](competitors.md)               | Comparison with other solutions                         |
 

--- a/doc/README.md
+++ b/doc/README.md
@@ -25,6 +25,7 @@ How users reach servers, and how the bastion→backend hop is secured.
 | [Bastion architecture](bastion-architecture.md)                 | Bastion→backend certificate vouching; `ob-ssh`/`ob-scp`/`ob-sftp` |
 | [PAM authentication modes](pam-modes.md)                        | The A–E matrix (token / key / password / cert)                    |
 | [LemonLDAP::NG configuration](llng-configuration.md)            | Server-side: OIDC RP, plugins, SSH CA, server groups              |
+| [LemonLDAP::NG plugin parameters](llng-plugin-parameters.md)    | Reference: optional `[portal]` parameters (indicative)            |
 | [Design: certificate vouching](design/bastion-cert-vouching.md) | Why and how the ephemeral-cert hop works                          |
 
 ## Access & permissions

--- a/doc/README.md
+++ b/doc/README.md
@@ -10,6 +10,7 @@ and [Access & Permissions](permissions.md).
 | Document                                           | Description                                          |
 | -------------------------------------------------- | ---------------------------------------------------- |
 | [Docker demo](../quick-start/README.md)            | LLNG portal + a self-enrolling SSH server in ~2 min  |
+| [Configure your SSO](llng-configuration.md)        | Install the plugins + create the OIDC client(s)      |
 | [Shell installer quick-start](shell-quickstart.md) | Generate + run a self-extracting installer per host  |
 | [Ansible quick-start](ansible-quickstart.md)       | Generate + apply bastion/backend roles to a fleet    |
 | [Deployment builder](../admin-builder/README.md)   | `ob-builder` — produce the shell / Ansible artefacts |

--- a/doc/README.md
+++ b/doc/README.md
@@ -1,42 +1,79 @@
 # Open Bastion Documentation
 
-## Getting Started
+Grouped by theme, roughly in reading order: **try it → deploy it → understand
+the connection model → manage access → record & audit → operate → go deep.**
+New here? Start with a quick-start, then skim [Bastion Architecture](bastion-architecture.md)
+and [Access & Permissions](permissions.md).
 
-| Document                                             | Description                                |
-| ---------------------------------------------------- | ------------------------------------------ |
-| [LemonLDAP::NG Configuration](llng-configuration.md) | Server-side LLNG setup and plugins         |
-| [PAM Authentication Modes](pam-modes.md)             | All 4 PAM configurations with examples     |
-| [Configuration Reference](configuration.md)          | All configuration options                  |
-| [Ansible Quick-start](ansible-quickstart.md)         | Generate + apply roles with ob-builder     |
-| [Shell Installer Quick-start](shell-quickstart.md)   | Generate + run a self-extracting installer |
+## Start here
 
-## Features
+| Document                                           | Description                                          |
+| -------------------------------------------------- | ---------------------------------------------------- |
+| [Docker demo](../quick-start/README.md)            | LLNG portal + a self-enrolling SSH server in ~2 min  |
+| [Shell installer quick-start](shell-quickstart.md) | Generate + run a self-extracting installer per host  |
+| [Ansible quick-start](ansible-quickstart.md)       | Generate + apply bastion/backend roles to a fleet    |
+| [Deployment builder](../admin-builder/README.md)   | `ob-builder` — produce the shell / Ansible artefacts |
+| [Admin guide](admin-guide.md)                      | End-to-end manual walkthrough per role               |
 
-| Document                                        | Description                                   |
-| ----------------------------------------------- | --------------------------------------------- |
-| [Service Accounts](service-accounts.md)         | Ansible, backup, CI/CD accounts               |
-| [Bastion Architecture](bastion-architecture.md) | Bastion-to-backend certificate vouching       |
-| [Session Recording](session-recording.md)       | SSH session recording for audit               |
-| [Session Containment Hardening](hardening.md)   | logind, limits, at/cron containment           |
-| [Primary Audit Trace](audit.md)                 | Optional auditd-based syscall audit trail     |
-| [CrowdSec Integration](crowdsec.md)             | IP blocking and alert reporting               |
-| [Security Features](security.md)                | Key policies, rate limiting, cache protection |
+## Connections & architecture
 
-## Administration
+How users reach servers, and how the bastion→backend hop is secured.
 
-| Document                      | Description                     |
-| ----------------------------- | ------------------------------- |
-| [Admin Guide](admin-guide.md) | Complete administration guide   |
-| [Competitors](competitors.md) | Comparison with other solutions |
+| Document                                                        | Description                                                       |
+| --------------------------------------------------------------- | ----------------------------------------------------------------- |
+| [Bastion architecture](bastion-architecture.md)                 | Bastion→backend certificate vouching; `ob-ssh`/`ob-scp`/`ob-sftp` |
+| [PAM authentication modes](pam-modes.md)                        | The A–E matrix (token / key / password / cert)                    |
+| [LemonLDAP::NG configuration](llng-configuration.md)            | Server-side: OIDC RP, plugins, SSH CA, server groups              |
+| [Design: certificate vouching](design/bastion-cert-vouching.md) | Why and how the ephemeral-cert hop works                          |
 
-## Security Analysis
+## Access & permissions
 
-Detailed security documentation for audits and compliance:
+Who can do what, where — and which knob lives on the SSO vs the server.
+
+| Document                                | Description                                                        |
+| --------------------------------------- | ------------------------------------------------------------------ |
+| [Access & permissions](permissions.md)  | SSO-side vs Open-Bastion-side controls; the "where do I set X" map |
+| [Service accounts](service-accounts.md) | Key-only local accounts (ansible, backup, CI/CD)                   |
+
+## Session recording & audit
+
+| Document                                                                       | Description                           |
+| ------------------------------------------------------------------------------ | ------------------------------------- |
+| [Session recording](session-recording.md)                                      | Tamper-evident terminal I/O capture   |
+| [Primary audit trace](audit.md)                                                | Optional `auditd`-based syscall trail |
+| [Design: tamper-evident recording](design/tamper-evident-session-recording.md) | Why recordings stream to a root sink  |
+
+## Offline & resilience
+
+| Document                                               | Description                                   |
+| ------------------------------------------------------ | --------------------------------------------- |
+| [Offline mode](offline-mode.md)                        | Cached authorization when LLNG is unreachable |
+| [Offline cache administration](offline-cache-admin.md) | Cache config, TTLs, lockout, `ob-cache-admin` |
+
+## Security & hardening
+
+| Document                                      | Description                                        |
+| --------------------------------------------- | -------------------------------------------------- |
+| [Security features](security.md)              | Key policy, rate limiting, cache protection, audit |
+| [Session containment hardening](hardening.md) | logind kill, process limits, at/cron allow-lists   |
+| [CrowdSec integration](crowdsec.md)           | Pre-auth IP blocking + post-auth reporting         |
+
+## Reference
+
+| Document                                    | Description                     |
+| ------------------------------------------- | ------------------------------- |
+| [Configuration reference](configuration.md) | Every `openbastion.conf` key    |
+| [Desktop SSO](desktop-sso.md)               | LightDM greeter + LLNG login    |
+| [Competitors](competitors.md)               | Comparison with other solutions |
+
+## Security analysis (EBIOS)
+
+Detailed threat model and risk study, for audits and compliance (French).
 
 | Document                                        | Description                      |
 | ----------------------------------------------- | -------------------------------- |
 | [Architecture](security/00-architecture.md)     | Security architecture overview   |
 | [Enrollment](security/01-enrollment.md)         | Server enrollment security       |
-| [SSH Connection](security/02-ssh-connection.md) | SSH authentication flow security |
+| [SSH connection](security/02-ssh-connection.md) | SSH authentication flow security |
 | [Offboarding](security/03-offboarding.md)       | User and server offboarding      |
-| [Risk Reduction](security/99-risk-reduce.md)    | Risk mitigation strategies       |
+| [Risk reduction](security/99-risk-reduce.md)    | Residual risks and mitigations   |

--- a/doc/desktop-sso.md
+++ b/doc/desktop-sso.md
@@ -1,5 +1,11 @@
 # Desktop SSO with Open Bastion
 
+> **⚠️ Experimental (alpha) — not production-ready.** Unlike Open Bastion's
+> server-side SSH/sudo features, this LightDM workstation-login greeter is an
+> early prototype: its authentication path has **not** been security-reviewed and
+> has **no test environment** yet. Do not rely on it to protect workstation
+> access. Documented here for experimentation only.
+
 This document describes how to configure desktop workstations to use Open Bastion
 for Single Sign-On (SSO) via LightDM.
 

--- a/doc/llng-configuration.md
+++ b/doc/llng-configuration.md
@@ -29,10 +29,14 @@ sudo apt-get install \
 # pam-access = token-based auth; ssh-ca = certificate-based auth
 ```
 
-### Option B: RPM and other distributions (plugin-store CLI)
+### Option B: Plugin-store CLI (`lemonldap-ng-store`)
 
-There is no plugin RPM repository. On RHEL / Rocky / Fedora (and on Debian too)
-use the generic `lemonldap-ng-store` CLI bundled with LemonLDAP::NG >= 2.23.0:
+The `lemonldap-ng-store` CLI installs and activates plugins from the store
+regardless of the OS package manager. It will be \*\*bundled with LemonLDAP::NG
+
+> = 2.24.0\*\*; for now it is provided by the lemonldap-ng-plugins store itself —
+> install the `linagora-lemonldap-ng-store` package first (from the Linagora
+> repository set up in Option A).
 
 ```bash
 sudo lemonldap-ng-store add-store https://linagora.github.io/lemonldap-ng-plugins/
@@ -43,9 +47,12 @@ sudo lemonldap-ng-store install ssh-ca     --activate   # certificate-based auth
 sudo systemctl restart lemonldap-ng-fastcgi-server
 ```
 
-`--activate` registers each plugin in `customPlugins` automatically. (On LLNG
-< 2.23.0 the CLI ships separately as the `linagora-lemonldap-ng-store` Debian
-package.)
+`--activate` registers each plugin in `customPlugins` automatically.
+
+> **RPM / non-Debian systems:** the `linagora-lemonldap-ng-store` package is
+> currently Debian-only, so until LemonLDAP::NG **2.24.0** bundles the CLI there
+> is no packaged plugin-install path on RHEL / Rocky / Fedora. Use a Docker image
+> (Option C) or run the portal on Debian in the meantime.
 
 ### Option C: Docker
 

--- a/doc/llng-configuration.md
+++ b/doc/llng-configuration.md
@@ -6,7 +6,7 @@ Before deploying the PAM module on your servers, you need to configure LemonLDAP
 
 The Open Bastion plugins are available from the [Linagora plugin store](https://linagora.github.io/lemonldap-ng-plugins/).
 
-### Option A: Debian/Ubuntu (recommended)
+### Option A: Debian/Ubuntu (APT)
 
 Add the Linagora plugin repository and install:
 
@@ -21,15 +21,40 @@ echo "deb [signed-by=/usr/share/keyrings/linagora-llng-plugins.gpg] https://lina
 
 # Install (pick pam-access and/or ssh-ca depending on your auth mode)
 sudo apt-get update
-sudo apt-get install lemonldap-ng-plugin-oidc-device-authorization \
-                     lemonldap-ng-plugin-oidc-device-organization \
-                     lemonldap-ng-plugin-pam-access \  # token-based auth
-                     lemonldap-ng-plugin-ssh-ca         # certificate-based auth
+sudo apt-get install \
+  lemonldap-ng-plugin-oidc-device-authorization \
+  lemonldap-ng-plugin-oidc-device-organization \
+  lemonldap-ng-plugin-pam-access \
+  lemonldap-ng-plugin-ssh-ca
+# pam-access = token-based auth; ssh-ca = certificate-based auth
 ```
 
-### Option B: Docker
+### Option B: RPM and other distributions (plugin-store CLI)
 
-The `yadd/lemonldap-ng-portal` images already include all plugins. No extra installation needed — just enable them via `customPlugins` (see Step 3).
+There is no plugin RPM repository. On RHEL / Rocky / Fedora (and on Debian too)
+use the generic `lemonldap-ng-store` CLI bundled with LemonLDAP::NG >= 2.23.0:
+
+```bash
+sudo lemonldap-ng-store add-store https://linagora.github.io/lemonldap-ng-plugins/
+sudo lemonldap-ng-store install oidc-device-authorization --activate
+sudo lemonldap-ng-store install oidc-device-organization --activate
+sudo lemonldap-ng-store install pam-access --activate   # token-based auth
+sudo lemonldap-ng-store install ssh-ca     --activate   # certificate-based auth
+sudo systemctl restart lemonldap-ng-fastcgi-server
+```
+
+`--activate` registers each plugin in `customPlugins` automatically. (On LLNG
+< 2.23.0 the CLI ships separately as the `linagora-lemonldap-ng-store` Debian
+package.)
+
+### Option C: Docker
+
+All `yadd/lemonldap-ng-*` application images tagged **>= 2.23.0-1** already bundle
+the Open Bastion plugins — e.g. `lemonldap-ng-portal`,
+`lemonldap-ng-portal-hiperf`, `lemonldap-ng-manager`, `lemonldap-ng-full`,
+`lemonldap-ng-ssoaas-fastcgi-server`. No extra installation is needed — just
+enable them via `customPlugins` (see Step 3). See the full image set at
+<https://github.com/guimard/llng-docker/>.
 
 ### Plugins used by Open Bastion
 

--- a/doc/llng-configuration.md
+++ b/doc/llng-configuration.md
@@ -32,11 +32,10 @@ sudo apt-get install \
 ### Option B: Plugin-store CLI (`lemonldap-ng-store`)
 
 The `lemonldap-ng-store` CLI installs and activates plugins from the store
-regardless of the OS package manager. It will be \*\*bundled with LemonLDAP::NG
-
-> = 2.24.0\*\*; for now it is provided by the lemonldap-ng-plugins store itself —
-> install the `linagora-lemonldap-ng-store` package first (from the Linagora
-> repository set up in Option A).
+regardless of the OS package manager. It is **bundled with LemonLDAP::NG 2.24.0
+and later**; on earlier versions it is provided by the lemonldap-ng-plugins store
+itself — install the `linagora-lemonldap-ng-store` package first (from the
+Linagora repository set up in Option A).
 
 ```bash
 sudo lemonldap-ng-store add-store https://linagora.github.io/lemonldap-ng-plugins/
@@ -56,7 +55,7 @@ sudo systemctl restart lemonldap-ng-fastcgi-server
 
 ### Option C: Docker
 
-All `yadd/lemonldap-ng-*` application images tagged **>= 2.23.0-1** already bundle
+All `yadd/lemonldap-ng-*` application images tagged **2.23.0-1 or later** already bundle
 the Open Bastion plugins — e.g. `lemonldap-ng-portal`,
 `lemonldap-ng-portal-hiperf`, `lemonldap-ng-manager`, `lemonldap-ng-full`,
 `lemonldap-ng-ssoaas-fastcgi-server`. No extra installation is needed — just

--- a/doc/llng-configuration.md
+++ b/doc/llng-configuration.md
@@ -46,7 +46,10 @@ sudo lemonldap-ng-store install ssh-ca     --activate   # certificate-based auth
 sudo systemctl restart lemonldap-ng-fastcgi-server
 ```
 
-`--activate` registers each plugin in `customPlugins` automatically.
+With the Autoloader present (see Step 3), `--activate` is a no-op: the store drops
+each plugin's autoload rule into `/etc/lemonldap-ng/autoload.d/` and the plugin
+loads once its activation condition is truthy. (Only on a portal without the
+Autoloader does `--activate` fall back to editing `customPlugins`.)
 
 > **RPM / non-Debian systems:** the `linagora-lemonldap-ng-store` package is
 > currently Debian-only, so until LemonLDAP::NG **2.24.0** bundles the CLI there
@@ -59,8 +62,9 @@ The LemonLDAP::NG portal/manager images tagged **2.23.0-1 or later** already
 bundle the Open Bastion plugins — `yadd/lemonldap-ng-portal`,
 `yadd/lemonldap-ng-manager` and `yadd/lemonldap-ng-full` (the high-performance
 uWSGI portal is a tag variant of the portal image, e.g.
-`yadd/lemonldap-ng-portal:2.23.0-1-hiperf`). No extra installation is needed —
-just enable them via `customPlugins` (see Step 3). See the full image set at
+`yadd/lemonldap-ng-portal:2.23.0-1-hiperf`). They also ship the Autoloader
+enabled, so no extra installation is needed — just activate the plugins (see
+Step 3). See the full image set at
 <https://github.com/guimard/llng-docker/>.
 
 ### Plugins used by Open Bastion
@@ -109,30 +113,31 @@ In the LLNG Manager, create a new OIDC Relying Party:
 > authorization-code flow can still return a refresh token even when this is
 > misconfigured, so test the **device** flow, not auth-code.
 
-## Step 3: Enable the Plugins
+## Step 3: Activate the Plugins
 
-Use `customPlugins` inside `lemonldap-ng.ini`, section `[portal]`:
+These plugins ship **autoload rules**, so you do **not** edit `customPlugins`.
+With LLNG's **Autoloader** — enabled by default in LemonLDAP::NG 2.24.0 and later,
+and added by the `linagora-lemonldap-ng-store` backport on earlier versions — each
+plugin loads automatically as soon as its activation condition is truthy. Set the
+relevant key in `lemonldap-ng.ini`, section `[portal]` (or the matching toggle in
+the Manager):
 
-- Token-based authentication (PamAccess only):
+| Plugin                   | Activates when…                                                              |
+| ------------------------ | ---------------------------------------------------------------------------- |
+| PamAccess (token auth)   | `pamAccessActivation = 1`                                                    |
+| SSHCA (certificate auth) | `sshCaActivation = 1`                                                        |
+| OIDCDeviceAuthorization  | any RP sets `oidcRPMetaDataOptionsAllowDeviceAuthorization` (done in Step 2) |
+| OIDCDeviceOrganization   | any RP sets `oidcRPMetaDataOptionsDeviceOwnership` (done in Step 2)          |
 
-```ini
-[portal]
-customPlugins = ::Plugins::OIDCDeviceAuthorization, ::Plugins::OIDCDeviceOrganization, ::Plugins::PamAccess
-```
+In practice you only set `pamAccessActivation` and/or `sshCaActivation` for your
+auth mode; the two OIDC device plugins switch on automatically from the per-RP
+options you configured in [Step 2](#step-2-create-the-oidc-relying-party).
 
-- Certificate-based authentication (SSHCA only):
-
-```ini
-[portal]
-customPlugins = ::Plugins::OIDCDeviceAuthorization, ::Plugins::OIDCDeviceOrganization, ::Plugins::SSHCA
-```
-
-- Both:
-
-```ini
-[portal]
-customPlugins = ::Plugins::OIDCDeviceAuthorization, ::Plugins::OIDCDeviceOrganization, ::Plugins::PamAccess, ::Plugins::SSHCA
-```
+> **Legacy portals without the Autoloader** (LLNG < 2.24.0 and no
+> `linagora-lemonldap-ng-store`): add the modules to `customPlugins` in `[portal]`
+> instead — e.g.
+> `customPlugins = ::Plugins::OIDCDeviceAuthorization, ::Plugins::OIDCDeviceOrganization, ::Plugins::PamAccess, ::Plugins::SSHCA`
+> (drop `PamAccess` or `SSHCA` per your mode).
 
 ## Step 4: Plugin Parameters
 

--- a/doc/llng-configuration.md
+++ b/doc/llng-configuration.md
@@ -352,6 +352,7 @@ When a user moves from staging to production access, their docker and developers
 
 ## See Also
 
+- [Access & Permissions](permissions.md) - Which controls live SSO-side vs server-side
 - [PAM Authentication Modes](pam-modes.md) - Configure PAM on servers
 - [Configuration Reference](configuration.md) - All configuration options
 - [Admin Guide](admin-guide.md) - Complete administration guide

--- a/doc/llng-configuration.md
+++ b/doc/llng-configuration.md
@@ -55,11 +55,12 @@ sudo systemctl restart lemonldap-ng-fastcgi-server
 
 ### Option C: Docker
 
-All `yadd/lemonldap-ng-*` application images tagged **2.23.0-1 or later** already bundle
-the Open Bastion plugins — e.g. `lemonldap-ng-portal`,
-`lemonldap-ng-portal-hiperf`, `lemonldap-ng-manager`, `lemonldap-ng-full`,
-`lemonldap-ng-ssoaas-fastcgi-server`. No extra installation is needed — just
-enable them via `customPlugins` (see Step 3). See the full image set at
+The LemonLDAP::NG portal/manager images tagged **2.23.0-1 or later** already
+bundle the Open Bastion plugins — `yadd/lemonldap-ng-portal`,
+`yadd/lemonldap-ng-manager` and `yadd/lemonldap-ng-full` (the high-performance
+uWSGI portal is a tag variant of the portal image, e.g.
+`yadd/lemonldap-ng-portal:2.23.0-1-hiperf`). No extra installation is needed —
+just enable them via `customPlugins` (see Step 3). See the full image set at
 <https://github.com/guimard/llng-docker/>.
 
 ### Plugins used by Open Bastion

--- a/doc/llng-configuration.md
+++ b/doc/llng-configuration.md
@@ -90,8 +90,11 @@ In the LLNG Manager, create a new OIDC Relying Party:
 2. Configure:
    - **Client ID**: `pam-access`
    - **Client secret**: Generate a strong secret
-   - **Allowed grant types**: Enable `device_code` (for server enrollment)
-   - **Allowed scopes**: `openid`, `pam:server`, `offline_access`
+   - **Scopes**: servers enroll with the `pam:server` scope, which is a **custom
+     Open-Bastion scope** (not a built-in one). Grant it with a per-RP **scope
+     rule** — `oidcRPMetaDataScopeRules`, e.g. `pam:server => 1` (the demos also
+     grant `pam`). `offline_access` is **not** a scope you list here; it is
+     enabled by `oidcRPMetaDataOptionsAllowOffline` (see step 3).
 3. Set the per-RP options that let servers enroll with a **renewable** identity
    (see [Per-RP Device Authorization Parameters](#per-rp-device-authorization-parameters)):
    - `oidcRPMetaDataOptionsAllowDeviceAuthorization` = `1`

--- a/doc/llng-configuration.md
+++ b/doc/llng-configuration.md
@@ -90,13 +90,8 @@ In the LLNG Manager, create a new OIDC Relying Party:
 2. Configure:
    - **Client ID**: `pam-access`
    - **Client secret**: Generate a strong secret
-   - **Scopes**: usually nothing to configure. `ob-enroll` requests the
-     `pam:server` scope and a default LLNG portal issues it as-is (e.g.
-     `sso.linagora.com` runs with no scope rule for it). Only if your portal
-     restricts OIDC scopes do you need to grant `pam:server` via a per-RP scope
-     rule (`oidcRPMetaDataScopeRules`, e.g. `pam:server => 1`). `offline_access`
-     is enabled by `oidcRPMetaDataOptionsAllowOffline` (step 3), not by a scope
-     entry.
+   - No scope configuration is needed (the requested `pam:server` scope is issued
+     as-is); offline sessions are authorized in step 3.
 3. Set the per-RP options that let servers enroll with a **renewable** identity
    (see [Per-RP Device Authorization Parameters](#per-rp-device-authorization-parameters)):
    - `oidcRPMetaDataOptionsAllowDeviceAuthorization` = `1`

--- a/doc/llng-configuration.md
+++ b/doc/llng-configuration.md
@@ -90,11 +90,13 @@ In the LLNG Manager, create a new OIDC Relying Party:
 2. Configure:
    - **Client ID**: `pam-access`
    - **Client secret**: Generate a strong secret
-   - **Scopes**: servers enroll with the `pam:server` scope, which is a **custom
-     Open-Bastion scope** (not a built-in one). Grant it with a per-RP **scope
-     rule** — `oidcRPMetaDataScopeRules`, e.g. `pam:server => 1` (the demos also
-     grant `pam`). `offline_access` is **not** a scope you list here; it is
-     enabled by `oidcRPMetaDataOptionsAllowOffline` (see step 3).
+   - **Scopes**: usually nothing to configure. `ob-enroll` requests the
+     `pam:server` scope and a default LLNG portal issues it as-is (e.g.
+     `sso.linagora.com` runs with no scope rule for it). Only if your portal
+     restricts OIDC scopes do you need to grant `pam:server` via a per-RP scope
+     rule (`oidcRPMetaDataScopeRules`, e.g. `pam:server => 1`). `offline_access`
+     is enabled by `oidcRPMetaDataOptionsAllowOffline` (step 3), not by a scope
+     entry.
 3. Set the per-RP options that let servers enroll with a **renewable** identity
    (see [Per-RP Device Authorization Parameters](#per-rp-device-authorization-parameters)):
    - `oidcRPMetaDataOptionsAllowDeviceAuthorization` = `1`

--- a/doc/llng-configuration.md
+++ b/doc/llng-configuration.md
@@ -118,20 +118,21 @@ In the LLNG Manager, create a new OIDC Relying Party:
 These plugins ship **autoload rules**, so you do **not** edit `customPlugins`.
 With LLNG's **Autoloader** — enabled by default in LemonLDAP::NG 2.24.0 and later,
 and added by the `linagora-lemonldap-ng-store` backport on earlier versions — each
-plugin loads automatically as soon as its activation condition is truthy. Set the
-relevant key in `lemonldap-ng.ini`, section `[portal]` (or the matching toggle in
-the Manager):
+plugin loads automatically as soon as its activation condition is truthy. You
+toggle that condition **in the LLNG Manager**; the underlying configuration keys
+are listed here for reference:
 
-| Plugin                   | Activates when…                                                              |
-| ------------------------ | ---------------------------------------------------------------------------- |
-| PamAccess (token auth)   | `pamAccessActivation = 1`                                                    |
-| SSHCA (certificate auth) | `sshCaActivation = 1`                                                        |
-| OIDCDeviceAuthorization  | any RP sets `oidcRPMetaDataOptionsAllowDeviceAuthorization` (done in Step 2) |
-| OIDCDeviceOrganization   | any RP sets `oidcRPMetaDataOptionsDeviceOwnership` (done in Step 2)          |
+| Plugin                   | Configuration key / condition                                                | Reference                                                                                                                        |
+| ------------------------ | ---------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| PamAccess (token auth)   | `pamAccessActivation = 1`                                                    | [pam-access](https://github.com/linagora/lemonldap-ng-plugins/tree/main/plugins/pam-access#readme)                               |
+| SSHCA (certificate auth) | `sshCaActivation = 1`                                                        | [ssh-ca](https://github.com/linagora/lemonldap-ng-plugins/tree/main/plugins/ssh-ca#readme)                                       |
+| OIDCDeviceAuthorization  | any RP sets `oidcRPMetaDataOptionsAllowDeviceAuthorization` (done in Step 2) | [oidc-device-authorization](https://github.com/linagora/lemonldap-ng-plugins/tree/main/plugins/oidc-device-authorization#readme) |
+| OIDCDeviceOrganization   | any RP sets `oidcRPMetaDataOptionsDeviceOwnership` (done in Step 2)          | [oidc-device-organization](https://github.com/linagora/lemonldap-ng-plugins/tree/main/plugins/oidc-device-organization#readme)   |
 
-In practice you only set `pamAccessActivation` and/or `sshCaActivation` for your
-auth mode; the two OIDC device plugins switch on automatically from the per-RP
-options you configured in [Step 2](#step-2-create-the-oidc-relying-party).
+In practice you only enable PamAccess and/or SSHCA in the Manager for your auth
+mode; the two OIDC device plugins switch on automatically from the per-RP options
+you configured in [Step 2](#step-2-create-the-oidc-relying-party). See each
+plugin's README (linked above) for its full list of parameters.
 
 > **Legacy portals without the Autoloader** (LLNG < 2.24.0 and no
 > `linagora-lemonldap-ng-store`): add the modules to `customPlugins` in `[portal]`

--- a/doc/llng-configuration.md
+++ b/doc/llng-configuration.md
@@ -42,6 +42,12 @@ The `yadd/lemonldap-ng-portal` images already include all plugins. No extra inst
 
 ## Step 2: Create the OIDC Relying Party
 
+The OIDC Relying Party (a.k.a. OIDC client) is what your servers enroll against —
+one RP can carry a whole fleet, or you can use several (one per project/zone).
+For **general** OIDC RP configuration, refer to the upstream
+[LemonLDAP::NG OpenID Connect documentation](https://lemonldap-ng.org/documentation/latest/idpopenidconnect.html);
+the options below are the Open-Bastion-specific ones.
+
 In the LLNG Manager, create a new OIDC Relying Party:
 
 1. Go to **OpenID Connect Relying Parties** → **Add**

--- a/doc/llng-configuration.md
+++ b/doc/llng-configuration.md
@@ -93,7 +93,7 @@ In the LLNG Manager, create a new OIDC Relying Party:
    - No scope configuration is needed (the requested `pam:server` scope is issued
      as-is); offline sessions are authorized in step 3.
 3. Set the per-RP options that let servers enroll with a **renewable** identity
-   (see [Per-RP Device Authorization Parameters](#per-rp-device-authorization-parameters)):
+   (see [Per-RP Device Authorization Parameters](llng-plugin-parameters.md#per-rp-device-authorization-parameters)):
    - `oidcRPMetaDataOptionsAllowDeviceAuthorization` = `1`
    - `oidcRPMetaDataOptionsDeviceOwnership` = `organization`
    - `oidcRPMetaDataOptionsAllowOffline` = `1`
@@ -140,79 +140,14 @@ plugin's README (linked above) for its full list of parameters.
 > `customPlugins = ::Plugins::OIDCDeviceAuthorization, ::Plugins::OIDCDeviceOrganization, ::Plugins::PamAccess, ::Plugins::SSHCA`
 > (drop `PamAccess` or `SSHCA` per your mode).
 
-## Step 4: Plugin Parameters
+## Plugin parameters
 
-Additional and optional parameters that can be inserted into `lemonldap-ng.ini`, section `[portal]`:
+The optional `[portal]` parameters for these plugins — PamAccess token settings,
+device-authorization tuning, and SSH CA — are listed in a separate reference
+page: **[LemonLDAP::NG Plugin Parameters](llng-plugin-parameters.md)**. The
+defaults are fine for a standard setup.
 
-### General Parameters
-
-| Parameter                                       | Default      | Description                                                                                        |
-| ----------------------------------------------- | ------------ | -------------------------------------------------------------------------------------------------- |
-| `oidcServiceDeviceAuthorizationExpiration`      | `600` (10mn) | Device authorization expiration time                                                               |
-| `oidcServiceDeviceAuthorizationPollingInterval` | `5`          | Polling interval in seconds (clients polling faster get `slow_down` errors)                        |
-| `oidcServiceDeviceAuthorizationUserCodeLength`  | `8`          | Length of user code (base-20 charset, collision-safe)                                              |
-| `portalDisplayPamAccess`                        | `0`          | Set to 1 (or a rule) to display PAM tab                                                            |
-| `pamAccessRp`                                   | `pam-access` | OIDC Relying Party name                                                                            |
-| `pamAccessTokenDuration`                        | `600` (10mn) | Token duration                                                                                     |
-| `pamAccessMaxDuration`                          | `3600` (1h)  | Maximum token duration                                                                             |
-| `pamAccessExportedVars`                         | `{}`         | Exported variables                                                                                 |
-| `pamAccessOfflineTtl`                           | `86400` (1d) | Offline cache TTL                                                                                  |
-| `pamAccessSshRules`                             | `{}`         | SSH access rules                                                                                   |
-| `pamAccessServerGroups`                         | `{}`         | Server groups configuration                                                                        |
-| `pamAccessSudoRules`                            | `{}`         | Sudo rules                                                                                         |
-| `pamAccessOfflineEnabled`                       | `0`          | Enable offline mode                                                                                |
-| `pamAccessHeartbeatInterval`                    | `300` (5mn)  | Heartbeat interval                                                                                 |
-| `pamAccessManagedGroups`                        | `{}`         | Unix groups managed by LLNG per server group (see [Group Synchronization](#group-synchronization)) |
-
-### Per-RP Device Authorization Parameters
-
-These are set in the LLNG Manager on each OIDC Relying Party:
-
-| Parameter                                       | Default | Description                                                                                                                                                                                                           |
-| ----------------------------------------------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `oidcRPMetaDataOptionsAllowDeviceAuthorization` | `0`     | Enable device grant. Can be a rule expression to restrict who can approve                                                                                                                                             |
-| `oidcRPMetaDataOptionsDeviceOwnership`          | (empty) | Set to `organization` for organizational device mode (see below)                                                                                                                                                      |
-| `oidcRPMetaDataOptionsAllowOffline`             | `0`     | Set to `1` to issue an **offline refresh token** so `ob-heartbeat` can renew the server's access token. **Required** for server enrollment (with the `offline_access` scope and `oidc-device-organization` >= 0.3.3). |
-
-### Organizational Device Enrollment
-
-When `oidcRPMetaDataOptionsDeviceOwnership` is set to `organization` on an RP, the **OIDCDeviceOrganization** plugin changes the device authorization behavior:
-
-- An administrator approves the device normally through the `/device` page
-- The resulting tokens identify the **client application** (client_id) instead of the approving admin
-- The device token survives the admin's session expiration or account removal
-- Refresh tokens remain valid independently of the admin's session
-
-This is useful for enrolling servers, kiosks, or IoT devices that belong to the organization rather than a specific user.
-
-For the device to get a **durable** (offline) refresh token, also set
-`oidcRPMetaDataOptionsAllowOffline = 1` and deploy `oidc-device-organization`
-**>= 0.3.3** (earlier versions stripped `offline_access`, leaving the server
-with a non-renewable token). See the critical note under
-[Step 2](#step-2-create-the-oidc-relying-party).
-
-### Device Authorization Security Features
-
-- **CSRF protection**: the `/device` verification form uses a one-time token
-- **Rate limiting**: clients polling faster than the configured interval receive `slow_down` errors with incremental backoff
-- **User code collision detection**: codes are regenerated on collision (up to 10 retries)
-- **Per-RP access rules**: `AllowDeviceAuthorization` accepts boolean expressions to restrict which users can approve devices
-- **CrowdSec integration**: invalid user_code attempts are reported to CrowdSec (scenario `llng/device-auth-bruteforce`)
-
-When offline mode is enabled, the server-side cache is protected by
-[Cache Brute-Force Protection](security.md#cache-brute-force-protection).
-
-### SSH CA Parameters (optional)
-
-| Parameter               | Default    | Description                               |
-| ----------------------- | ---------- | ----------------------------------------- |
-| `portalDisplaySshCa`    | `0`        | Set to 1 (or a rule) to display SSHCA tab |
-| `sshCaCertMaxValidity`  | `365` (1y) | Maximum certificate validity              |
-| `sshCaSerialPath`       | `""`       | Path for certificate serial storage       |
-| `sshCaPrincipalSources` | `$uid`     | Principal sources                         |
-| `sshCaKrlPath`          | `""`       | Path for Key Revocation List              |
-
-## Step 4.1: Generate and Import the SSH CA Key (optional)
+## Step 4: Generate and Import the SSH CA Key (optional)
 
 If you're using the SSH CA plugin for key-based authentication, you need to generate a CA key pair and import it into LemonLDAP::NG.
 

--- a/doc/llng-plugin-parameters.md
+++ b/doc/llng-plugin-parameters.md
@@ -1,0 +1,89 @@
+# LemonLDAP::NG Plugin Parameters
+
+Optional parameters for the Open Bastion LLNG plugins, inserted into
+`lemonldap-ng.ini`, section `[portal]` (or set via the Manager). This is a
+reference companion to [LemonLDAP::NG Configuration](llng-configuration.md) —
+none of these are required to get started.
+
+> **Indicative only.** Names and defaults below are provided for convenience and
+> may lag behind the plugins. The **authoritative** reference is each plugin's
+> own documentation in the
+> [lemonldap-ng-plugins](https://github.com/linagora/lemonldap-ng-plugins/tree/main/plugins)
+> repository (see the per-plugin links at the bottom) — defer to it in case of
+> any doubt or discrepancy.
+
+## General Parameters
+
+| Parameter                                       | Default      | Description                                                                                                             |
+| ----------------------------------------------- | ------------ | ----------------------------------------------------------------------------------------------------------------------- |
+| `oidcServiceDeviceAuthorizationExpiration`      | `600` (10mn) | Device authorization expiration time                                                                                    |
+| `oidcServiceDeviceAuthorizationPollingInterval` | `5`          | Polling interval in seconds (clients polling faster get `slow_down` errors)                                             |
+| `oidcServiceDeviceAuthorizationUserCodeLength`  | `8`          | Length of user code (base-20 charset, collision-safe)                                                                   |
+| `portalDisplayPamAccess`                        | `0`          | Set to 1 (or a rule) to display PAM tab                                                                                 |
+| `pamAccessRp`                                   | `pam-access` | OIDC Relying Party name                                                                                                 |
+| `pamAccessTokenDuration`                        | `600` (10mn) | Token duration                                                                                                          |
+| `pamAccessMaxDuration`                          | `3600` (1h)  | Maximum token duration                                                                                                  |
+| `pamAccessExportedVars`                         | `{}`         | Exported variables                                                                                                      |
+| `pamAccessOfflineTtl`                           | `86400` (1d) | Offline cache TTL                                                                                                       |
+| `pamAccessSshRules`                             | `{}`         | SSH access rules                                                                                                        |
+| `pamAccessServerGroups`                         | `{}`         | Server groups configuration                                                                                             |
+| `pamAccessSudoRules`                            | `{}`         | Sudo rules                                                                                                              |
+| `pamAccessOfflineEnabled`                       | `0`          | Enable offline mode                                                                                                     |
+| `pamAccessHeartbeatInterval`                    | `300` (5mn)  | Heartbeat interval                                                                                                      |
+| `pamAccessManagedGroups`                        | `{}`         | Unix groups managed by LLNG per server group (see [Group Synchronization](llng-configuration.md#group-synchronization)) |
+
+## Per-RP Device Authorization Parameters
+
+These are set in the LLNG Manager on each OIDC Relying Party:
+
+| Parameter                                       | Default | Description                                                                                                                                                                                                           |
+| ----------------------------------------------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `oidcRPMetaDataOptionsAllowDeviceAuthorization` | `0`     | Enable device grant. Can be a rule expression to restrict who can approve                                                                                                                                             |
+| `oidcRPMetaDataOptionsDeviceOwnership`          | (empty) | Set to `organization` for organizational device mode (see below)                                                                                                                                                      |
+| `oidcRPMetaDataOptionsAllowOffline`             | `0`     | Set to `1` to issue an **offline refresh token** so `ob-heartbeat` can renew the server's access token. **Required** for server enrollment (with the `offline_access` scope and `oidc-device-organization` >= 0.3.3). |
+
+## Organizational Device Enrollment
+
+When `oidcRPMetaDataOptionsDeviceOwnership` is set to `organization` on an RP, the **OIDCDeviceOrganization** plugin changes the device authorization behavior:
+
+- An administrator approves the device normally through the `/device` page
+- The resulting tokens identify the **client application** (client_id) instead of the approving admin
+- The device token survives the admin's session expiration or account removal
+- Refresh tokens remain valid independently of the admin's session
+
+This is useful for enrolling servers, kiosks, or IoT devices that belong to the organization rather than a specific user.
+
+For the device to get a **durable** (offline) refresh token, also set
+`oidcRPMetaDataOptionsAllowOffline = 1` and deploy `oidc-device-organization`
+**>= 0.3.3** (earlier versions stripped `offline_access`, leaving the server
+with a non-renewable token). See the critical note under
+[Step 2](llng-configuration.md#step-2-create-the-oidc-relying-party).
+
+## Device Authorization Security Features
+
+- **CSRF protection**: the `/device` verification form uses a one-time token
+- **Rate limiting**: clients polling faster than the configured interval receive `slow_down` errors with incremental backoff
+- **User code collision detection**: codes are regenerated on collision (up to 10 retries)
+- **Per-RP access rules**: `AllowDeviceAuthorization` accepts boolean expressions to restrict which users can approve devices
+- **CrowdSec integration**: invalid user_code attempts are reported to CrowdSec (scenario `llng/device-auth-bruteforce`)
+
+When offline mode is enabled, the server-side cache is protected by
+[Cache Brute-Force Protection](security.md#cache-brute-force-protection).
+
+## SSH CA Parameters (optional)
+
+| Parameter               | Default    | Description                               |
+| ----------------------- | ---------- | ----------------------------------------- |
+| `portalDisplaySshCa`    | `0`        | Set to 1 (or a rule) to display SSHCA tab |
+| `sshCaCertMaxValidity`  | `365` (1y) | Maximum certificate validity              |
+| `sshCaSerialPath`       | `""`       | Path for certificate serial storage       |
+| `sshCaPrincipalSources` | `$uid`     | Principal sources                         |
+| `sshCaKrlPath`          | `""`       | Path for Key Revocation List              |
+
+## See Also
+
+- [LemonLDAP::NG Configuration](llng-configuration.md) — the setup walkthrough
+- Per-plugin READMEs: [pam-access](https://github.com/linagora/lemonldap-ng-plugins/tree/main/plugins/pam-access#readme),
+  [ssh-ca](https://github.com/linagora/lemonldap-ng-plugins/tree/main/plugins/ssh-ca#readme),
+  [oidc-device-authorization](https://github.com/linagora/lemonldap-ng-plugins/tree/main/plugins/oidc-device-authorization#readme),
+  [oidc-device-organization](https://github.com/linagora/lemonldap-ng-plugins/tree/main/plugins/oidc-device-organization#readme)

--- a/doc/pam-modes.md
+++ b/doc/pam-modes.md
@@ -369,6 +369,7 @@ sudo systemctl restart sshd
 
 ## See Also
 
+- [Access & Permissions](permissions.md) - Which controls live SSO-side vs server-side
 - [LemonLDAP::NG Configuration](llng-configuration.md) - Server-side setup
 - [Configuration Reference](configuration.md) - All configuration options
 - [Service Accounts](service-accounts.md) - SSH key authentication for automation

--- a/doc/permissions.md
+++ b/doc/permissions.md
@@ -1,0 +1,127 @@
+# Access & Permissions: what you can control, and where
+
+Open Bastion enforces access on **two layers**. Knowing which layer owns a given
+decision is the key to operating it well:
+
+- **SSO side (LemonLDAP::NG)** — _who_ may connect to which servers and _who_ may
+  `sudo`, driven by **groups**. Centralized, applies fleet-wide, changes take
+  effect in minutes.
+- **Open Bastion side (per server)** — _how_ authentication and authorization are
+  enforced locally: the PAM mode, the sudo policy, key-only service accounts,
+  user provisioning, containment hardening, and any `sshd`/PAM tweaks.
+
+The recommended posture is **"the SSO decides"**: keep per-server files minimal
+and drive everything from LLNG groups. But every local knob below remains
+available for defense-in-depth or for hosts that need a local exception
+(see [Dual management](#dual-management)).
+
+## Quick map — "I want to control X. Where?"
+
+| Goal                                            | Layer            | How                                                                                           |
+| ----------------------------------------------- | ---------------- | --------------------------------------------------------------------------------------------- |
+| Who can SSH into which servers                  | **SSO**          | [Server groups](llng-configuration.md#server-groups) + `pam-access` rules                     |
+| Who can `sudo`                                  | **SSO** (+local) | LLNG group → sudo authorization; optionally local `sudoers`                                   |
+| Make `sudo` require a fresh SSO token           | **OB**           | [PAM Mode E](pam-modes.md) (max-security)                                                     |
+| Which SSH **key types/sizes** are allowed       | **OB**           | `ssh_key_policy_enabled`, `ssh_key_allowed_types` ([security](security.md#ssh-key-policy))    |
+| Auth method (token / SSH key / password)        | **OB**           | [PAM mode A–E](pam-modes.md)                                                                  |
+| Non-SSO automation logins (ansible, backup, CI) | **OB**           | [`service-accounts.conf`](service-accounts.md)                                                |
+| Auto-created home / shell / UID-GID range       | **OB**           | provisioning keys in [`openbastion.conf`](configuration.md)                                   |
+| Which Unix groups are synced from LLNG          | **both**         | LLNG `managed_groups` + local `allowed_managed_groups` whitelist                              |
+| Process containment (kill on logout, at/cron)   | **OB**           | [`--enable-hardening`](hardening.md)                                                          |
+| Bastion → backend connection trust              | **both**         | LLNG signs the hop cert; backend `allowed_bastions` ([architecture](bastion-architecture.md)) |
+| Revoke an admin everywhere                      | **SSO**          | remove from the group / close the account (see below)                                         |
+| Onboard an admin                                | **SSO**          | add to the right group; they self-serve their SSH cert                                        |
+
+## SSO side (LemonLDAP::NG)
+
+Configured once in the portal, applied to the whole fleet. See
+[LemonLDAP::NG Configuration](llng-configuration.md) for the setup.
+
+- **Server groups** — tag each enrolled server with a group; access rules are
+  written per group, not per host. See
+  [Server groups](llng-configuration.md#server-groups).
+- **Access rules (`pam-access`)** — for a given server group, decide which LLNG
+  user groups may open an SSH session and which may `sudo`. This is the primary
+  "who can do what, where" control.
+- **SSH CA (`ssh-ca`)** — LLNG signs users' SSH certificates (validity window,
+  principals). Users self-serve a cert with `ob-ssh-cert`; closing their account
+  or letting the cert expire removes access. See the SSH CA section of
+  [llng-configuration](llng-configuration.md).
+- **Group synchronization** — LLNG advertises a user's `managed_groups`; the PAM
+  module maps them to Unix supplementary groups on login (creating groups when
+  needed). Pair with the local whitelist below.
+- **Lifecycle**
+  - _Onboarding_: add the user to a group → rights apply on next login.
+  - _Role change_: change their groups → old rights drop and new ones apply
+    within minutes (bounded by the [offline cache](offline-mode.md) TTL).
+  - _Offboarding_: remove from the group or close the SSO account. See the
+    detailed [offboarding procedure](security/03-offboarding.md).
+
+## Open Bastion side (per server)
+
+Written into `/etc/open-bastion/` by `ob-bastion-setup` / `ob-backend-setup` /
+`ob-standalone-setup` (or the [ob-builder](../admin-builder/README.md) artefacts).
+
+- **PAM mode (A–E)** — the strictness of authentication and whether `sudo` is
+  token-gated. Mode E (max-security) accepts only SSO-signed certs, requires a
+  fresh LLNG token for `sudo`, and enforces a KRL. See
+  [PAM Authentication Modes](pam-modes.md).
+- **sudo policy** — token-gated via `pam_openbastion` (Mode E), and/or a local
+  rule: the setups create the `open-bastion-sudo` group and
+  `/etc/sudoers.d/open-bastion`. A host can also keep its own classic `sudoers`
+  in parallel.
+- **Service accounts** — key-only local accounts that bypass OIDC, with a local
+  sudo grant. Powerful and local: see the trade-offs (sudo without token,
+  reachability requirements) in [Service Accounts](service-accounts.md).
+- **User provisioning** — shell, home, UID/GID ranges, skeleton dir, plus the
+  `approved_shells` / `approved_home_prefixes` allow-lists that bound what a
+  provisioned (or service) account may use. See [Configuration](configuration.md).
+- **Group-sync whitelist** — `allowed_managed_groups` limits which LLNG-managed
+  groups may be created/modified locally (defense-in-depth); groups outside the
+  pool are never touched. See [Configuration](configuration.md).
+- **Offline resilience** — `cache_enabled`, `cache_ttl`, and a shorter high-risk
+  TTL bound how long cached authorizations survive an SSO outage. See
+  [Offline mode](offline-mode.md) and [cache administration](offline-cache-admin.md).
+- **Containment hardening** — opt-in `--enable-hardening` adds logind
+  `KillUserProcesses`, an `nproc` cap and `at`/`cron` allow-lists. See
+  [Hardening](hardening.md).
+
+### Tuning the generated `sshd` / PAM configuration
+
+The setups own two things you may want to extend:
+
+- **`sshd` drop-ins** under `/etc/ssh/sshd_config.d/` (e.g.
+  `00-open-bastion-*.conf`, and `60-max-security.conf` in Mode E). You can layer
+  **additional** drop-ins for site policy — for example an
+  `AuthorizedKeysCommand` to serve [service-account keys](service-accounts.md) in
+  Mode E, or `AllowTcpForwarding no` to close the port-forward channel. Mind
+  `sshd`'s "first value wins" rule for single-valued keywords (the `00-` prefix
+  makes the Open Bastion settings win over distro drop-ins).
+- **`/etc/pam.d/sshd`** (and `/etc/pam.d/sudo`, `sudo-i`) — the PAM stacks that
+  invoke `pam_openbastion`. You can add stock PAM modules (e.g. `pam_systemd`,
+  `pam_mkhomedir` options) around them.
+
+> **Re-running a setup regenerates these files.** Keep site additions in
+> separate, higher-numbered `sshd_config.d` drop-ins where possible, and re-apply
+> PAM changes after an upgrade (re-running `ob-*-setup` is the supported path —
+> see the upgrade notes in the [CHANGELOG](../CHANGELOG.md)).
+
+## Dual management
+
+The two layers are complementary, not exclusive:
+
+- **SSO-only (recommended)** — no local sudoers, no service accounts; every
+  decision comes from LLNG groups. Simplest to reason about and audit.
+- **SSO + local** — keep specific local exceptions alongside the SSO: a
+  break-glass [service account](service-accounts.md), a host-local `sudoers`
+  rule, or a stricter PAM mode on a sensitive host. Local grants are **not**
+  visible to the SSO, so inventory and review them deliberately (see the EBIOS
+  risks for service accounts in [risk reduction](security/99-risk-reduce.md)).
+
+## See also
+
+- [PAM Authentication Modes](pam-modes.md) — the A–E matrix
+- [LemonLDAP::NG Configuration](llng-configuration.md) — server-side setup
+- [Configuration Reference](configuration.md) — every `openbastion.conf` key
+- [Service Accounts](service-accounts.md) — key-only local accounts
+- [Bastion Architecture](bastion-architecture.md) — bastion→backend trust

--- a/doc/service-accounts.md
+++ b/doc/service-accounts.md
@@ -285,6 +285,7 @@ service_accounts_file = /etc/open-bastion/service-accounts.conf
 
 ## See Also
 
+- [Access & Permissions](permissions.md) - Which controls live SSO-side vs server-side
 - [Configuration Reference](configuration.md) - All configuration options
 - [PAM Authentication Modes](pam-modes.md) - PAM configurations
 - [Security Features](security.md) - SSH key policies

--- a/doc/troubleshooting.md
+++ b/doc/troubleshooting.md
@@ -44,13 +44,47 @@ curl -X POST https://auth.example.com/pam/authorize \
 
 ## Common issues
 
-| Issue                        | Cause                 | Solution                                     |
-| ---------------------------- | --------------------- | -------------------------------------------- |
-| `PAM unable to load module`  | Module not in path    | Check `/lib/security/` or `/lib64/security/` |
-| `Token introspection failed` | Wrong credentials     | Verify client_id and client_secret           |
-| `Server not enrolled`        | Missing/invalid token | Run `ob-enroll`                              |
-| `User not authorized`        | Server group rules    | Check LLNG Manager configuration             |
-| `Connection refused`         | Portal unreachable    | Check network and portal_url                 |
+| Issue                              | Cause                           | Solution                                           |
+| ---------------------------------- | ------------------------------- | -------------------------------------------------- |
+| `PAM unable to load module`        | Module not in path              | Check `/lib/security/` or `/lib64/security/`       |
+| `Token introspection failed`       | Wrong credentials               | Verify client_id and client_secret                 |
+| `Server not enrolled`              | Missing/invalid token           | Run `ob-enroll`                                    |
+| `User not authorized`              | Server group rules              | Check LLNG Manager configuration                   |
+| `Connection refused`               | Portal unreachable              | Check network and portal_url                       |
+| `Too many authentication failures` | Client offers too many SSH keys | `ssh -o IdentitiesOnly=yes -i <key> …` (see below) |
+
+## "Too many authentication failures"
+
+```
+Received disconnect from <host>: Too many authentication failures
+```
+
+This is a **client-side** problem, not an Open Bastion rejection. When you have
+many SSH keys (in `~/.ssh` or loaded in an `ssh-agent`), the SSH client offers
+them all, one by one, before the one that actually works. `sshd` counts every
+offered key as a failed attempt and drops the connection once it exceeds
+`MaxAuthTries` (default 6) — so the right key is never reached.
+
+Tell the client to offer **only** the key you specify:
+
+```bash
+ssh -o IdentitiesOnly=yes -i ~/.ssh/id_for_this_host user@host
+```
+
+To make it permanent, pin it per host in `~/.ssh/config`:
+
+```sshconfig
+Host bastion.example.com
+    IdentityFile ~/.ssh/id_for_this_host
+    IdentitiesOnly yes
+    # If an agent holds many keys and still interferes, also:
+    # IdentityAgent none
+```
+
+`IdentitiesOnly yes` makes the client present only the listed `IdentityFile`(s)
+instead of every key the agent advertises. This also matters when using an
+SSO-signed certificate: pin the cert's key with `-i` + `IdentitiesOnly=yes` (the
+`ob-ssh` / `ob-scp` / `ob-sftp` connectors already do this internally).
 
 ## Re-enrollment
 

--- a/doc/troubleshooting.md
+++ b/doc/troubleshooting.md
@@ -1,0 +1,62 @@
+# Troubleshooting
+
+Common checks and fixes when SSH/sudo access or enrollment misbehaves. See also
+the [Configuration Reference](configuration.md), [PAM modes](pam-modes.md) and
+[Access & Permissions](permissions.md).
+
+## Check logs
+
+```bash
+# System auth log
+sudo tail -f /var/log/auth.log
+
+# Or journald
+sudo journalctl -u sshd -f
+```
+
+`pam_openbastion` logs to the `authpriv` facility, so its detailed messages are
+only visible to root / the `adm` group.
+
+## Enable debug mode
+
+In `/etc/open-bastion/openbastion.conf`:
+
+```ini
+log_level = debug
+```
+
+## Test token introspection
+
+```bash
+curl -X POST https://auth.example.com/oauth2/introspect \
+  -u "pam-access:secret" \
+  -d "token=<user_token>"
+```
+
+## Test the authorization endpoint
+
+```bash
+curl -X POST https://auth.example.com/pam/authorize \
+  -H "Authorization: Bearer $(sudo cat /var/lib/open-bastion/token)" \
+  -H "Content-Type: application/json" \
+  -d '{"user": "testuser", "host": "'$(hostname)'", "server_group": "default"}'
+```
+
+## Common issues
+
+| Issue                        | Cause                 | Solution                                     |
+| ---------------------------- | --------------------- | -------------------------------------------- |
+| `PAM unable to load module`  | Module not in path    | Check `/lib/security/` or `/lib64/security/` |
+| `Token introspection failed` | Wrong credentials     | Verify client_id and client_secret           |
+| `Server not enrolled`        | Missing/invalid token | Run `ob-enroll`                              |
+| `User not authorized`        | Server group rules    | Check LLNG Manager configuration             |
+| `Connection refused`         | Portal unreachable    | Check network and portal_url                 |
+
+## Re-enrollment
+
+If the server token expires or is compromised:
+
+```bash
+sudo rm /var/lib/open-bastion/token
+sudo ob-enroll
+```


### PR DESCRIPTION
## Summary

Restructures the documentation for **progressive discovery** (#166). No source
changes; `doc/security/` (the EBIOS study) is intentionally left untouched.

## What changed

**`README.md` — discovery-first**
- Leads with a **value proposition** ("What Open Bastion gives you": SSO decides
  SSH/sudo, no per-server keys/sudoers, no recorder bypass, fleet deploy,
  self-service onboarding, instant offboarding/role-change).
- Adds a concise **"How it works"** overview (auth → `/pam/authorize` → NSS →
  bastion cert hop → recording).
- **Promotes the three quick-starts** up front, then points to a theme-organized
  index instead of a flat link table.

**`doc/README.md` — themed index**
- Regrouped by theme: _start here · connections & architecture · access &
  permissions · session recording & audit · offline & resilience · security &
  hardening · reference · security analysis (EBIOS)_, in rough reading order.

**`doc/permissions.md` — new advanced doc (the requested gap)**
- Consolidates **which access control lives SSO-side vs Open-Bastion-side**, with
  a "where do I set X?" map table, an SSO-side section (server groups, pam-access
  rules, SSH CA, group sync, lifecycle), an OB-side section (PAM modes, sudo
  policy, service accounts, provisioning, group-sync whitelist, offline,
  hardening), a section on **tuning the generated `sshd`/PAM config**, and a
  "dual management" note. This material was previously scattered across the PAM,
  LLNG, configuration and hardening docs.

**Cross-linking**
- Added an "Access & Permissions" See-Also link from `pam-modes.md`,
  `llng-configuration.md` and `service-accounts.md`.

## Scope / safety
- **No file moved or renamed** → existing inbound links keep working.
- `doc/security/` (EBIOS) unchanged, per the request.
- All relative links verified to resolve; markdown is `prettier`-clean.

Closes #166
