### PR TITLE
fix(postinst): warn when a certificate mode is installed on an sshd that still accepts passwords

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **The postinst reports a mode-c install on an sshd that still takes passwords
+  (#180).** mode-c is the one PAM mode whose generated stack refuses passwords
+  outright (`auth required pam_deny.so`), so an sshd left with
+  `PasswordAuthentication yes` is a mismatch worth naming. It is only reported,
+  never fixed: turning password authentication off from a package script can
+  lock out an administrator connected over a password session, and this
+  project's convention is that intrusive hardening is opt-in
+  (`ob-bastion-setup` writes that drop-in, and it is run deliberately).
+
+  The warning escalates when `UsePAM no` is in effect, because sshd then checks
+  `/etc/shadow` itself and never consults the stack — the PAM denial is not
+  merely redundant there, it is bypassed.
+
+  Only mode-c. mode-a, mode-b and mode-d all accept a password somewhere by
+  design: mode-b and mode-d are given `auth sufficient pam_unix.so`, and mode-a
+  carries its token over the password prompt. `sshd -T` is read without `-C`,
+  which cannot be built at install time, so a `Match` block re-enabling
+  passwords is not seen and the check stays silent — it reports a mismatch it
+  can see, and never claims the absence of one.
+
+
 - **`UPGRADE-NOTES.md`.** What has to be done, or checked, before deploying a
   release — starting with the `lemonldap-ng-plugins` 0.6.0 upgrade: the
   `/pam/whoami` migration above, unbound vouchers dropping from 12 h to 15 min,

--- a/debian/open-bastion.postinst
+++ b/debian/open-bastion.postinst
@@ -18,6 +18,54 @@ backup_pam_file() {
     fi
 }
 
+# Warn when a certificate-only PAM mode is installed while sshd still accepts
+# passwords (#180).
+#
+# We deliberately do NOT edit sshd_config here. Disabling password
+# authentication from a package postinst can lock out an administrator who is
+# connected over a password session, and this project's convention is that
+# intrusive hardening is opt-in. ob-bastion-setup writes the
+# `PasswordAuthentication no` drop-in, and it is run deliberately.
+#
+# The generated PAM stack already denies (auth required pam_deny.so), so a
+# password attempt is refused -- but only while sshd routes it through PAM.
+# With `UsePAM no` sshd checks /etc/shadow itself and never consults the stack,
+# so the mismatch is worth reporting rather than leaving silent.
+warn_if_sshd_accepts_passwords() {
+    _mode="$1"
+
+    case "$_mode" in
+        mode-c|mode-d) ;;   # certificate/key modes: passwords are not expected
+        *) return 0 ;;
+    esac
+
+    command -v sshd >/dev/null 2>&1 || return 0
+
+    # Effective configuration, comments and drop-ins resolved by sshd itself.
+    _eff=$(sshd -T 2>/dev/null) || return 0
+    [ -n "$_eff" ] || return 0
+
+    _pw=$(printf '%s\n' "$_eff" | sed -n 's/^passwordauthentication //p')
+    _kbd=$(printf '%s\n' "$_eff" | sed -n 's/^kbdinteractiveauthentication //p')
+    _usepam=$(printf '%s\n' "$_eff" | sed -n 's/^usepam //p')
+
+    [ "$_pw" = "yes" ] || [ "$_kbd" = "yes" ] || return 0
+
+    echo "open-bastion: WARNING - PAM mode '$_mode' expects certificate or key" >&2
+    echo "  authentication, but sshd still accepts passwords" >&2
+    echo "  (PasswordAuthentication=$_pw, KbdInteractiveAuthentication=$_kbd)." >&2
+    echo "  The installed PAM stack denies password authentication, so logins" >&2
+    echo "  are refused -- but that protection depends on sshd using PAM." >&2
+    if [ "$_usepam" = "no" ]; then
+        echo "  UsePAM is 'no' on this host: sshd checks /etc/shadow itself and" >&2
+        echo "  never consults the PAM stack. Password logins are NOT refused." >&2
+    fi
+    echo "  Run ob-bastion-setup (or ob-backend-setup) to write the sshd" >&2
+    echo "  drop-in that turns password authentication off." >&2
+
+    return 0
+}
+
 # Generate PAM configuration for sshd
 generate_pam_sshd() {
     mode="$1"
@@ -231,6 +279,7 @@ case "$1" in
             # Backup and configure sshd
             backup_pam_file "$PAM_SSHD" "sshd"
             generate_pam_sshd "$MODE" "$SERVER_GROUP" > "$PAM_SSHD"
+            warn_if_sshd_accepts_passwords "$MODE"
 
             # Configure sudo if requested
             if [ "$CONFIGURE_SUDO" = "true" ]; then

--- a/debian/open-bastion.postinst
+++ b/debian/open-bastion.postinst
@@ -34,14 +34,26 @@ backup_pam_file() {
 warn_if_sshd_accepts_passwords() {
     _mode="$1"
 
+    # mode-c ONLY. It is the one mode whose generated stack refuses passwords
+    # (auth required pam_deny.so). mode-d is "All methods (SSH keys, Open
+    # Bastion tokens, Unix passwords)" per debian/open-bastion.templates, and
+    # generate_pam_sshd gives mode-b and mode-d the same stack, with
+    # `auth sufficient pam_unix.so` -- passwords are accepted there by design.
+    # Warning on mode-d would state three false things and advise turning off a
+    # method the administrator explicitly chose.
     case "$_mode" in
-        mode-c|mode-d) ;;   # certificate/key modes: passwords are not expected
+        mode-c) ;;
         *) return 0 ;;
     esac
 
     command -v sshd >/dev/null 2>&1 || return 0
 
     # Effective configuration, comments and drop-ins resolved by sshd itself.
