### PR TITLE
chore(security): stop ob-builder bundles from leaking the client secret

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,28 @@ local-test/vm/
 build-verify/
 build-asan/
 bv/
+
+# Deployment bundles produced by ob-builder (#203).
+#
+# A bundle built with client_secret_mode=embedded carries the OIDC client
+# secret in clear text in roles/open-bastion/defaults/main.yml, and its
+# inventory names production hosts. Generate bundles OUTSIDE this working
+# tree; these entries only cover the ones that are already here.
+/linagora-setup-bastion/
+/linagora-setup-backend/
+/old-linagora-setup/
+/*-setup-bastion/
+/*-setup-backend/
+/*-setup-standalone/
+
+# Presentation material dropped in the tree
+/Open-Bastion.zip
+
+# Upstream source packages unpacked for reference (openssh, pam)
+/openssh_*.orig.tar.*
+/openssh_*.debian.tar.*
+/openssh_*.dsc
+/pam_*.orig.tar.*
+/pam_*.debian.tar.*
+/pam_*.dsc
+/pam-[0-9]*/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **`ob-builder` artefacts that carry the client secret are no longer
+  world-readable, and no longer commit themselves (#203).** With
+  `client_secret_mode: embedded` the OIDC client secret is written in clear text
+  into the shell installer (`0755`) and the Ansible role's `defaults/main.yml`
+  (`0644`). Both are now restricted to the building user (`0700` / `0600`), and
+  an embedded bundle gets a `.gitignore` at its root so a `git add -A` in a
+  surrounding working tree cannot publish it. Bundles built with the default
+  `client_secret_mode: prompt` are unchanged — nothing secret reaches the disk,
+  so there is nothing to hide. The repository's own `.gitignore` also covers the
+  bundle directories that were sitting untracked in the working tree.
+
 - **A world- or group-readable `/etc/open-bastion/cache.key` is now rejected
   instead of used with a warning** (offline auth cache, desktop SSO). Versions
   up to 0.6.2 accepted such a key and merely logged a warning. `SECURITY.md`

--- a/admin-builder/ob-builder
+++ b/admin-builder/ob-builder
@@ -1377,6 +1377,50 @@ VARSPROMPT
 }
 
 # ─────────────────────────────────────────────────────────────────────────
+# Protecting artefacts that carry the client secret (#203).
+#
+# With client_secret_mode=embedded the OIDC client secret is written in clear
+# text into every artefact: the shell installer (0755 by default) and the
+# Ansible role's defaults/main.yml (0644). Two accidents follow from that, and
+# both were observed on a real build host: any local account could read the
+# secret, and a bundle generated inside a git working tree was one `git add -A`
+# away from being published.
+#
+# These helpers are no-ops for client_secret_mode=prompt/none, where nothing
+# secret is written to disk in the first place.
+# ─────────────────────────────────────────────────────────────────────────
+_tighten_if_embedded() {
+    local path="$1" mode="$2"
+
+    [ "$CLIENT_SECRET_MODE" = "embedded" ] || return 0
+    [ "$DRY_RUN" = "1" ] && return 0
+    [ -e "$path" ] || return 0
+
+    chmod -- "$mode" "$path" \
+        || log_warn "Could not restrict permissions on $path (it holds the client secret)"
+}
+
+_write_bundle_gitignore() {
+    local outpath="$1"
+
+    [ "$CLIENT_SECRET_MODE" = "embedded" ] || return 0
+    [ "$DRY_RUN" = "1" ] && return 0
+
+    atomic_write "$outpath/.gitignore" "0644" \
+"# Written by ob-builder $VERSION.
+#
+# This bundle was built with client_secret_mode=embedded:
+# roles/open-bastion/defaults/main.yml holds the OIDC client secret in clear
+# text, and the inventory names real hosts. Ignoring the whole directory keeps
+# a stray 'git add -A' from publishing it.
+#
+# To version this bundle deliberately: delete this file, hold the secret with
+# 'ansible-vault encrypt_string' and rebuild with client_secret_mode=prompt.
+*
+"
+}
+
+# ─────────────────────────────────────────────────────────────────────────
 # Shell installer rendering.
 # The template installer.sh.in references @@OPENBASTION_CONF_TEMPLATE@@,
 # which must contain the (already-expanded) contents of the conf template
