### PR TITLE
feat(ob-ssh): run a one-shot command on the backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `/var/lib/open-bastion/sessions`, preserving the tamper-evident layout. See
   `doc/session-recording.md` and `ob-session-prune(8)`.
 
+### Fixed
+
+- **`ob-scp` / `ob-sftp` no longer shadow `scp`/`sftp`'s own `-c CIPHER`.** Their
+  config option is now long-only (`--config`); a short `-c` used to be consumed
+  as the config path, so `ob-scp -c aes256-gcm@openssh.com …` never reached
+  `scp`. Other options (`-p`, `-P PORT`, `-r`, `-b FILE`, `-l`, …) already passed
+  through and still do; use `--` to end ob-* option parsing explicitly.
+
 ### Documentation
 
 - **Docs reorganized for progressive discovery.** `README.md` now leads with a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`ob-ssh` can run a one-shot command on the backend.** A trailing command is
+  now forwarded to the backend (`ob-ssh backend uptime`) and run
+  non-interactively — no pty, output captured verbatim, like `ssh host cmd` —
+  instead of being mis-read as a port (`Bad port '...'`). New `-p`/`--port`,
+  `-l`/`--login` and `-o` (ssh option passthrough) flags, plus `--` to end
+  option parsing; the legacy positional `[port]` still works. Works in both
+  direct and `ForceCommand` modes. From a workstation whose `ssh_config` sets
+  `RemoteCommand ob-ssh ...`, override it to append the command:
+  `ssh -o RemoteCommand="ob-ssh 10.0.0.5 ls -la" backend1` (ssh forbids
+  combining a command-line command with a configured `RemoteCommand`).
 - **`ob-sftp` bastion file-transfer connector.** The `sftp` counterpart of
   `ob-ssh` / `ob-scp`: run on a bastion, it mints a short-lived,
   LLNG-signed certificate (via the shared `ob-cert-lib.sh`) and opens an

--- a/man/ob-scp.1
+++ b/man/ob-scp.1
@@ -31,9 +31,18 @@ so a direct backend-to-backend transfer would be rejected. Routing every
 connection through the bastion keeps the source address matching the
 certificate.
 .SH OPTIONS
-Options consumed by ob-scp itself must come first:
+Options consumed by ob-scp itself must come first. Any further options are
+passed straight to
+.BR scp (1)
+\(em including
+.BR scp 's
+own
+.BR \-c " " \fICIPHER\fR,
+which is why ob-scp's config option is long-only (a short
+.B \-c
+would shadow it).
 .TP
-.BR \-c ", " \-\-config " " \fIFILE\fR
+.BR \-\-config " " \fIFILE\fR
 Use alternate configuration file (default: /etc/open-bastion/ssh-proxy.conf)
 .TP
 .BR \-d ", " \-\-debug

--- a/man/ob-sftp.1
+++ b/man/ob-sftp.1
@@ -34,9 +34,18 @@ the ephemeral private key lives in tmpfs and is wiped when
 .B ob-sftp
 exits.
 .SH OPTIONS
-Options consumed by ob-sftp itself must come first:
+Options consumed by ob-sftp itself must come first. Any further options are
+passed straight to
+.BR sftp (1)
+\(em including
+.BR sftp 's
+own
+.BR \-c " " \fICIPHER\fR,
+which is why ob-sftp's config option is long-only (a short
+.B \-c
+would shadow it).
 .TP
-.BR \-c ", " \-\-config " " \fIFILE\fR
+.BR \-\-config " " \fIFILE\fR
 Use alternate configuration file (default: /etc/open-bastion/ssh-proxy.conf)
 .TP
 .BR \-d ", " \-\-debug

--- a/man/ob-ssh.1
+++ b/man/ob-ssh.1
@@ -3,7 +3,7 @@
 ob-ssh \- bastion-to-backend SSH connector with LLNG certificate vouching
 .SH SYNOPSIS
 .B ob-ssh
-[\fIOPTIONS\fR] [\fIuser@\fR]\fIbackend\fR [\fIport\fR]
+[\fIOPTIONS\fR] [\fIuser@\fR]\fIbackend\fR [\fIport\fR] [\fIcommand ...\fR]
 .SH DESCRIPTION
 .B ob-ssh
 runs on a bastion server, invoked by a user already authenticated to the