+    # Deliberately without -C: a connection spec would need a user, host and
+    # address we do not have at install time. The cost is that `Match` blocks
+    # are not evaluated, so a Match that re-enables PasswordAuthentication is
+    # not seen and this check stays silent. Best-effort by design -- it reports
+    # a mismatch it can see, and never claims the absence of one.
     _eff=$(sshd -T 2>/dev/null) || return 0
     [ -n "$_eff" ] || return 0
 

--- a/tests/test_ob_postinst_sshd_warning.sh
+++ b/tests/test_ob_postinst_sshd_warning.sh
@@ -51,8 +51,22 @@ run_case mode-c "'passwordauthentication no' 'kbdinteractiveauthentication yes' 
     "mode-c with KbdInteractiveAuthentication yes warns" warn
 run_case mode-c "'passwordauthentication yes' 'kbdinteractiveauthentication no' 'usepam no'" \
     "UsePAM no escalates: stack is not consulted" warn "NOT refused"
+# Every mode whose generated stack accepts a password must stay silent. mode-d
+# is the one that matters: it is "All methods (SSH keys, Open Bastion tokens,
+# Unix passwords)" and generate_pam_sshd gives it `auth sufficient pam_unix.so`,
+# so warning there would call a deliberate choice a misconfiguration and advise
+# turning it off. mode-a denies passwords in the stack, but it is a token mode:
+# sshd taking passwords is how the token is carried, not a mismatch.
 run_case mode-a "'passwordauthentication yes' 'kbdinteractiveauthentication yes' 'usepam yes'" \
-    "password modes are not warned about" silent
+    "mode-a (token) is not warned about" silent
+run_case mode-b "'passwordauthentication yes' 'kbdinteractiveauthentication yes' 'usepam yes'" \
+    "mode-b (token or password) is not warned about" silent
+run_case mode-d "'passwordauthentication yes' 'kbdinteractiveauthentication yes' 'usepam yes'" \
+    "mode-d (all methods) is not warned about" silent
+run_case mode-d "'passwordauthentication yes' 'kbdinteractiveauthentication no' 'usepam no'" \
+    "mode-d with UsePAM no is not warned about either" silent
+run_case none "'passwordauthentication yes' 'kbdinteractiveauthentication yes' 'usepam yes'" \
+    "mode 'none' is not warned about" silent
 
 # The helper must actually be called, and after the PAM stack is written --
 # a helper that exists but is never invoked would pass every case above.