@@ -1415,6 +1459,7 @@ render_shell_installer() {
     ph_set OPENBASTION_CONF_TEMPLATE "$conf_content"
 
     render_template "$installer_tpl" "$outpath" "0755"
+    _tighten_if_embedded "$outpath" "0700"
 
     if [ "$DRY_RUN" != "1" ] && [ -n "$SIGN_WITH" ]; then
         log_step "Signing $outpath with key $SIGN_WITH"
@@ -1551,6 +1596,9 @@ render_ansible_role() {
         atomic_write_from "$files_dir/jwks.json" "0644" "$WORK_DIR/jwks.json"
     fi
 
+    _tighten_if_embedded "$outpath/roles/open-bastion/defaults/main.yml" "0600"
+    _write_bundle_gitignore "$outpath"
+
     log_info "Ansible role written to $outpath"
 }
 
@@ -1606,6 +1654,9 @@ EOF
     if [ -f "$WORK_DIR/jwks.json" ]; then
         atomic_write_from "$files_dir/jwks.json" "0644" "$WORK_DIR/jwks.json"
     fi
+    _tighten_if_embedded "$defaults_dir/main.yml" "0600"
+    _write_bundle_gitignore "$outpath"
+
     log_info "Stub Ansible role written to $outpath"
 }
 

--- a/doc/ansible-quickstart.md
+++ b/doc/ansible-quickstart.md
@@ -85,6 +85,23 @@ public key fetched from the portal. See
 [`admin-builder/templates/ansible/role/README.md`](../admin-builder/templates/ansible/role/README.md)
 for the full list of `ob_*` variables.
 
+### If you build with `client_secret_mode: embedded`
+
+The default is `prompt`, which keeps the OIDC client secret out of every
+generated file. `embedded` bakes it in clear text into `defaults/main.yml` and
+into the shell installer, so the bundle becomes a credential:
+
+- `ob-builder` restricts those two files to the building user (`0600` and
+  `0700`) and drops a `.gitignore` at the root of the bundle so a `git add -A`
+  in a surrounding working tree cannot publish it;
+- treat the directory as secret material — do not copy it into a repository, an
+  attachment or a shared drive;
+- to version it anyway, delete that `.gitignore`, rebuild with
+  `client_secret_mode: prompt`, and supply the secret with
+  `ansible-vault encrypt_string 's3cr3t' --name ob_client_secret`;
+- if a bundle has already been shared, rotate the client secret in the LLNG
+  portal: it is a bearer credential for the deployment's OIDC client.
+
 ## Step 2 — Declare your hosts and their IPs
 
 **This is where the IPs of the machines you are building go.** Create an