@@ -29,10 +29,16 @@ POSTs the ephemeral public key plus the voucher to LemonLDAP::NG
 user, pinned to the bastion's source address, bastion_id in the key-id).
 .IP 4. 4
 Connects to the backend with that certificate.
+.PP
+With no trailing \fIcommand\fR an interactive shell is opened on the backend.
+When a \fIcommand\fR is given it is run non-interactively (no pty is requested,
+mirroring \fBssh\fR(1) \fIhost command\fR) and its output is returned verbatim,
+so it pipes and captures cleanly.
 .SS Modes
 .TP
 .B Direct mode
-Called with a target host argument (the common case).
+Called with a target host argument (the common case), optionally followed by a
+command to run on the backend.
 .TP
 .B ForceCommand mode
 When \fBSSH_ORIGINAL_COMMAND\fR is set (used as an sshd ForceCommand).
@@ -43,6 +49,22 @@ When neither a target argument nor SSH_ORIGINAL_COMMAND is set, prompts for one.
 .TP
 .BR \-c ", " \-\-config " " \fIFILE\fR
 Use alternate configuration file (default: /etc/open-bastion/ssh-proxy.conf)
+.TP
+.BR \-p ", " \-\-port " " \fIPORT\fR
+Backend SSH port; overrides the legacy positional \fIport\fR argument.
+.TP
+.BR \-l ", " \-\-login " " \fIUSER\fR
+Backend login user; overrides \fB$USER\fR for a bare (user-less) host.
+.TP
+.BI \-o " OPTION"
+Pass an
+.BR ssh (1)
+\fB\-o\fR option through to the backend connection (e.g. \fB\-o
+ServerAliveInterval=30\fR). May be repeated; appended after the config's
+\fBSSH_OPTIONS\fR.
+.TP
+.B \-\-
+End option parsing; the host and command follow.
 .TP
 .BR \-d ", " \-\-debug
 Enable debug output to stderr
@@ -142,6 +164,15 @@ $ ob-ssh backend-web01
 
 # Different remote user and port:
 $ ob-ssh admin@backend-web01 2222
+
+# Run a single command on the backend (non-interactive, output captured):
+$ ob-ssh backend-web01 uptime
+$ ob-ssh admin@backend-web01 -p 2222 -- systemctl status nginx
+
+# From a workstation through an ssh_config "RemoteCommand ob-ssh ..." entry,
+# override RemoteCommand to append the backend command (ssh forbids combining a
+# command-line command with a configured RemoteCommand):
+$ ssh -o RemoteCommand="ob-ssh 10.0.0.5 ls -la" backend1
 .fi
 .SH SEE ALSO
 .BR ob-scp (1),

--- a/scripts/ob-scp
+++ b/scripts/ob-scp
@@ -29,7 +29,7 @@
 
 set -euo pipefail
 
-VERSION="0.2.3"
+VERSION="0.2.4"
 PROG_NAME=$(basename "$0")
 
 # Source the shared cert-vouching library: the installed path first, then
@@ -56,12 +56,14 @@ through the bastion (scp -3) so they match the certificate's pinned source
 address.
 
 Options (consumed by $PROG_NAME, must come first):
-  -c, --config FILE   Use alternate config file (default: $CONFIG_FILE)
+      --config FILE   Use alternate config file (default: $CONFIG_FILE)
   -d, --debug         Enable debug output
   -h, --help          Show this help
   -V, --version       Show version
 
-Any further options are passed straight to scp (e.g. -r, -P PORT, -p, -C, -l).
+Any further options are passed straight to scp (e.g. -r, -P PORT, -p, -C, -l,
+and -c CIPHER — scp's own -c is no longer shadowed by a config short option).
+Use -- to end $PROG_NAME option parsing explicitly.
 
 Examples:
   $PROG_NAME ./data.tar dwho@backend1:/tmp/
@@ -101,7 +103,9 @@ SCP_ARGS=()
 parse_args() {
     while [ $# -gt 0 ]; do
         case "$1" in
-            -c|--config) CONFIG_FILE="$2"; shift 2 ;;
+            # --config is long-only on purpose: scp's own -c selects a cipher, so
+            # a short -c here would shadow it and never reach scp.
+            --config)    CONFIG_FILE="$2"; shift 2 ;;
             -d|--debug)
                 # DEBUG is consumed by debug() in ob-cert-lib.sh (sourced above).
                 # shellcheck disable=SC2034