--- a/tests/test_ob_postinst_sshd_warning.sh
+++ b/tests/test_ob_postinst_sshd_warning.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+# Test: the postinst warns when a certificate-only PAM mode is installed while
+# sshd still accepts passwords (#180).
+#
+# #220 made the generated mode-c stack deny (auth required pam_deny.so), so a
+# password attempt is refused. But the postinst never touches sshd_config, so
+# between `apt install` and the first ob-bastion-setup the host still offers
+# password authentication -- and with UsePAM no, sshd never consults the stack
+# at all. The postinst must say so rather than leave the mismatch silent.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+POSTINST="$SCRIPT_DIR/debian/open-bastion.postinst"
+
+passed=0; failed=0
+pass() { echo "  PASS: $1"; passed=$((passed+1)); }
+fail() { echo "  FAIL: $1"; [ -n "${2:-}" ] && echo "    $2"; failed=$((failed+1)); }
+
+WORK=$(mktemp -d); trap 'rm -rf "$WORK"' EXIT
+sed -n '/^warn_if_sshd_accepts_passwords()/,/^}/p' "$POSTINST" > "$WORK/helper.sh"
+[ -s "$WORK/helper.sh" ] || { echo "  FAIL: helper not found in postinst"; exit 1; }
+mkdir -p "$WORK/fakebin"
+
+# $1 mode, $2 sshd -T lines, $3 description, $4 expect (warn|silent), $5 extra regex
+run_case() {
+    local mode="$1" cfg="$2" desc="$3" expect="$4" extra="${5:-}" out
+    printf '#!/bin/sh\n[ "$1" = "-T" ] || exit 1\nprintf "%%s\\n" %s\n' "$cfg" \
+        > "$WORK/fakebin/sshd"
+    chmod +x "$WORK/fakebin/sshd"
+    out=$(cd "$WORK" && PATH="$WORK/fakebin:$PATH" \
+        sh -c ". ./helper.sh; warn_if_sshd_accepts_passwords $mode" 2>&1)
+
+    if [ "$expect" = "silent" ]; then
+        [ -z "$out" ] && pass "$desc" || fail "$desc" "expected no output, got: $out"
+        return
+    fi
+    if ! grep -q "WARNING" <<<"$out"; then
+        fail "$desc" "expected a warning, got: ${out:-<nothing>}"; return
+    fi
+    if [ -n "$extra" ] && ! grep -qE "$extra" <<<"$out"; then
+        fail "$desc" "warning missing /$extra/: $out"; return
+    fi
+    pass "$desc"
+}
+
+run_case mode-c "'passwordauthentication no' 'kbdinteractiveauthentication no' 'usepam yes'" \
+    "mode-c with passwords already off stays silent" silent
+run_case mode-c "'passwordauthentication yes' 'kbdinteractiveauthentication no' 'usepam yes'" \
+    "mode-c with PasswordAuthentication yes warns" warn "ob-bastion-setup"
+run_case mode-c "'passwordauthentication no' 'kbdinteractiveauthentication yes' 'usepam yes'" \
+    "mode-c with KbdInteractiveAuthentication yes warns" warn
+run_case mode-c "'passwordauthentication yes' 'kbdinteractiveauthentication no' 'usepam no'" \
+    "UsePAM no escalates: stack is not consulted" warn "NOT refused"
+run_case mode-a "'passwordauthentication yes' 'kbdinteractiveauthentication yes' 'usepam yes'" \
+    "password modes are not warned about" silent
+
+# The helper must actually be called, and after the PAM stack is written --
+# a helper that exists but is never invoked would pass every case above.
+if grep -q '^ *warn_if_sshd_accepts_passwords "\$MODE"' "$POSTINST"; then
+    _gen=$(grep -n 'generate_pam_sshd "\$MODE"' "$POSTINST" | head -1 | cut -d: -f1)
+    _warn=$(grep -n '^ *warn_if_sshd_accepts_passwords "\$MODE"' "$POSTINST" | head -1 | cut -d: -f1)
+    if [ -n "$_gen" ] && [ -n "$_warn" ] && [ "$_warn" -gt "$_gen" ]; then
+        pass "postinst calls the helper after writing the PAM stack"
+    else
+        fail "postinst calls the helper after writing the PAM stack" \
+             "generate at line ${_gen:-?}, warn at line ${_warn:-?}"
+    fi
+else
+    fail "postinst calls the helper after writing the PAM stack" "no call found"
+fi
+
+# The postinst must not edit sshd_config itself: disabling password auth from a
+# package script can lock out an admin on a password session (#220 scope note).
+if grep -qE '(>|>>|sed -i|tee).*sshd_config' "$POSTINST"; then
+    fail "postinst does not write sshd_config"
+else
+    pass "postinst does not write sshd_config"
+fi
+
+echo
+echo "=== Results: $((passed))/$((passed+failed)) passed, $failed failed ==="
+[ "$failed" -eq 0 ]