--- a/tests/test_ob_builder_embedded_secret.sh
+++ b/tests/test_ob_builder_embedded_secret.sh
@@ -1,0 +1,227 @@
+#!/bin/bash
+#
+# Test suite for the protection of ob-builder artefacts that carry the OIDC
+# client secret in clear text (#203).
+#
+# With client_secret_mode=embedded, the secret is written verbatim into the
+# shell installer (0755) and into the Ansible role's defaults/main.yml (0644).
+# Two accidents follow, and both were observed on a real build host: any local
+# account could read the secret, and a bundle generated inside a git working
+# tree was one `git add -A` away from being published.
+#
+# These tests pin both guards, and pin that they stay out of the way for
+# client_secret_mode=prompt/none, where no secret reaches the disk at all.
+#
+
+set -u
+
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BUILDER="$SCRIPT_DIR/admin-builder/ob-builder"
+export OB_BUILDER_LIB_DIR="$SCRIPT_DIR/admin-builder/lib"
+export OB_BUILDER_SHARE="$SCRIPT_DIR/admin-builder"
+
+TEST_TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TEST_TMPDIR"' EXIT
+
+test_pass() { echo -e "${GREEN}✓${NC} $1"; ((TESTS_PASSED++)); }
+test_fail() {
+    echo -e "${RED}✗${NC} $1"
+    [ -n "${2:-}" ] && echo -e "  ${YELLOW}Details:${NC} $2"
+    ((TESTS_FAILED++))
+}
+
+# Source ob-builder definitions into THIS shell (functions + globals), with the
+# top-level `set -euo pipefail` and the final `main "$@"` removed so nothing
+# runs and a failing helper does not kill the harness.
+# shellcheck disable=SC1090
+eval "$(sed -e 's/^set -euo pipefail$//' -e '/^main "\$@"$/d' "$BUILDER")"
+DRY_RUN=0
+
+mode_of() { stat -c '%a' "$1"; }
+
+# ── _tighten_if_embedded ────────────────────────────────────────────────────
+
+test_tighten_embedded() {
+    local f="$TEST_TMPDIR/installer.sh"
+    : > "$f"; chmod 0755 "$f"
+
+    CLIENT_SECRET_MODE=embedded
+    _tighten_if_embedded "$f" "0700"
+
+    if [ "$(mode_of "$f")" = "700" ]; then
+        test_pass "embedded: shell installer tightened 0755 -> 0700"
+    else
+        test_fail "embedded: shell installer not tightened" "mode=$(mode_of "$f")"
+    fi
+}
+
+test_tighten_defaults() {
+    local f="$TEST_TMPDIR/main.yml"
+    : > "$f"; chmod 0644 "$f"
+
+    CLIENT_SECRET_MODE=embedded
+    _tighten_if_embedded "$f" "0600"
+
+    if [ "$(mode_of "$f")" = "600" ]; then
+        test_pass "embedded: role defaults/main.yml tightened 0644 -> 0600"
+    else
+        test_fail "embedded: defaults/main.yml not tightened" "mode=$(mode_of "$f")"
+    fi
+}
+
+test_tighten_noop_when_not_embedded() {
+    local ok=true f
+    for mode in prompt none; do
+        f="$TEST_TMPDIR/keep-$mode"
+        : > "$f"; chmod 0644 "$f"
+        CLIENT_SECRET_MODE="$mode"
+        _tighten_if_embedded "$f" "0600"
+        [ "$(mode_of "$f")" = "644" ] || ok=false
+    done
+    $ok && test_pass "prompt/none: permissions left alone (no secret on disk)" \
+         || test_fail "prompt/none: permissions were changed anyway"
+}
+
+test_tighten_missing_file() {
+    CLIENT_SECRET_MODE=embedded
+    if _tighten_if_embedded "$TEST_TMPDIR/does-not-exist" "0600"; then
+        test_pass "missing file: returns success instead of aborting the build"
+    else
+        test_fail "missing file: non-zero exit would abort a set -e build"
+    fi
+}
+
+test_tighten_dry_run() {
+    local f="$TEST_TMPDIR/dryrun"
+    : > "$f"; chmod 0644 "$f"
+
+    CLIENT_SECRET_MODE=embedded
+    DRY_RUN=1
+    _tighten_if_embedded "$f" "0600"
+    DRY_RUN=0
+
+    if [ "$(mode_of "$f")" = "644" ]; then
+        test_pass "dry-run: touches nothing"
+    else
+        test_fail "dry-run: modified the file" "mode=$(mode_of "$f")"
+    fi
+}
+
+# ── _write_bundle_gitignore ─────────────────────────────────────────────────
+
+test_gitignore_written() {
+    local out="$TEST_TMPDIR/bundle-embedded"
+    mkdir -p "$out"
+
+    CLIENT_SECRET_MODE=embedded
+    _write_bundle_gitignore "$out"
+
+    if [ ! -f "$out/.gitignore" ]; then
+        test_fail "embedded: no .gitignore written"
+        return
+    fi
+    if grep -qx '\*' "$out/.gitignore"; then
+        test_pass "embedded: bundle .gitignore ignores the whole directory"
+    else
+        test_fail "embedded: .gitignore does not ignore everything" \
+                  "$(cat "$out/.gitignore")"
+    fi
+}
+
+test_gitignore_actually_ignores() {
+    command -v git >/dev/null 2>&1 || {
+        test_pass "git not available: skipping the end-to-end ignore check"
+        return
+    }
+
+    local repo="$TEST_TMPDIR/repo"
+    mkdir -p "$repo"
+    git -C "$repo" init -q 2>/dev/null || {
+        test_pass "git init unavailable: skipping the end-to-end ignore check"
+        return
+    }
+
+    local out="$repo/acme-setup-bastion"
+    mkdir -p "$out/roles/open-bastion/defaults"
+    echo 'ob_client_secret: "s3cr3t"' > "$out/roles/open-bastion/defaults/main.yml"
+
+    CLIENT_SECRET_MODE=embedded
+    _write_bundle_gitignore "$out"
+
+    git -C "$repo" add -A 2>/dev/null
+    if git -C "$repo" diff --cached --name-only | grep -q 'main.yml'; then
+        test_fail "git add -A still stages the secret-bearing file" \
+                  "$(git -C "$repo" diff --cached --name-only)"
+    else
+        test_pass "git add -A no longer stages the embedded secret"
+    fi
+}
+
+test_gitignore_not_written_when_not_embedded() {
+    local ok=true out
+    for mode in prompt none; do
+        out="$TEST_TMPDIR/bundle-$mode"
+        mkdir -p "$out"
+        CLIENT_SECRET_MODE="$mode"
+        _write_bundle_gitignore "$out"
+        [ -f "$out/.gitignore" ] && ok=false
+    done
+    $ok && test_pass "prompt/none: no .gitignore (the bundle is safe to version)" \
+         || test_fail "prompt/none: an unnecessary .gitignore was written"
+}
+
+test_gitignore_dry_run() {
+    local out="$TEST_TMPDIR/bundle-dryrun"
+    mkdir -p "$out"
+
+    CLIENT_SECRET_MODE=embedded
+    DRY_RUN=1
+    _write_bundle_gitignore "$out"
+    DRY_RUN=0
+
+    if [ -f "$out/.gitignore" ]; then
+        test_fail "dry-run: wrote a .gitignore"
+    else
+        test_pass "dry-run: writes nothing"
+    fi
+}
+
+echo "=========================================="
+echo "ob-builder embedded-secret protection (#203)"
+echo "=========================================="
+echo ""
+
+test_tighten_embedded
+test_tighten_defaults
+test_tighten_noop_when_not_embedded
+test_tighten_missing_file
+test_tighten_dry_run
+test_gitignore_written
+test_gitignore_actually_ignores
+test_gitignore_not_written_when_not_embedded
+test_gitignore_dry_run
+
+echo ""
+echo "=========================================="
+echo "Test Summary"
+echo "=========================================="
+echo -e "${GREEN}Passed:${NC} $TESTS_PASSED"
+echo -e "${RED}Failed:${NC} $TESTS_FAILED"
+echo "Total:  $((TESTS_PASSED + TESTS_FAILED))"
+echo ""
+
+if [ $TESTS_FAILED -eq 0 ]; then
+    echo -e "${GREEN}All tests passed!${NC}"
+    exit 0
+else
+    echo -e "${RED}Some tests failed.${NC}"
+    exit 1
+fi