--- a/scripts/ob-sftp
+++ b/scripts/ob-sftp
@@ -22,7 +22,7 @@
 
 set -euo pipefail
 
-VERSION="0.2.3"
+VERSION="0.2.4"
 PROG_NAME=$(basename "$0")
 
 # Source the shared cert-vouching library: the installed path first, then
@@ -48,12 +48,14 @@ vouched certificate authenticates as a single principal). No SSH key of your
 own on the bastion and no agent forwarding are needed.
 
 Options (consumed by $PROG_NAME, must come first):
-  -c, --config FILE   Use alternate config file (default: $CONFIG_FILE)
+      --config FILE   Use alternate config file (default: $CONFIG_FILE)
   -d, --debug         Enable debug output
   -h, --help          Show this help
   -V, --version       Show version
 
-Any further options are passed straight to sftp (e.g. -r, -P PORT, -b FILE, -C).
+Any further options are passed straight to sftp (e.g. -r, -P PORT, -b FILE, -C,
+and -c CIPHER — sftp's own -c is no longer shadowed by a config short option).
+Use -- to end $PROG_NAME option parsing explicitly.
 
 Examples:
   $PROG_NAME dwho@backend1
@@ -84,7 +86,9 @@ SFTP_ARGS=()
 parse_args() {
     while [ $# -gt 0 ]; do
         case "$1" in
-            -c|--config) CONFIG_FILE="$2"; shift 2 ;;
+            # --config is long-only on purpose: sftp's own -c selects a cipher, so
+            # a short -c here would shadow it and never reach sftp.
+            --config)    CONFIG_FILE="$2"; shift 2 ;;
             -d|--debug)
                 # DEBUG is consumed by debug() in ob-cert-lib.sh (sourced above).
                 # shellcheck disable=SC2034

--- a/scripts/ob-ssh
+++ b/scripts/ob-ssh
@@ -32,8 +32,17 @@
 
 set -euo pipefail
 
-VERSION="0.2.3"
+VERSION="0.3.0"
 PROG_NAME=$(basename "$0")
+
+# Remote command to run on the backend. Empty => interactive shell (the historic
+# behaviour). Populated by parse_args (direct mode) or force_command_mode, then
+# appended verbatim to the backend ssh invocation as separate argv elements (no
+# shell re-splitting on the bastion). Declared here so `set -u` is satisfied even
+# on code paths that never set it.
+REMOTE_CMD=()
+# Default login user from -l/--login; overrides $USER for a bare (user-less) host.
+OB_LOGIN_USER=""
 
 # Source the shared cert-vouching library: the installed path first, then
 # alongside this script (running from the source tree / tests).
