### PR TITLE
fix(nss): null pw_buffer after freeing expired cache entry (nscd double-free)

### DIFF
--- a/nss/libnss_openbastion.c
+++ b/nss/libnss_openbastion.c
@@ -611,10 +611,18 @@ static cache_entry_t *cache_find(const char *username)
                 return &g_cache.entries[i];
             }
 
-            /* Expired - remove */
+            /* Expired - remove.
+             * Null BOTH pointers (not just username): the slot stays within
+             * [0, count) as a hole with its old timestamp, and cache_add may
+             * later evict it as the "oldest" entry, freeing username and
+             * pw_buffer again. Leaving pw_buffer dangling => double free.
+             * Only ever reached in a long-lived consumer whose cache fills to
+             * capacity (e.g. nscd); short-lived callers exit first. */
             free(g_cache.entries[i].username);
             free(g_cache.entries[i].pw_buffer);
             g_cache.entries[i].username = NULL;
+            g_cache.entries[i].pw_buffer = NULL;
+            g_cache.entries[i].valid = 0;
             return NULL;
         }
     }
@@ -640,10 +648,13 @@ static cache_entry_t *cache_find_by_uid(uid_t uid)
                 return &g_cache.entries[i];
             }
 
-            /* Expired - remove */
+            /* Expired - remove. Null pw_buffer too (see cache_find): a hole
+             * left with a dangling pw_buffer is double-freed on eviction. */
             free(g_cache.entries[i].username);
             free(g_cache.entries[i].pw_buffer);
             g_cache.entries[i].username = NULL;
+            g_cache.entries[i].pw_buffer = NULL;
+            g_cache.entries[i].valid = 0;
             return NULL;
         }
     }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -48,6 +48,22 @@ add_executable(test_nss_openbastion test_nss_openbastion.c)
 target_include_directories(test_nss_openbastion PRIVATE ${CMAKE_SOURCE_DIR}/include)
 add_test(NAME test_nss_openbastion COMMAND test_nss_openbastion)
 
+# Regression test for the NSS in-memory LRU cache (expire-then-evict double free).
+# Includes libnss_openbastion.c directly to drive the static cache helpers, so it
+# needs the same libs as the module itself (curl/json-c/pthread).
+add_executable(test_nss_cache test_nss_cache.c)
+target_include_directories(test_nss_cache PRIVATE
+    ${CMAKE_SOURCE_DIR}/include
+    ${CURL_INCLUDE_DIRS}
+    ${JSON_C_INCLUDE_DIRS}
+)
+target_link_libraries(test_nss_cache
+    ${CURL_LIBRARIES}
+    ${JSON_C_LIBRARIES}
+    pthread
+)
+add_test(NAME test_nss_cache COMMAND test_nss_cache)
+
 # Test path validation
 add_executable(test_path_validator test_path_validator.c ../src/config.c ../src/str_utils.c)
 target_include_directories(test_path_validator PRIVATE ${CMAKE_SOURCE_DIR}/include)

--- a/tests/test_nss_cache.c
+++ b/tests/test_nss_cache.c
@@ -24,6 +24,23 @@
 
 #include <assert.h>
 
+/* Release everything init_cache()/cache_add() allocated, so the test leaves
+ * no leaks under LeakSanitizer (free() is NULL-safe for expired holes). */
+static void cache_teardown(void)
+{
+    if (!g_cache.entries) {
+        return;
+    }
+    for (size_t i = 0; i < g_cache.count; i++) {
+        free(g_cache.entries[i].username);
+        free(g_cache.entries[i].pw_buffer);
+    }
+    free(g_cache.entries);
+    g_cache.entries = NULL;
+    g_cache.count = 0;
+    g_cache.capacity = 0;
+}
+
 static struct passwd make_pw(const char *name, uid_t uid)
 {
     struct passwd pw;
@@ -73,6 +90,7 @@ static int test_expire_then_evict_no_double_free(void)
     cache_add("newcomer", &extra, 1);
 
     /* If we reach this line, no double free occurred. */
+    cache_teardown();
     return 1;
 }
 
