### PR TITLE
fix(ob-client): handle a negative /pam/verify verdict (valid:false, no user) cleanly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **A rejected `/pam/verify` token now fails cleanly instead of looking like a
+  server outage.** On any negative verdict — expired or invalid one-time token,
+  wrong token type, or an SSH fingerprint the portal refuses — the pam-access
+  plugin answers `{"valid":false,"error":"<reason>"}` with no `user` field
+  (`user` is only present on a positive verdict). The client required `user`
+  unconditionally and bailed out with `Missing required 'user' field in
+  response`, returning `PAM_AUTHINFO_UNAVAIL` — which reads as a server problem
+  and, with `auth sufficient`, fell through to `pam_unix` then `pam_deny`. It
+  now treats a `valid:false` verdict as a normal negative result: the reason is
+  surfaced, authentication fails with `PAM_AUTH_ERR`, and rate-limiting/CrowdSec
+  reporting run as intended. The verify-response parser was extracted
+  (`ob_parse_verify_response`) and is now covered by unit tests.
+
 ## [0.6.2] - 2026-06-25
 
 Hotfix for 0.6.1: the Debian package failed to install/upgrade.

--- a/include/ob_client.h
+++ b/include/ob_client.h
@@ -122,6 +122,19 @@ int ob_verify_token(ob_client_t *client,
                     const char *fingerprint,
                     ob_response_t *response);
 
+/*
+ * Parse a /pam/verify response body into *response.
+ *
+ * Exposed (non-static) for unit testing the response contract; not part of the
+ * stable client API. *response is reset on entry. Returns 0 for a well-formed
+ * response — response->active reflects the verdict, and response->user is set
+ * only when active is true (a valid:false verdict legitimately omits 'user' and
+ * yields response->reason from the 'error'/'reason' field). Returns -1 on a
+ * malformed response, writing a message into err[0..errlen).
+ */
+int ob_parse_verify_response(const char *body, ob_response_t *response,
+                             char *err, size_t errlen);
+
 #ifdef ENABLE_DESKTOP_SSO  /* Desktop SSO only and never compiled inside open-bastion core */
 /*
  * Introspect an access token via /oauth2/introspect

--- a/src/ob_client.c
+++ b/src/ob_client.c
@@ -755,12 +755,25 @@ int ob_verify_token(ob_client_t *client,
         return -1;
     }
 
-    /* Parse JSON response */
-    struct json_object *json = json_tokener_parse(buf.data);
+    /* Parse JSON response (extracted for unit testing the response contract) */
+    int prc = ob_parse_verify_response(buf.data, response,
+                                       client->error, sizeof(client->error));
     free_buffer(&buf);
+    return prc;
+}
 