### PR DESCRIPTION
Refs #203.

## The finding

Two untracked directories in the working tree — `linagora-setup-bastion/` and `old-linagora-setup/` — are `ob-builder` Ansible bundles built with `client_secret_mode: embedded`. Each holds a literal `ob_client_secret` in `roles/open-bastion/defaults/main.yml` and an inventory naming production hosts, and `git check-ignore` returned nothing for either.

## Two halves

**1. `.gitignore`** now covers those two directories, the `-bastion` / `-backend` / `-standalone` bundle names `ob-builder` derives from an operator's `--output-ansible` path, the presentation zip, and the openssh/pam source packages unpacked alongside them.

```
$ git status --short
?? analyse/          # audit notes, no credentials
```

**2. `ob-builder` itself**, because ignoring the bundles that happen to be here does not stop the next one. With `client_secret_mode: embedded` the secret goes in clear text into two artefacts, both left readable by every local account on the build host:

| artefact | before | after |
| --- | --- | --- |
| shell installer | `0755` | `0700` |
| role `defaults/main.yml` | `0644` | `0600` |

and an embedded bundle now gets a `.gitignore` at its root ignoring itself, so a bundle generated inside *any* git working tree cannot be committed by accident. The file explains how to version the bundle deliberately: rebuild with `client_secret_mode: prompt` and hold the secret in `ansible-vault`.

All of this is a **no-op for `client_secret_mode: prompt` (the default) and `none`** — no secret reaches the disk, so there is nothing to restrict or hide, and those bundles stay versionable.

## Tests

`tests/test_ob_builder_embedded_secret.sh` (9 cases, picked up by the CI's `tests/test_ob_*.sh` glob) pins both guards, their dry-run behaviour, the missing-file path (must not abort a `set -e` build), and that `prompt`/`none` bundles are untouched — including an end-to-end check that `git add -A` in a real repository no longer stages the secret-bearing file.

## Not done here

The issue also asks to delete the superseded local copy and rotate the client secret. Both act on untracked files and on the LLNG portal, outside a PR; `doc/ansible-quickstart.md` now states the rotation rule, since a shared bundle is a bearer credential for the deployment's OIDC client.

https://claude.ai/code/session_011q88Fs4nFuUs7JMvmgbBTN