@@ -101,6 +119,7 @@ static int test_expire_by_uid_then_evict_no_double_free(void)
     struct passwd extra = make_pw("uidnewcomer", 400000);
     cache_add("uidnewcomer", &extra, 1);
 
+    cache_teardown();
     return 1;
 }
 

--- a/tests/test_nss_cache.c
+++ b/tests/test_nss_cache.c
@@ -1,0 +1,129 @@
+/*
+ * test_nss_cache.c - Regression test for the in-memory LRU cache of the
+ * NSS module (libnss_openbastion.c).
+ *
+ * Reproduces the double-free that crashed nscd (SIGABRT,
+ * "double free or corruption (out)") roughly every 4-5h on bastions:
+ *
+ *   - cache_find()/cache_find_by_uid() free an expired entry's pw_buffer
+ *     but (before the fix) leave the pointer dangling, only nulling username.
+ *   - The slot stays within [0, count) as a hole with its old (oldest)
+ *     timestamp.
+ *   - cache_add(), once the cache is full, evicts the oldest entry and frees
+ *     username + pw_buffer again => double free of the dangling pw_buffer.
+ *
+ * This only fires in a long-lived consumer whose cache reaches capacity
+ * (nscd); short-lived callers (ls/id/sudo/sshd) exit first, which is why it
+ * went unnoticed.
+ *
+ * We include the module source directly to drive the static cache helpers
+ * (init_cache/cache_add/cache_find) against the real g_cache/g_config state.
+ */
+
+#include "../nss/libnss_openbastion.c"
+
+#include <assert.h>
+
+static struct passwd make_pw(const char *name, uid_t uid)
+{
+    struct passwd pw;
+    pw.pw_name = (char *)name;
+    pw.pw_passwd = (char *)"x";
+    pw.pw_uid = uid;
+    pw.pw_gid = uid;
+    pw.pw_gecos = (char *)"";
+    pw.pw_dir = (char *)"/home/x";
+    pw.pw_shell = (char *)"/bin/bash";
+    return pw;
+}
+
+/*
+ * Fill the cache to capacity, expire+find one entry (creating a dangling
+ * pw_buffer hole in the buggy code), then force an eviction that lands on
+ * that hole. The buggy code double-frees here and aborts; the fixed code
+ * survives because pw_buffer was nulled.
+ */
+static int test_expire_then_evict_no_double_free(void)
+{
+    if (init_cache() != 0) {
+        fprintf(stderr, "init_cache failed\n");
+        return 0;
+    }
+    /* Long TTL so entries don't expire on their own; we backdate manually. */
+    g_config.cache_ttl = 1000000;
+
+    char name[32];
+    for (size_t i = 0; i < g_cache.capacity; i++) {
+        snprintf(name, sizeof(name), "user%zu", i);
+        struct passwd pw = make_pw(name, (uid_t)(100000 + i));
+        cache_add(name, &pw, 1);
+    }
+    assert(g_cache.count == g_cache.capacity);
+
+    /* Make slot 0 both expired and the oldest entry. */
+    g_cache.entries[0].timestamp = time(NULL) - (g_config.cache_ttl + 100);
+
+    /* Look it up: expired => freed. Buggy code leaves pw_buffer dangling. */
+    cache_entry_t *e = cache_find("user0");
+    assert(e == NULL);
+
+    /* Adding one more triggers eviction of the oldest = slot 0. The buggy
+     * code frees the dangling pw_buffer a second time -> SIGABRT here. */
+    struct passwd extra = make_pw("newcomer", 200000);
+    cache_add("newcomer", &extra, 1);
+
+    /* If we reach this line, no double free occurred. */
+    return 1;
+}
+
+/* Same scenario through the UID lookup path. */
+static int test_expire_by_uid_then_evict_no_double_free(void)
+{
+    if (init_cache() != 0) {
+        fprintf(stderr, "init_cache failed\n");
+        return 0;
+    }
+    g_config.cache_ttl = 1000000;
+
+    char name[32];
+    for (size_t i = 0; i < g_cache.capacity; i++) {
+        snprintf(name, sizeof(name), "u%zu", i);
+        struct passwd pw = make_pw(name, (uid_t)(300000 + i));
+        cache_add(name, &pw, 1);
+    }
+    assert(g_cache.count == g_cache.capacity);
+
+    g_cache.entries[0].timestamp = time(NULL) - (g_config.cache_ttl + 100);
+
+    cache_entry_t *e = cache_find_by_uid(300000);
+    assert(e == NULL);
+
+    struct passwd extra = make_pw("uidnewcomer", 400000);
+    cache_add("uidnewcomer", &extra, 1);
+
+    return 1;
+}
+
+int main(void)
+{
+    int ok = 1;
+
+    printf("  Testing expire_then_evict_no_double_free... ");
+    if (test_expire_then_evict_no_double_free()) {
+        printf("PASS\n");
+    } else {
+        printf("FAIL\n");
+        ok = 0;
+    }
+
+    printf("  Testing expire_by_uid_then_evict_no_double_free... ");
+    if (test_expire_by_uid_then_evict_no_double_free()) {
+        printf("PASS\n");
+    } else {
+        printf("FAIL\n");
+        ok = 0;
+    }
+
+    printf("%s\n", ok ? "All NSS cache tests passed" : "NSS cache tests FAILED");
+    return ok ? 0 : 1;
+}