+int ob_parse_verify_response(const char *body, ob_response_t *response,
+                             char *err, size_t errlen)
+{
+    if (!body || !response) {
+        if (err && errlen) snprintf(err, errlen, "Invalid parameters");
+        return -1;
+    }
+    memset(response, 0, sizeof(*response));
+
+    struct json_object *json = json_tokener_parse(body);
     if (!json) {
-        snprintf(client->error, sizeof(client->error), "Invalid JSON response");
+        snprintf(err, errlen, "Invalid JSON response");
         return -1;
     }
 
@@ -768,36 +781,51 @@ int ob_verify_token(ob_client_t *client,
 
     /* Security: Validate required fields are present and have correct type */
     if (!json_object_object_get_ex(json, "valid", &val)) {
-        snprintf(client->error, sizeof(client->error),
-                 "Missing required 'valid' field in response");
+        snprintf(err, errlen, "Missing required 'valid' field in response");
         json_object_put(json);
         return -1;
     }
     if (!json_object_is_type(val, json_type_boolean)) {
-        snprintf(client->error, sizeof(client->error),
+        snprintf(err, errlen,
                  "Invalid 'valid' field type in response (expected boolean)");
         json_object_put(json);
         return -1;
     }
     response->active = json_object_get_boolean(val);
 
+    /*
+     * A negative verdict (valid:false) legitimately carries no 'user' field:
+     * the pam-access plugin answers {"valid":false,"error":"..."} for an
+     * expired/invalid/wrong-type token (and revoked-fingerprint rejections).
+     * Treat that as a successful call with an inactive token — surface the
+     * reason and let the caller report a clean auth failure. Requiring 'user'
+     * here turned an expired OTP into a hard "Missing required 'user' field"
+     * error (PAM_AUTHINFO_UNAVAIL), masking the real cause and skipping the
+     * proper not-active handling (rate limiting, CrowdSec, clear logging).
+     */
+    if (!response->active) {
+        if (json_object_object_get_ex(json, "error", &val) ||
+            json_object_object_get_ex(json, "reason", &val)) {
+            response->reason = safe_json_strdup(val);
+        }
+        json_object_put(json);
+        return 0;
+    }
+
     if (!json_object_object_get_ex(json, "user", &val)) {
-        snprintf(client->error, sizeof(client->error),
-                 "Missing required 'user' field in response");
+        snprintf(err, errlen, "Missing required 'user' field in response");
         json_object_put(json);
         return -1;
     }
     const char *user_str = json_object_get_string(val);
     if (!user_str) {
-        snprintf(client->error, sizeof(client->error),
-                 "Invalid 'user' field type in response");
+        snprintf(err, errlen, "Invalid 'user' field type in response");
         json_object_put(json);
         return -1;
     }
     response->user = strdup(user_str);
     if (!response->user) {
-        snprintf(client->error, sizeof(client->error),
-                 "Out of memory copying 'user' field");
+        snprintf(err, errlen, "Out of memory copying 'user' field");
         json_object_put(json);
         return -1;
     }

--- a/tests/test_ob_client.c
+++ b/tests/test_ob_client.c
@@ -360,6 +360,99 @@ static void test_introspect_token_no_server(void)
 }
 #endif /* ENABLE_DESKTOP_SSO */
 
+/*
+ * /pam/verify response-contract tests.
+ *
+ * Regression for the "sudo after a long wait fails" bug: when the user's
+ * one-time PAM token (OTP) has expired, the pam-access plugin answers
+ * {"valid":false,"error":"Token expired"} with NO 'user' field. The parser
+ * used to require 'user' unconditionally and reported a hard
+ * "Missing required 'user' field" error (PAM_AUTHINFO_UNAVAIL), masking the
+ * expiry. It must instead return success with active=false and the reason.
+ */
+static void test_verify_expired_token_no_user(void)
+{
+    TEST("verify response: valid:false without user (expired OTP)");
+
+    ob_response_t r;
+    char err[256] = {0};
+    int rc = ob_parse_verify_response(
+        "{\"valid\":false,\"error\":\"Token expired\"}", &r, err, sizeof(err));
+
+    if (rc != 0) {
+        FAIL("expired-token response should parse successfully (rc=0)");
+        return;
+    }
+    if (r.active) {
+        FAIL("expired token must yield active=false");
+        ob_response_free(&r);
+        return;
+    }
+    if (r.user != NULL) {
+        FAIL("expired token must not set user");
+        ob_response_free(&r);
+        return;
+    }
+    if (!r.reason || strcmp(r.reason, "Token expired") != 0) {
+        FAIL("reason should carry the plugin's error message");
+        ob_response_free(&r);
+        return;
+    }
+    ob_response_free(&r);
+    PASS();
+}
+
+static void test_verify_active_requires_user(void)
+{
+    TEST("verify response: valid:true still requires user");
+
+    ob_response_t r;
+    char err[256] = {0};
+    int rc = ob_parse_verify_response("{\"valid\":true}", &r, err, sizeof(err));
+
+    if (rc == 0) {
+        FAIL("active response without user must fail");
+        ob_response_free(&r);
+        return;
+    }
+    PASS();
+}
+
+static void test_verify_active_with_user(void)
+{
+    TEST("verify response: valid:true with user");
+
+    ob_response_t r;
+    char err[256] = {0};
+    int rc = ob_parse_verify_response(
+        "{\"valid\":true,\"user\":\"xguimard\"}", &r, err, sizeof(err));
+
+    if (rc != 0 || !r.active || !r.user || strcmp(r.user, "xguimard") != 0) {
+        FAIL("valid active response should parse user");
+        ob_response_free(&r);
+        return;
+    }
+    ob_response_free(&r);
+    PASS();
+}
+
+static void test_verify_missing_valid(void)
+{
+    TEST("verify response: missing 'valid' field is rejected");
+
+    ob_response_t r;
+    char err[256] = {0};
+    int rc = ob_parse_verify_response(
+        "{\"user\":\"xguimard\"}", &r, err, sizeof(err));
+
+    if (rc == 0) {
+        FAIL("response without 'valid' must fail");
+        ob_response_free(&r);
+        return;
+    }
+    PASS();
+}
+
 int main(void)
 {
     printf("Running ob_client tests...\n\n");
@@ -380,6 +473,12 @@ int main(void)
     test_client_init_no_portal();
     test_client_init_valid();
     test_client_error_null();
+
+    /* /pam/verify response contract (expired-OTP regression) */
+    test_verify_expired_token_no_user();
+    test_verify_active_requires_user();
+    test_verify_active_with_user();
+    test_verify_missing_valid();
 
 #ifdef ENABLE_DESKTOP_SSO  /* Desktop SSO only and never compiled inside open-bastion core */
     /* Introspection tests (JWT client assertion) */


### PR DESCRIPTION
## What

`/pam/verify` returns `{"valid":false,"error":"<reason>"}` with **no `user` field** on any negative verdict — an expired or invalid one-time token, a wrong token type, or an SSH fingerprint the portal refuses. The `user` field is only present on a positive verdict.

`ob_verify_token` required `user` unconditionally and bailed out with `Missing required 'user' field in response`, returning `PAM_AUTHINFO_UNAVAIL`. That reads as a server outage and, with `auth sufficient`, falls through to `pam_unix` then `pam_deny` — so the real reason never surfaces.

## Fix

Treat a `valid:false` verdict as a normal negative result: surface `error`/`reason`, return `active=false`. `pam_sm_authenticate` then hits the clean not-active path — `PAM_AUTH_ERR` with the reason logged, plus correct rate-limiter and CrowdSec reporting.

The verify-response parsing is extracted into `ob_parse_verify_response()` (prototyped in `ob_client.h`) and covered by unit tests in `test_ob_client.c`:
- `valid:false` without `user` → parses, `active=false`, reason carried (the regression)
- `valid:true` still requires `user`
- `valid:true` with `user` → parsed
- missing `valid` → rejected

## Scope

This is an **independent robustness fix**. It is **not** the fix for `sudo` failing on a long-open SSH session — that one lives entirely in the pam-access LemonLDAP::NG plugin (hop-certificate binding window), already shipped in **pam-access 0.3.10**. This PR just makes any negative `/pam/verify` verdict (including a genuinely expired OTP) fail cleanly instead of looking like a server problem.

## Test

`ctest -R ob_client` → pass (build clean, ASan/UBSan clean).