### PR DESCRIPTION
Ferme la moitié restante de #180.

## Ce que #220 avait déjà corrigé

La pile PAM mode-c générée est passée de `auth required pam_permit.so` à `auth required pam_deny.so`. Mesuré avec `pam_start_confdir` : `pam_authenticate()` renvoie `7 PAM_AUTH_ERR`. Le bypass d'origine — n'importe quel mot de passe accepté si sshd exécutait la pile — n'existe plus.

## Ce qui restait

Le postinst écrit la pile PAM et ne regarde jamais `sshd_config`. Entre `apt install` et le premier `ob-bastion-setup`, l'hôte annonce donc toujours `PasswordAuthentication` / `KbdInteractiveAuthentication` :

1. surface de brute-force inutile sur un hôte censé n'accepter que des certificats ;
2. le refus repose **entièrement** sur la pile PAM — avec `UsePAM no`, sshd vérifie `/etc/shadow` lui-même et ne consulte jamais la pile, donc les mots de passe sont réellement acceptés ;
3. rien ne signale à l'administrateur que la configuration effective contredit le mode choisi.

## L'approche : avertir, ne pas agir

**Ce correctif ne modifie pas `sshd_config`.** Couper l'authentification par mot de passe depuis un script de paquet peut verrouiller un administrateur connecté par mot de passe — c'est précisément pourquoi #220 avait exclu ce périmètre, et la convention du projet est que tout durcissement intrusif est opt-in. `ob-bastion-setup` écrit déjà ce drop-in et est lancé délibérément.

Le helper lit la configuration **effective** via `sshd -T`, donc les commentaires et les drop-ins sont résolus par sshd plutôt que re-parsés à la main. Il ne fait rien si sshd est absent, si `sshd -T` échoue, ou dans les modes à mot de passe.

Exemple de sortie, cas `UsePAM no` :

```
open-bastion: WARNING - PAM mode 'mode-c' expects certificate or key
  authentication, but sshd still accepts passwords
  (PasswordAuthentication=yes, KbdInteractiveAuthentication=no).
  The installed PAM stack denies password authentication, so logins
  are refused -- but that protection depends on sshd using PAM.
  UsePAM is 'no' on this host: sshd checks /etc/shadow itself and
  never consults the PAM stack. Password logins are NOT refused.
  Run ob-bastion-setup (or ob-backend-setup) to write the sshd
  drop-in that turns password authentication off.
```

## Tests

`tests/test_ob_postinst_sshd_warning.sh`, 7 assertions :

- mode-c avec mots de passe déjà désactivés → silence ;
- `PasswordAuthentication yes` → avertit ;
- `KbdInteractiveAuthentication yes` → avertit ;
- `UsePAM no` → avertit **et** signale que la pile n'est pas consultée ;
- modes à mot de passe → silence ;
- le postinst **appelle** effectivement le helper, après l'écriture de la pile ;
- le postinst **n'écrit pas** dans `sshd_config`.

Les deux dernières méritent un mot. Le contrôle de mutation a montré que sans l'avant-dernière, supprimer l'appel au helper laissait la suite verte — un helper présent mais jamais invoqué serait passé inaperçu. La dernière verrouille la prudence : si quelqu'un fait un jour toucher `sshd_config` au postinst, le test échoue.

Vérifications : `sh -n` sur le postinst source et assemblé (`#DEBHELPER#` présent une fois, hors commentaire), `shellcheck --severity=warning` propre, les 20 tests shell et `ctest` 20/20.

Fixes #180

https://claude.ai/code/session_01NooTfXy6MgavPeiNwB8cBX