### PR DESCRIPTION
## Problem

`nscd` crashed with `SIGABRT` roughly every 4-5h on bastions (Wazuh `ANOM_ABEND`, rule 80711), systemd restarting it (restart counter > 28). One `SIGSEGV` also observed. The crash is in our `libnss_openbastion.so.2`, not nscd itself.

## Root cause — a double-free in our in-memory LRU cache

`cache_find()` / `cache_find_by_uid()` free an expired entry's `pw_buffer` but only null `username`, leaving `pw_buffer` **dangling**. The slot stays within `[0, count)` as a hole keeping its old (oldest) `timestamp`, so `cache_add()` — once the cache is full (capacity 100) — evicts it as the "oldest" entry and frees `username` + `pw_buffer` **again** → `double free or corruption (out)` → `SIGABRT`.

This only fires in a **long-lived** consumer whose cache reaches capacity (nscd). Short-lived callers (`ls`/`id`/`sudo`/sshd) exit before the cache fills, so eviction never runs and the bug stayed hidden. Everything is serialized under `g_cache.lock`, so this is a deterministic logic bug, **not** a data race.

## Evidence (nscd coredump, Debian 13)

```
malloc_printerr "double free or corruption (out)"
  _int_free_merge_chunk -> _int_free -> __GI___libc_free
  -> libnss_openbastion.so.2 (frame #10)
  -> _nss_openbastion_getpwnam_r
  -> getpwnam_r
  -> nscd worker pool -> start_thread
```
All 10 other threads idle in `pthread_cond_wait` at the time of the crash.

## Fix

Null `pw_buffer` (and clear `valid`) on expiry in both `cache_find` and `cache_find_by_uid`, so the later eviction free becomes a harmless `free(NULL)`.

## Test

New `tests/test_nss_cache.c` includes the module source to drive the real static cache helpers: it fills the cache to capacity, expires+finds one entry, then forces an eviction onto that slot. It **aborts on the pre-fix code** (reproduced: `free(): double free detected`, exit 134) and **passes with the fix**. `ctest -R nss` → 2/2 pass; module builds clean with hardening flags.

## Relationship to `fix/drop-nscd`

Dropping nscd removes the *only trigger* but does not fix the bug. This PR is the actual root-cause fix and protects any future long-lived in-process NSS consumer. The two changes are independent and can merge separately.