### PR TITLE
docs(readme): add Linagora logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Open Bastion
 
+[![Linagora](linagora.png)](https://linagora.com)
+
 **Control SSH access and sudo privileges on your Linux servers from your SSO —
 no more per-server keys or sudoers.**
 
@@ -254,8 +256,6 @@ AGPL-3.0
 Xavier Guimard <xguimard@linagora.com>
 
 Copyright (C) [Linagora](https://linagora.com)
-
-[![Linagora](linagora.png)](https://linagora.com)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
-# Open Bastion
+<p align="center">
+  <a href="https://linagora.com"><img src="linagora.png" alt="Linagora"></a>
+</p>
 
-[![Linagora](linagora.png)](https://linagora.com)
+# Open Bastion
 
 **Control SSH access and sudo privileges on your Linux servers from your SSO —
 no more per-server keys or sudoers.**

--- a/README.md
+++ b/README.md
@@ -255,6 +255,8 @@ Xavier Guimard <xguimard@linagora.com>
 
 Copyright (C) [Linagora](https://linagora.com)
 
+[![Linagora](linagora.png)](https://linagora.com)
+
 ---
 
 [^1]: This is optional, of course: you can keep non-Open-Bastion backends and manage them the old way, with SSH keys.


### PR DESCRIPTION
Adds the `linagora.png` logo (linked to linagora.com) in the README footer next to the copyright, matching its use in `presentation.md`.