### PR TITLE
fix(ob-client): stop an over-long token overflowing the introspection POST buffer

### DIFF
--- a/src/ob_client.c
+++ b/src/ob_client.c
@@ -884,9 +884,30 @@ int ob_introspect_token(ob_client_t *client,
 
     /* Build POST data with JWT client assertion (RFC 7523) */
     char *escaped_token = curl_easy_escape(client->curl, token, 0);
+    if (!escaped_token) {
+        snprintf(client->error, sizeof(client->error),
+                 "Failed to URL-encode token for introspection");
+        return -1;
+    }
+
     char postdata[8192];
     int len = snprintf(postdata, sizeof(postdata), "token=%s", escaped_token);
     curl_free(escaped_token);
+
+    /*
+     * snprintf() returns the length the result WOULD have had, not the number
+     * of bytes written. A token whose URL-encoded form does not fit therefore
+     * yields len >= sizeof(postdata): using it as an offset would point past
+     * the end of the buffer and make "sizeof(postdata) - len" wrap around to a
+     * huge size_t, so the append below would write outside the stack frame.
+     * Reject the request before that can happen.
+     */
+    if (len < 0 || (size_t)len >= sizeof(postdata)) {
+        explicit_bzero(postdata, sizeof(postdata));
+        snprintf(client->error, sizeof(client->error),
+                 "POST data too long for introspection");
+        return -1;
+    }
 
     /* Add JWT client assertion for authentication */
     struct curl_slist *headers = NULL;
@@ -895,6 +916,7 @@ int ob_introspect_token(ob_client_t *client,
                                                 client->client_secret,
                                                 url);
         if (!client_jwt) {
+            explicit_bzero(postdata, sizeof(postdata));
             snprintf(client->error, sizeof(client->error),
                      "Failed to generate JWT for introspection");
             return -1;
@@ -906,11 +928,13 @@ int ob_introspect_token(ob_client_t *client,
         free(client_jwt);
 
         if (!encoded_jwt) {
+            explicit_bzero(postdata, sizeof(postdata));
             snprintf(client->error, sizeof(client->error),
                      "Failed to URL-encode JWT for introspection");
             return -1;
         }
 
+        /* len is bounded by the check above, so this offset stays in range */
         int written = snprintf(postdata + len, sizeof(postdata) - len,
             "&client_id=%s"
             "&client_assertion_type=urn%%3Aietf%%3Aparams%%3Aoauth%%3A"
@@ -918,10 +942,11 @@ int ob_introspect_token(ob_client_t *client,
             "&client_assertion=%s", client->client_id, encoded_jwt);
         curl_free(encoded_jwt);
 
-        /* Check for buffer overflow */
+        /* Check for truncation (snprintf() itself stayed inside the buffer) */
         if (written < 0 || (size_t)written >= sizeof(postdata) - len) {
+            explicit_bzero(postdata, sizeof(postdata));
             snprintf(client->error, sizeof(client->error),
-                     "POST data buffer overflow in introspection");
+                     "POST data too long for introspection");
             return -1;
         }
         len += written;

--- a/tests/test_ob_client.c
+++ b/tests/test_ob_client.c
@@ -358,6 +358,69 @@ static void test_introspect_token_no_server(void)
 
     ob_client_destroy(client);
 }
+
+/*
+ * Regression test for the introspection POST-data stack overflow.
+ *
+ * ob_introspect_token() builds "token=<url-encoded token>" into an 8 KiB stack
+ * buffer with snprintf(), which returns the length the result WOULD have had.
+ * That return value was used unchecked as an offset for the client_assertion
+ * append: an over-long token made the offset point past the buffer and made
+ * the remaining-size argument (sizeof(postdata) - len) wrap around to a huge
+ * size_t, so the append wrote outside the stack frame. The upstream PAM cap of
+ * 8192 raw characters does not prevent this because curl_easy_escape() expands
+ * reserved characters 3x ("#" -> "%23").
+ *
+ * A token of 4096 '#' characters encodes to 12288 bytes, which cannot fit. The
+ * call must fail cleanly with a "too long" error, before any HTTP request.
+ */
+static void test_introspect_token_oversized_token(void)
+{
+    TEST("introspect_token rejects an oversized token");
+
+    ob_client_config_t config = {0};
+    config.portal_url = "https://localhost:1"; /* Invalid port, would fail fast */
+    config.client_id = "test-client";
+    config.client_secret = "test-secret";
+    config.timeout = 1;
+    config.verify_ssl = false;
+
+    ob_client_t *client = ob_client_init(&config);
+    if (!client) {
+        FAIL("Failed to init client");
+        return;
+    }
+
+    /* 4096 reserved chars -> 12288 bytes once URL-encoded (> 8192) */
+    const size_t token_len = 4096;
+    char *token = malloc(token_len + 1);
+    if (!token) {
+        FAIL("Out of memory");
+        ob_client_destroy(client);
+        return;
+    }
+    memset(token, '#', token_len);
+    token[token_len] = '\0';
+
+    ob_response_t response = {0};
+    int ret = ob_introspect_token(client, token, &response);
+    free(token);
+
+    const char *error = ob_client_error(client);
+
+    if (ret != -1) {
+        FAIL("Oversized token must be rejected");
+    } else if (!error || strstr(error, "too long") == NULL) {
+        /* A curl error here would mean the request was sent anyway, i.e. the
+         * body was built from a truncated/overflowed buffer. */
+        FAIL("Should fail with a 'POST data too long' error");
+    } else {
+        PASS();
+    }
+
+    ob_response_free(&response);
+    ob_client_destroy(client);
+}
 #endif /* ENABLE_DESKTOP_SSO */
 
 /*
@@ -484,6 +547,7 @@ int main(void)
     /* Introspection tests (JWT client assertion) */
     test_introspect_token_null_params();
     test_introspect_token_no_server();
+    test_introspect_token_oversized_token();
 #endif /* ENABLE_DESKTOP_SSO */
 
     printf("\n%d/%d tests passed\n", tests_passed, tests_run);


### PR DESCRIPTION
Fixes #179

## The bug

`ob_introspect_token()` (`src/ob_client.c`) built its POST body into a 8192-byte **stack** buffer in two steps:

```c
char postdata[8192];
int len = snprintf(postdata, sizeof(postdata), "token=%s", escaped_token);  /* return UNCHECKED */
...
int written = snprintf(postdata + len, sizeof(postdata) - len,              /* OOB ptr + wrapped size */
    "&client_id=%s&client_assertion_type=...&client_assertion=%s", client->client_id, encoded_jwt);
if (written < 0 || (size_t)written >= sizeof(postdata) - len) { ... }       /* checked AFTER the write */
```

`snprintf()` returns the length the result **would** have had, not the number of bytes written. As soon as the URL-encoded token exceeds 8185 bytes, `len >= 8192`, so:

* `postdata + len` points past the end of the buffer, and
* `sizeof(postdata) - len` underflows (it is `size_t` arithmetic) to a value near `SIZE_MAX`.

The second `snprintf()` therefore believes it has unlimited room and writes the client assertion outside the stack frame. The truncation guard runs only after the damage is done.

The upstream cap in `src/pam_openbastion.c` (`strlen(password) > 8192`) does **not** prevent it: `curl_easy_escape()` expands reserved characters 3x, so 4096 raw `#` characters already encode to 12288 bytes. The code is shipped in the packages — both `debian/rules` and `rpm/open-bastion.spec:69` build with `-DINSTALL_DESKTOP=ON`, which defines `ENABLE_DESKTOP_SSO`.

## The fix

Check the first `snprintf()` return *before* using it as an offset, and fail through the function's existing error convention (`client->error` + `return -1`). This is exactly the guard `src/token_manager.c` already had around its own two-step POST builders — the error string is aligned on it (`"POST data too long ..."`).

Two small hardenings on the same lines, kept minimal:

* `curl_easy_escape()` returning `NULL` was passed straight to `"%s"` (UB); it now fails cleanly, matching `token_manager.c`.
* the early error returns now `explicit_bzero()` the buffer that already holds the token, like the success path does.

The second `snprintf()` is left as a separate call: the client-assertion part is conditional (`client_id && client_secret`), so merging both into a single `snprintf()` would need a duplicated format string. With `len` now bounded, its size argument can no longer wrap, and its post-check is a plain truncation check.

### Step 3: other instances of the pattern

Grepped the whole `src/` tree for `snprintf()` returns used as pointer offsets / remaining-size operands:

* `src/ob_client.c:888` — **the bug, fixed here**. It was the only unguarded one.
* `src/token_manager.c:282`, `:298`, `:423` — same two-step shape, but both functions (`refresh_token`, `introspect`) already validate `len < 0 || (size_t)len >= sizeof(post_data)` right after the first `snprintf()` (lines 250-259 and 396-399). Not vulnerable, left untouched.
* `src/cache_key.c:108`, `src/notify.c:63`, `src/rate_limiter.c:96`, `src/crowdsec.c:177`, `src/offline_cache.c:240`, `src/secret_store.c:194` — all `snprintf(buf + (i * 2), 3, "%02x", ...)` hex-encoding loops. The offset is a loop counter, not an snprintf return, and is bounded by the digest length. Not affected.

## The test

`tests/test_ob_client.c` already had a reachable seam: `test_introspect_token_no_server()` calls `ob_introspect_token()` against `https://localhost:1` and lets the request fail. The new `test_introspect_token_oversized_token()` uses the same seam with a 4096-character token of `#`, which URL-encodes to 12288 bytes, and asserts that the call returns `-1` with a `"too long"` error — i.e. it fails *before* the HTTP request rather than corrupting the stack. A curl error there would mean the body was built from an overflowed buffer, so it is treated as a failure. No refactoring of the function was needed, and no existing test was changed or weakened.

Like the surrounding introspection tests, it is inside `#ifdef ENABLE_DESKTOP_SSO`, so it runs in the configuration the packages actually ship (`-DINSTALL_DESKTOP=ON`).

## Verification

Default configuration (baseline was 19/19):

```
$ cmake -S . -B build-verify -DBUILD_TESTING=ON
$ cmake --build build-verify -j$(nproc)     # no warnings, no errors
$ ctest --test-dir build-verify --output-on-failure
...
19/19 Test #19: test_ssh_key_policy ..............   Passed    0.00 sec

100% tests passed, 0 tests failed out of 19

Total Test time (real) =   9.04 sec
```

Shipped configuration, where the new test is compiled in:

```
$ cmake -S . -B build-desktop -DBUILD_TESTING=ON -DINSTALL_DESKTOP=ON
$ cmake --build build-desktop -j$(nproc)
$ ctest --test-dir build-desktop --output-on-failure
...
21/21 Test #21: test_ssh_key_policy ..............   Passed    0.00 sec

100% tests passed, 0 tests failed out of 21

Total Test time (real) =  27.60 sec

$ ./build-desktop/tests/test_ob_client
...
  Testing introspect_token with NULL params... PASSED
  Testing introspect_token builds JWT request (no server)... PASSED
  Testing introspect_token rejects an oversized token... PASSED

18/18 tests passed
```

### AddressSanitizer

Built with `-DCMAKE_C_FLAGS="-fsanitize=address -g -O1"`. The new test reproduces the overflow on the **pre-fix** code:

```
==331620==ERROR: AddressSanitizer: stack-buffer-overflow on address 0x7b1626303526 ...
WRITE of size 436 at 0x7b1626303526 thread T0
    #0 vsnprintf
    #1 snprintf
    #2 ob_introspect_token src/ob_client.c:914
    #3 test_introspect_token_oversized_token tests/test_ob_client.c:406

Address 0x7b1626303526 is located in stack of thread T0 at offset 13606 in frame
    #0 ob_introspect_token src/ob_client.c:872
  This frame has 5 object(s):
    [1312, 9504) 'postdata' (line 887) <== Memory access at offset 13606 overflows this variable
SUMMARY: AddressSanitizer: stack-buffer-overflow src/ob_client.c:914 in ob_introspect_token
```

With the fix applied, the same ASan binary reports `18/18 tests passed` and no sanitizer findings.

https://claude.ai/code/session_01NooTfXy6MgavPeiNwB8cBX