@@ -66,21 +75,29 @@ connect_via_cert() {
     trap "rm -rf '$OB_EPH_DIR'" EXIT
 
     # TTY handling — the crux of correct interactive behaviour through the hop:
-    #   * interactive (stdin is a tty): force a remote pty with -tt. ssh then
+    #   * a remote command was given (`ob-ssh host cmd...`): mirror ssh(1) and do
+    #     NOT allocate a pty (-T). Output stays clean (no \r, no pty echo) so it
+    #     pipes and captures like a normal `ssh host cmd`.
+    #   * interactive shell, stdin is a tty: force a remote pty with -tt. ssh then
     #     puts the bastion-side tty into raw mode, so input is echoed ONCE (by
     #     the backend pty, not also by the bastion tty), and Ctrl-C / a failing
     #     command act on the REMOTE shell instead of tearing down this proxy.
     #     Relying on ssh's tty auto-detection here is fragile and is what
     #     produced the double-echo / shell-killed-on-Ctrl-C reports.
-    #   * non-interactive (piped stdin, e.g. a scripted command): -T, no pty.
+    #   * interactive shell, piped stdin (e.g. a here-doc fed to the shell): -T.
     local -a tty_opt
-    if [ -t 0 ]; then
+    if [ "${#REMOTE_CMD[@]}" -gt 0 ]; then
+        tty_opt=(-T)
+    elif [ -t 0 ]; then
         tty_opt=(-tt)
     else
         tty_opt=(-T)
     fi
 
-    # Re-originate: the BASTION authenticates to the backend with the cert.
+    # Re-originate: the BASTION authenticates to the backend with the cert. Any
+    # REMOTE_CMD is appended AFTER the host as separate argv elements: ssh sends
+    # it to the backend to run, and the array keeps each word intact (no bastion
+    # re-splitting / globbing). Empty array expands to nothing under `set -u`.
     local rc=0
     ssh -i "$OB_EPH_KEY" \
         -o CertificateFile="$OB_EPH_CERT" \
@@ -90,7 +107,7 @@ connect_via_cert() {
         -p "$target_port" \
         "${SSH_OPTIONS_ARRAY[@]}" \
         -l "$target_user" \
-        -- "$target_host" || rc=$?
+        -- "$target_host" "${REMOTE_CMD[@]}" || rc=$?
 
     exit $rc
 }
@@ -112,7 +129,7 @@ parse_target_spec() {
 direct_mode() {
     local spec="$1"
     local port="${2:-22}"
-    local user="${USER:-$(whoami)}"
+    local user="${OB_LOGIN_USER:-${USER:-$(whoami)}}"
     parse_target_spec "$spec" "$user"
     connect_via_cert "$SPEC_HOST" "$SPEC_USER" "$port"
 }
@@ -160,6 +177,11 @@ force_command_mode() {
         exit 1
     fi
 
+    # Anything after the host token is the command to run on the backend, e.g.
+    # `ssh backend ls -la` -> REMOTE_CMD=(ls -la). i points at the host; in both
+    # the `--` and bare-host branches the command therefore starts at i+1.
+    REMOTE_CMD=("${toks[@]:$((i + 1))}")
+
     parse_target_spec "$target" "$user"
     connect_via_cert "$SPEC_HOST" "$SPEC_USER" "$port"
 }
@@ -187,23 +209,31 @@ interactive_mode() {
 # Show usage
 usage() {
     cat <<EOF
-Usage: $PROG_NAME [OPTIONS] [user@]backend [port]
+Usage: $PROG_NAME [OPTIONS] [user@]backend [port] [command...]
 
 Bastion-to-backend SSH connector with LLNG certificate vouching. Run on a
 bastion by a user already authenticated to it; the bastion mints a short-lived,
 LLNG-signed certificate and re-originates the SSH connection to the backend.
 No SSH key of your own on the bastion and no agent forwarding are needed.
 
+With no command, an interactive shell is opened on the backend. With a trailing
+command, it is run non-interactively (like \`ssh host cmd\`) and its output is
+returned verbatim, e.g. \`$PROG_NAME backend uptime\`.
+
 Modes:
-  Direct mode:        $PROG_NAME [user@]backend [port]
+  Direct mode:        $PROG_NAME [user@]backend [port] [command...]
   ForceCommand mode:  $PROG_NAME            (reads SSH_ORIGINAL_COMMAND)
   Interactive mode:   $PROG_NAME            (prompts for target)
 
 Options:
   -c, --config FILE   Use alternate config file (default: $CONFIG_FILE)
+  -p, --port PORT     Backend SSH port (overrides the positional [port])
+  -l, --login USER    Backend login user (overrides \$USER for a bare host)
+  -o OPTION           Pass an ssh -o option through to the backend connection
   -d, --debug         Enable debug output
   -h, --help          Show this help
   -V, --version       Show version
+  --                  End option parsing (host and command follow)
 
 Configuration ($CONFIG_FILE):
     PORTAL_URL="https://auth.example.com"
@@ -220,6 +250,8 @@ EOF
 
 # Parse arguments
 parse_args() {
+    REMOTE_CMD=()
+    local explicit_port=""
     while [ $# -gt 0 ]; do
         case "$1" in
             -c|--config)
@@ -232,6 +264,21 @@ parse_args() {
                 DEBUG=true
                 shift
                 ;;
+            -p|--port)
+                explicit_port="$2"
+                shift 2
+                ;;
+            -l|--login)
+                OB_LOGIN_USER="$2"
+                shift 2
+                ;;
+            -o)
+                # Pass an arbitrary ssh option through to the backend connection,
+                # e.g. `-o ServerAliveInterval=30`. Appended to the array already
+                # seeded from the config's SSH_OPTIONS.
+                SSH_OPTIONS_ARRAY+=("-o" "$2")
+                shift 2
+                ;;
             -h|--help)
                 usage
                 exit 0
@@ -239,6 +286,11 @@ parse_args() {
             -V|--version)
                 echo "$PROG_NAME version $VERSION"
                 exit 0
+                ;;
+            --)
+                # Explicit end of options; everything after is host + command.
+                shift
+                break
                 ;;
             -*)
                 error "Unknown option: $1"
@@ -251,9 +303,22 @@ parse_args() {
         esac
     done
 
-    # Remaining arguments: [user@]host [port]
+    # Remaining positional arguments: [user@]host [port] [command...]
     TARGET_SPEC="${1:-}"
-    TARGET_PORT="${2:-22}"
+    [ $# -gt 0 ] && shift
+
+    # A purely-numeric next token is the legacy positional port (kept for
+    # backward compatibility, e.g. `ob-ssh admin@backend 2222`). Otherwise the
+    # rest of the line is the command to run on the backend.
+    TARGET_PORT=22
+    if [ $# -gt 0 ] && [[ "$1" =~ ^[0-9]+$ ]]; then
+        TARGET_PORT="$1"
+        shift
+    fi
+    REMOTE_CMD=("$@")
+
+    # An explicit -p/--port wins over the positional port.
+    [ -n "$explicit_port" ] && TARGET_PORT="$explicit_port"
 }
 
 # Main

--- a/scripts/ob-ssh
+++ b/scripts/ob-ssh
@@ -317,8 +317,13 @@ parse_args() {
     fi
     REMOTE_CMD=("$@")
 
-    # An explicit -p/--port wins over the positional port.
-    [ -n "$explicit_port" ] && TARGET_PORT="$explicit_port"
+    # An explicit -p/--port wins over the positional port. Use an `if` (not a
+    # `&&` list) so parse_args does NOT return the test's non-zero status as its
+    # own exit code: under `set -e` that would abort the whole script the moment
+    # no -p was given (i.e. almost always).
+    if [ -n "$explicit_port" ]; then
+        TARGET_PORT="$explicit_port"
+    fi
 }
 
 # Main

--- a/tests/test_ob_scp.sh
+++ b/tests/test_ob_scp.sh
@@ -182,6 +182,46 @@ TESTSCRIPT
     fi
 }
 
+# parse_args: own options are consumed, everything else (incl. scp's own -c
+# CIPHER) reaches SCP_ARGS. Regression: a short -c used to be ob-scp's --config
+# and swallowed scp's cipher option so it never reached scp.
+test_parse_args_passthrough() {
+    local test_script="$TEST_TMPDIR/test_scp_passthrough.sh"
+    cat > "$test_script" <<'TESTSCRIPT'
+#!/bin/bash
+set -u
+source_file="$1"
+
+eval "$(sed -e 's/^set -euo pipefail$//' -e '/^main "\$@"$/d' "$source_file")"
+
+check() { # argv... ; last arg is expected "CONFIG|SCP_ARGS*"
+    local expected="${!#}"
+    local -a argv=("${@:1:$#-1}")
+    CONFIG_FILE="DEFAULT"
+    parse_args "${argv[@]}"
+    local got="${CONFIG_FILE}|${SCP_ARGS[*]}"
+    [ "$got" = "$expected" ] || { echo "MISMATCH for [${argv[*]}]: got [$got] want [$expected]"; exit 1; }
+}
+#      argv...                                  expected CONFIG|SCP_ARGS
+check  ./f h:/p                                 "DEFAULT|./f h:/p"
+check  -c aes256-gcm@openssh.com ./f h:/p       "DEFAULT|-c aes256-gcm@openssh.com ./f h:/p"
+check  --config /x ./f h:/p                     "/x|./f h:/p"
+check  -P 2222 -r ./f h:/p                      "DEFAULT|-P 2222 -r ./f h:/p"
+check  -d -- -c aes ./f h:/p                    "DEFAULT|-c aes ./f h:/p"
+echo "SCP_PASSTHROUGH_OK"
+TESTSCRIPT
+
+    chmod +x "$test_script"
+    local output
+    output=$("$test_script" "$SCP_SCRIPT" 2>&1)
+
+    if echo "$output" | grep -q "SCP_PASSTHROUGH_OK"; then
+        test_pass "parse_args: scp options pass through; -c CIPHER not shadowed"
+    else
+        test_fail "scp option passthrough matrix" "Output: $output"
+    fi
+}
+
 # Main test execution
 echo "=========================================="
 echo "Testing ob-scp (llng bastion SCP connector)"
@@ -194,6 +234,7 @@ test_help_flag
 test_too_few_args
 test_is_remote_spec
 test_split_remote_spec
+test_parse_args_passthrough
 
 # Summary
 echo ""

--- a/tests/test_ob_sftp.sh
+++ b/tests/test_ob_sftp.sh
@@ -151,6 +151,46 @@ TESTSCRIPT
     fi
 }
 
+# parse_args: own options are consumed, everything else (incl. sftp's own -c
+# CIPHER) reaches SFTP_ARGS. Regression: a short -c used to be ob-sftp's
+# --config and swallowed sftp's cipher option so it never reached sftp.
+test_parse_args_passthrough() {
+    local test_script="$TEST_TMPDIR/test_sftp_passthrough.sh"
+    cat > "$test_script" <<'TESTSCRIPT'
+#!/bin/bash
+set -u
+source_file="$1"
+
+eval "$(sed -e 's/^set -euo pipefail$//' -e '/^main "\$@"$/d' "$source_file")"
+
+check() { # argv... ; last arg is expected "CONFIG|SFTP_ARGS*"
+    local expected="${!#}"
+    local -a argv=("${@:1:$#-1}")
+    CONFIG_FILE="DEFAULT"
+    parse_args "${argv[@]}"
+    local got="${CONFIG_FILE}|${SFTP_ARGS[*]}"
+    [ "$got" = "$expected" ] || { echo "MISMATCH for [${argv[*]}]: got [$got] want [$expected]"; exit 1; }
+}
+#      argv...                                  expected CONFIG|SFTP_ARGS
+check  dwho@h                                   "DEFAULT|dwho@h"
+check  -c aes256-gcm@openssh.com dwho@h         "DEFAULT|-c aes256-gcm@openssh.com dwho@h"
+check  --config /x dwho@h                       "/x|dwho@h"
+check  -P 2222 dwho@h:/var/log                  "DEFAULT|-P 2222 dwho@h:/var/log"
+check  -b /tmp/s dwho@h                         "DEFAULT|-b /tmp/s dwho@h"
+echo "SFTP_PASSTHROUGH_OK"
+TESTSCRIPT
+
+    chmod +x "$test_script"
+    local output
+    output=$("$test_script" "$SFTP_SCRIPT" 2>&1)
+
+    if echo "$output" | grep -q "SFTP_PASSTHROUGH_OK"; then
+        test_pass "parse_args: sftp options pass through; -c CIPHER not shadowed"
+    else
+        test_fail "sftp option passthrough matrix" "Output: $output"
+    fi
+}
+
 # Main test execution
 echo "=========================================="
 echo "Testing ob-sftp (llng bastion SFTP connector)"
@@ -162,6 +202,7 @@ test_version_flag
 test_help_flag
 test_no_args
 test_split_dest_spec
+test_parse_args_passthrough
 
 # Summary
 echo ""

--- a/tests/test_ob_ssh.sh
+++ b/tests/test_ob_ssh.sh
@@ -751,6 +751,41 @@ TESTSCRIPT
     fi
 }
 
+# Test 23: parse_args must return 0 under `set -e`. Regression: the function
+# used to end on `[ -n "$explicit_port" ] && ...`, which returns 1 when no -p is
+# given, so under the script's `set -euo pipefail` the `parse_args "$@"` call in
+# main() aborted ob-ssh before it ever connected (session opened then closed at
+# once). The other tests strip `set -euo pipefail`, so they could not catch it;
+# this one re-enables `set -e` around the call on purpose.
+test_parse_args_setminus_e() {
+    local test_script="$TEST_TMPDIR/test_parse_set_e.sh"
+    cat > "$test_script" <<'TESTSCRIPT'
+#!/bin/bash
+source_file="$1"
+eval "$(sed -e 's/^set -euo pipefail$//' -e '/^main "\$@"$/d' "$source_file")"
+
+# Replicate the real runtime: set -e active across the parse_args call. If
+# parse_args returns non-zero, set -e aborts here and REACHED is never printed.
+for argv in "backend" "backend ls -la" "user@backend 2222" "-p 2200 backend"; do
+    ( set -euo pipefail
+      # shellcheck disable=SC2086
+      parse_args $argv
+      echo "REACHED:$argv" ) || { echo "ABORTED:$argv"; exit 1; }
+done
+echo "SET_E_OK"
+TESTSCRIPT
+
+    chmod +x "$test_script"
+    local output
+    output=$("$test_script" "$PROXY_SCRIPT" 2>&1)
+
+    if echo "$output" | grep -q "SET_E_OK"; then
+        test_pass "parse_args returns 0 under set -e (no premature script abort)"
+    else
+        test_fail "parse_args set -e regression" "Output: $output"
+    fi
+}
+
 # Main test execution
 echo "=========================================="
 echo "Testing ob-ssh (llng bastion SSH connector)"
@@ -779,6 +814,7 @@ test_validate_hostname
 test_force_command_parse
 test_parse_args_command
 test_force_command_with_cmd
+test_parse_args_setminus_e
 
 # Summary
 echo ""

--- a/tests/test_ob_ssh.sh
+++ b/tests/test_ob_ssh.sh
@@ -673,6 +673,84 @@ TESTSCRIPT
     fi
 }
 
+# Test 21: parse_args splits a trailing command from the host/port and honours
+# -p/--port and -l/--login. Regression: `ob-ssh host ls` used to read "ls" as a
+# port ("Bad port 'ls'") and `-p`/`-l` were rejected as unknown options.
+test_parse_args_command() {
+    local test_script="$TEST_TMPDIR/test_parse_cmd.sh"
+    cat > "$test_script" <<'TESTSCRIPT'
+#!/bin/bash
+set -u
+source_file="$1"
+
+eval "$(sed -e 's/^set -euo pipefail$//' -e '/^main "\$@"$/d' "$source_file")"
+
+check() { # argv... ; last arg is expected "SPEC|PORT|USER|CMD"
+    local expected="${!#}"
+    local -a argv=("${@:1:$#-1}")
+    OB_LOGIN_USER=""
+    parse_args "${argv[@]}"
+    local got="${TARGET_SPEC}|${TARGET_PORT}|${OB_LOGIN_USER}|${REMOTE_CMD[*]}"
+    [ "$got" = "$expected" ] || { echo "MISMATCH for [${argv[*]}]: got [$got] want [$expected]"; exit 1; }
+}
+#      argv...                              expected SPEC|PORT|USER|CMD
+check  backend                             "backend|22||"
+check  backend 2222                        "backend|2222||"
+check  backend ls -la                      "backend|22||ls -la"
+check  backend 2222 ls -la                 "backend|2222||ls -la"
+check  -p 2200 backend uptime              "backend|2200||uptime"
+check  -l bob backend                      "backend|22|bob|"
+check  admin@backend 22 "echo hi there"    "admin@backend|22||echo hi there"
+check  -- backend ls                       "backend|22||ls"
+echo "PARSE_CMD_OK"
+TESTSCRIPT
+
+    chmod +x "$test_script"
+    local output
+    output=$("$test_script" "$PROXY_SCRIPT" 2>&1)
+
+    if echo "$output" | grep -q "PARSE_CMD_OK"; then
+        test_pass "parse_args: trailing command, -p/--port and -l/--login"
+    else
+        test_fail "parse_args command/option matrix" "Output: $output"
+    fi
+}
+
+# Test 22: ForceCommand mode forwards the trailing command to the backend, e.g.
+# `ssh backend ls -la` -> REMOTE_CMD=(ls -la), while still resolving host/port.
+test_force_command_with_cmd() {
+    local test_script="$TEST_TMPDIR/test_force_cmd.sh"
+    cat > "$test_script" <<'TESTSCRIPT'
+#!/bin/bash
+source_file="$1"
+eval "$(sed -e 's/^set -euo pipefail$//' -e '/^main "\$@"$/d' "$source_file")"
+
+# Stub the connector: also report the resolved remote command.
+connect_via_cert() { echo "HOST=$1 PORT=$3 CMD=[${REMOTE_CMD[*]}]"; }
+USER=alice
+
+check() { # $1 SSH_ORIGINAL_COMMAND  $2 expected
+    local got; got=$(SSH_ORIGINAL_COMMAND="$1" force_command_mode 2>/dev/null)
+    [ "$got" = "$2" ] || { echo "MISMATCH for [$1]: got [$got] want [$2]"; exit 1; }
+}
+check "ssh backend"                "HOST=backend PORT=22 CMD=[]"
+check "ssh backend ls -la"         "HOST=backend PORT=22 CMD=[ls -la]"
+check "ssh -p 2222 backend uptime" "HOST=backend PORT=2222 CMD=[uptime]"
+check "ssh -- backend whoami"      "HOST=backend PORT=22 CMD=[whoami]"
+echo "FORCE_CMD_OK"
+TESTSCRIPT
+
+    chmod +x "$test_script"
+    local output
+    output=$("$test_script" "$PROXY_SCRIPT" 2>&1)
+
+    if echo "$output" | grep -q "FORCE_CMD_OK"; then
+        test_pass "ForceCommand mode: trailing command forwarded to backend"
+    else
+        test_fail "ForceCommand command-forward matrix" "Output: $output"
+    fi
+}
+
 # Main test execution
 echo "=========================================="
 echo "Testing ob-ssh (llng bastion SSH connector)"
@@ -699,6 +777,8 @@ test_parse_args_debug
 test_missing_portal_url
 test_validate_hostname
 test_force_command_parse
+test_parse_args_command
+test_force_command_with_cmd
 
 # Summary
 echo ""


### PR DESCRIPTION
## Problem

`ob-ssh` only accepted `[user@]backend [port]`. The inner ssh ended with `-- "$host"` and **no command**, so:

- `ob-ssh 137.74.133.195 ls` → `ls` was read as a port → `Bad port 'ls'`
- `ob-ssh -p 22 137.74.133.195` → `[ERROR] Unknown option: -p`

As a result, through an `ssh_config` entry like `RemoteCommand ob-ssh <backend>`, it was impossible to run a non-interactive command on the backend (`ssh backend1 ls` fails client-side with *Cannot execute command-line and remote command*, and even when worked around, `ob-ssh` dropped the command).

While extending the family, two more issues surfaced in `ob-scp`/`ob-sftp` and a regression was introduced and fixed.

## Changes

### `ob-ssh` — run a one-shot command on the backend
- **Remote command**: everything after the host (and the optional numeric positional port) is forwarded to the backend as the command, as an `argv` array (no shell re-splitting on the bastion). When a command is present, no pty is requested (`-T`) so output pipes/captures cleanly like `ssh host cmd`.
- **New options**: `-p`/`--port`, `-l`/`--login`, `-o` (ssh option passthrough, repeatable), and `--` to end option parsing.
- **Backward compatible**: the legacy positional `[port]` still works (a purely-numeric token after the host is still taken as the port). Both `Direct` and `ForceCommand` modes are covered (`ssh backend ls -la` under an sshd `ForceCommand`).

### `ob-scp` / `ob-sftp` — stop shadowing `scp`/`sftp`'s own `-c CIPHER`
- These already passed `-p`, `-P PORT`, `-r`, `-b`, `-l`, … straight through to `scp`/`sftp`. But their own config flag was `-c|--config`, and `scp`/`sftp` use `-c CIPHER`: a user's `-c aes256-...` was swallowed as the config path and never reached the tool.
- The config option is now **long-only** (`--config`); `-c` passes through. Other short flags (`-d/--debug`, `-h/--help`, `-V/--version`) and `--` are unchanged and don't collide.

### Critical fix — `parse_args` must not return non-zero under `set -e`
- `parse_args` ended on `[ -n "$explicit_port" ] && TARGET_PORT=...`, whose test is false whenever no `-p` is given (the common case). As the function's last command, that made `parse_args` return `1`, and under the script's `set -euo pipefail` the `parse_args "$@"` call in `main()` **aborted `ob-ssh` before it ever connected** — through a `RemoteCommand` hop the bastion session opened and closed at once.
- Fixed by using an `if` so `parse_args` returns 0 on that path.

## Usage

```sh
ob-ssh backend uptime
ob-ssh admin@backend -p 2222 -- systemctl status nginx
# from a workstation whose ssh_config sets RemoteCommand:
ssh -o RemoteCommand="ob-ssh 10.0.0.5 ls -la" backend1
```

## Tests

- New cases: `parse_args` command/`-p`/`-l` matrix, ForceCommand command-forward, **a `set -e` regression test** (the suites strip `set -euo pipefail`, so they could not previously catch the abort), and `scp`/`sftp` passthrough/`-c`-collision tests.
- All green: **ob-ssh 23/23, ob-scp 7/7, ob-sftp 6/6**. `bash -n` OK, `shellcheck` clean (no new warnings).
- Verified end-to-end against the real script with stubbed externals: `main <host>` reaches the ssh invocation and exits 0. Confirmed working on the live lab.