### PR TITLE
fix(cert): drop the privileged fallback and let the host-key policy be tightened

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   so there is nothing to hide. The repository's own `.gitignore` also covers the
   bundle directories that were sitting untracked in the working tree.
 
+- **`ob-ssh` / `ob-scp` / `ob-sftp` no longer have a privileged shortcut around
+  `ob-cert-daemon` (#202).** `request_bastion_cert()` took a
+  `[ -r "$SERVER_TOKEN_FILE" ]` branch that called `/pam/bastion-cert` directly
+  with the bastion's bearer token whenever the caller could read the token file
+  — root, or a lab that had relaxed the `0600`. It was an escape hatch around
+  the SO_PEERCRED design, with none of the daemon's checks. It is gone: root and
+  unprivileged callers now take the same audited path through
+  `ob-cert-request` → `ob-cert-daemon`. `get_server_token()` and
+  `build_curl_opts()` went with it — the shared library no longer contacts the
+  portal at all. `SERVER_TOKEN_FILE` stays in `ssh-proxy.conf`: it is read by
+  `ob-cert-daemon`, which parses the same file.
+
+- **The bastion→backend host-key policy can now be tightened (#202).** The three
+  connectors passed `-o StrictHostKeyChecking=accept-new` *before* the
+  operator's `SSH_OPTIONS`, and `ssh` keeps the **first** value it is given for
+  an option — so the trust-on-first-use default could not be overridden at all.
+  The default is now emitted only when `SSH_OPTIONS` does not set the option, so
+  a site that pre-seeds `/etc/ssh/ssh_known_hosts` can refuse unknown backend
+  host keys:
+
+  ```
+  SSH_OPTIONS="-o StrictHostKeyChecking=yes -o GlobalKnownHostsFile=/etc/ssh/ssh_known_hosts"
+  ```
+
+  The TOFU trade-off itself — an attacker on the bastion→backend path can MITM
+  the *first* connection to a backend and read the session, though nothing
+  reusable is captured — is now documented in `doc/admin-guide.md`,
+  `man ob-ssh` and risk R-S9 of the EBIOS study, where it had never been stated.
+
 - **A world- or group-readable `/etc/open-bastion/cache.key` is now rejected
   instead of used with a warning** (offline auth cache, desktop SSO). Versions
   up to 0.6.2 accepted such a key and merely logged a warning. `SECURITY.md`

--- a/doc/admin-guide.md
+++ b/doc/admin-guide.md
@@ -294,15 +294,48 @@ cat > /etc/open-bastion/ssh-proxy.conf << 'EOF'
 # LLNG SSH Proxy configuration
 PORTAL_URL=https://auth.example.com
 SERVER_TOKEN_FILE=/var/lib/open-bastion/token
-SERVER_GROUP=bastion
 TARGET_GROUP=production
 TIMEOUT=10
 VERIFY_SSL=true
-SSH_OPTIONS="-o StrictHostKeyChecking=accept-new"
 EOF
 
 chmod 644 /etc/open-bastion/ssh-proxy.conf
 ```
+
+`PORTAL_URL`, `SERVER_TOKEN_FILE`, `VERIFY_SSL` and `TIMEOUT` are read here by
+`ob-cert-daemon`; `ob-ssh` and friends read only `TARGET_GROUP`, `SSH_OPTIONS`
+and `DEBUG`. The token itself is never read by the user-facing commands — the
+daemon holds it, and refuses it unless it is a root-owned `0600` regular file.
+`SERVER_GROUP` is still parsed for backward compatibility but does nothing: the
+bastion's group is resolved server-side from its enrolled token.
+
+#### Host-key policy on the bastion→backend hop
+
+`ob-ssh`, `ob-scp` and `ob-sftp` connect with
+`StrictHostKeyChecking=accept-new` unless you say otherwise. That is
+trust-on-first-use: the **first** connection to a given backend accepts whatever
+host key it presents, and every later one is pinned against the bastion's
+`known_hosts`.
+
+What that costs you: an attacker able to intercept the bastion→backend network
+path can impersonate a backend on that first connection and read the session.
+What it does not cost you: the ephemeral private key never leaves the bastion
+and the certificate is pinned to the bastion's source address, so nothing
+reusable is captured.
+
+If the bastion→backend path is not trusted, pre-seed the host keys and turn the
+policy off. `SSH_OPTIONS` is passed to `ssh` **before** the default, and `ssh`
+keeps the first value it is given for an option, so setting it here wins:
+
+```bash
+# Collect the backends' host keys over a trusted channel, once
+ssh-keyscan -t ed25519 backend-01 backend-02 >> /etc/ssh/ssh_known_hosts
+
+# /etc/open-bastion/ssh-proxy.conf
+SSH_OPTIONS="-o StrictHostKeyChecking=yes -o GlobalKnownHostsFile=/etc/ssh/ssh_known_hosts"
+```
+
+A backend whose key is not in that file is then refused instead of trusted.
 
 Users can then connect to backends in one command.
 

--- a/doc/security/02-ssh-connection.md
+++ b/doc/security/02-ssh-connection.md
@@ -636,12 +636,35 @@ pkill -u $USERNAME -KILL
 - **`target_host` enregistré dans le key-id** (`bastion=<id>;user=<u>;target=<h>`) : tracé à des fins d'audit. Note : `ob-ssh-principals` n'enforce que `bastion=<id>` (allowlist) et `user=<u>` — il **ne vérifie pas** `target=`, donc le certificat n'est pas restreint à un backend précis ; c'est `source-address` qui le restreint au bastion émetteur
 - La clé privée éphémère ne quitte jamais le bastion (tmpfs, effacée à la sortie) : seul le certificat signé transite sur le réseau
 
+**Limite connue — confiance à la première connexion (TOFU) :** `ob-ssh`,
+`ob-scp` et `ob-sftp` se connectent avec `StrictHostKeyChecking=accept-new` par
+défaut. La **première** connexion du bastion vers un backend donné accepte la
+clé d'hôte présentée sans la vérifier ; les suivantes sont épinglées par le
+`known_hosts` du bastion. Un attaquant capable d'intercepter le chemin
+bastion→backend peut donc se faire passer pour un backend lors de cette
+première connexion et **lire le contenu de la session**. Il ne capture rien de
+réutilisable : la clé privée éphémère ne quitte pas le bastion et le certificat
+est épinglé sur l'adresse source du bastion.
+
 **Remédiation configuration :**
 
 ```yaml
 # LLNG Manager - Réduire la durée de vie du certificat éphémère
 pamAccessBastionCertTtl: 60 # 1 minute au lieu de 2 (si politique plus stricte)
 ```
+
+```bash
+# Bastion - supprimer le TOFU : pré-alimenter les clés d'hôte par un canal
+# de confiance, puis refuser toute clé inconnue.
+ssh-keyscan -t ed25519 backend-01 backend-02 >> /etc/ssh/ssh_known_hosts
+
+# /etc/open-bastion/ssh-proxy.conf
+SSH_OPTIONS="-o StrictHostKeyChecking=yes -o GlobalKnownHostsFile=/etc/ssh/ssh_known_hosts"
+```
+
+`SSH_OPTIONS` est passé à `ssh` **avant** l'option par défaut et `ssh` retient
+la première valeur reçue pour une option : ce réglage l'emporte donc sur
+`accept-new`.
 
 |                 |                          Score résiduel                          |
 | --------------- | :--------------------------------------------------------------: |

--- a/man/ob-ssh.1
+++ b/man/ob-ssh.1
@@ -101,13 +101,29 @@ SSH_OPTIONS=""
 DEBUG=false
 .fi
 .PP
-A normal (non-root) user cannot read the root-only server token; the single
-privileged call is delegated to
+The server token is never read by
+.BR ob-ssh :
+the single privileged call is delegated to
 .BR ob-cert-daemon (8),
 a socket-activated service reached through the unprivileged
 .BR ob-cert-request (1)
-client. The daemon derives the certificate's user from the connection's
-SO_PEERCRED, so it always mints for the connecting user. No sudo, no setuid.
+client, which reads \fISERVER_TOKEN_FILE\fR from this same configuration file.
+The daemon derives the certificate's user from the connection's SO_PEERCRED, so
+it always mints for the connecting user. No sudo, no setuid, and root takes the
+same path as everyone else.
+.SS "Host key policy"
+The bastion\(->backend hop uses \fBStrictHostKeyChecking=accept-new\fR unless
+\fISSH_OPTIONS\fR sets the option itself. That is trust-on-first-use: the first
+connection to a backend accepts the host key it presents, later ones are pinned
+by \fIknown_hosts\fR. To refuse unknown keys instead, pre-seed the host keys
+over a trusted channel and set
+.PP
+.nf
+SSH_OPTIONS="-o StrictHostKeyChecking=yes -o GlobalKnownHostsFile=/etc/ssh/ssh_known_hosts"
+.fi
+.PP
+\fISSH_OPTIONS\fR is passed to \fBssh\fR before the default and \fBssh\fR keeps
+the first value given for an option, so this wins.
 .SH "TTY HANDLING"
 When standard input is a terminal,
 .B ob-ssh

--- a/scripts/ob-cert-lib.sh
+++ b/scripts/ob-cert-lib.sh
@@ -3,9 +3,10 @@
 #
 # ob-cert-lib.sh - shared bastion certificate-vouching helpers
 #
-# Sourced by ob-ssh, ob-scp and ob-sftp. Holds the
-# common configuration, logging and the LLNG /pam/bastion-cert minting flow so
-# both the SSH and SCP front-ends behave identically.
+# Sourced by ob-ssh, ob-scp and ob-sftp. Holds the common configuration,
+# logging and certificate-minting flow so the SSH, SCP and SFTP front-ends
+# behave identically. Minting itself is delegated to ob-cert-daemon through the
+# unprivileged ob-cert-request client; nothing here contacts the portal.
 #
 # This file is meant to be SOURCED, not executed. It does not set shell options
 # (the sourcing script owns `set -euo pipefail`) and defines no main().
@@ -17,7 +18,6 @@
 # Configuration (can be overridden via /etc/open-bastion/ssh-proxy.conf, then by
 # the sourcing script before load_config is called).
 : "${PORTAL_URL:=}"
-: "${SERVER_TOKEN_FILE:=/var/lib/open-bastion/token}"
 : "${TARGET_GROUP:=default}"
 : "${TIMEOUT:=10}"
 : "${VERIFY_SSL:=true}"
@@ -76,7 +76,10 @@ load_config() {
             value="${value#\'}" ; value="${value%\'}"
             case "$key" in
                 PORTAL_URL)          PORTAL_URL="$value" ;;
-                SERVER_TOKEN_FILE)   SERVER_TOKEN_FILE="$value" ;;
+                # SERVER_TOKEN_FILE is consumed by ob-cert-daemon, which
+                # parses this same file; nothing in this library reads the
+                # server token any more, so accept the key and drop it here.
+                SERVER_TOKEN_FILE)   : ;;
                 # SERVER_GROUP accepted-but-ignored (back-compat): the bastion's
                 # group is resolved server-side from its enrolled token.
                 SERVER_GROUP)        : ;;
@@ -94,6 +97,11 @@ load_config() {
 
 # Validate required configuration and warn about insecure transports. Call after
 # load_config from the sourcing script's main().
+#
+# PORTAL_URL is no longer contacted from here -- ob-cert-daemon holds the portal
+# connection -- but it stays required: an ssh-proxy.conf without it is an
+# unconfigured bastion, and failing here says so far more clearly than a socket
+# error would.
 validate_config() {
     if [ -z "$PORTAL_URL" ]; then
         error "PORTAL_URL not configured. Set it in $CONFIG_FILE"
@@ -104,32 +112,39 @@ validate_config() {
     fi
 }
 
+# ── Host-key policy ──────────────────────────────────────────────────────────
+# Emit the default host-key options for the bastion->backend hop, unless the
+# operator has already set StrictHostKeyChecking in SSH_OPTIONS.
+#
+# The default is accept-new: the first connection to a backend trusts whatever
+# host key it presents (TOFU), later ones are pinned by known_hosts. An attacker
+# who can intercept the bastion->backend path can therefore MITM that first hop
+# and read the session. The ephemeral private key never leaves the bastion and
+# the certificate is pinned to the bastion's source address, so credentials are
+# not stolen -- but the session content is exposed.
+#
+# ssh takes the FIRST value it is given for an option, so this must be emitted
+# after the operator's SSH_OPTIONS to be overridable; a site that pre-seeds
+# /etc/ssh/ssh_known_hosts sets, in /etc/open-bastion/ssh-proxy.conf:
+#
+#   SSH_OPTIONS="-o StrictHostKeyChecking=yes -o GlobalKnownHostsFile=/etc/ssh/ssh_known_hosts"
+#
+# See doc/security/02-ssh-connection.md.
+build_host_key_opts() {
+    # Consumed by the sourcing script (ob-ssh / ob-scp / ob-sftp), not this lib.
+    # shellcheck disable=SC2034
+    HOST_KEY_OPTS=()
+    local opt
+    for opt in ${SSH_OPTIONS_ARRAY[@]+"${SSH_OPTIONS_ARRAY[@]}"}; do
+        case "$opt" in
+            StrictHostKeyChecking=*|-oStrictHostKeyChecking=*) return 0 ;;
+        esac
+    done
+    # shellcheck disable=SC2034
+    HOST_KEY_OPTS=(-o StrictHostKeyChecking=accept-new)
+}
+
 # ── Certificate minting ──────────────────────────────────────────────────────
-# Build curl options into the global CURL_OPTS array.
-build_curl_opts() {
-    # --fail-with-body (not -f): on a non-2xx response curl still writes the
-    # JSON error body to stdout AND returns non-zero, so the caller can detect
-    # structured reasons like {"reason":"voucher_expired"} instead of getting an
-    # empty body. (-f would discard the body and hide the reason.)
-    CURL_OPTS=("-s" "--fail-with-body" "--connect-timeout" "$TIMEOUT")
-    if [ "$VERIFY_SSL" = "false" ]; then
-        CURL_OPTS+=("-k")
-    fi
-}
-
-# Read the server access token (JSON from ob-enroll, or plain text).
-get_server_token() {
-    if [ ! -f "$SERVER_TOKEN_FILE" ]; then
-        error "Server token file not found: $SERVER_TOKEN_FILE"
-        exit 1
-    fi
-    if head -c1 "$SERVER_TOKEN_FILE" | grep -q '{'; then
-        jq -r '.access_token // empty' "$SERVER_TOKEN_FILE" 2>/dev/null || cat "$SERVER_TOKEN_FILE"
-    else
-        cat "$SERVER_TOKEN_FILE"
-    fi
-}
-
 # Validate a hostname to prevent SSH option injection.
 # Only allows: alphanumeric, dots, hyphens, underscores, colons (IPv6), brackets.
 validate_hostname() {
@@ -163,62 +178,31 @@ request_bastion_cert() {
 
     debug "Requesting bastion cert for user $user to host $target_host"
 
+    # The server token is root-only BY DESIGN, and this is the only path: the
+    # single privileged call is performed by ob-cert-daemon (socket-activated,
+    # runs as root), reached through the unprivileged ob-cert-request client.
+    # The daemon derives the certificate's user from the connection's
+    # SO_PEERCRED — so it always mints for the connecting user, whatever we send
+    # — and the server token never leaves it. No sudo, no setuid, and minting is
+    # decoupled from the interactive sudo policy (Mode E).
+    #
+    # Until 0.6.2 a `[ -r "$SERVER_TOKEN_FILE" ]` branch called LLNG directly
+    # with the bearer token whenever the caller could read it — root, or a lab
+    # that had relaxed the 0600. It was an escape hatch around the SO_PEERCRED
+    # design with no counterpart in the daemon's checks, so it is gone: root
+    # and unprivileged callers now take the same, audited path (#202).
     local response
-    if [ -r "$SERVER_TOKEN_FILE" ]; then
-        # Privileged path (root, or a relaxed lab setup): call LLNG directly.
-        local server_token
-        server_token=$(get_server_token)
-        if [ -z "$server_token" ]; then
-            error "Failed to read server token"
-            return 1
-        fi
-
-        build_curl_opts
-
-        local json_payload
-        json_payload=$(jq -n \
-            --arg user "$user" \
-            --arg target_host "$target_host" \
-            --arg target_group "$TARGET_GROUP" \
-            --arg public_key "$pubkey" \
-            --arg voucher "$VOUCHER" \
-            '{user: $user, target_host: $target_host, target_group: $target_group, public_key: $public_key, voucher: $voucher}')
-
-        # 2>/dev/null (not 2>&1): keep curl's stderr OUT of $response so it stays
-        # valid JSON. With --fail-with-body the JSON error body is captured even
-        # on non-2xx, so we do NOT early-return on a non-zero rc — the parser
-        # below extracts .reason/.error. Only a truly empty response is fatal.
-        response=$(curl "${CURL_OPTS[@]}" \
-            -X POST \
-            -H "Authorization: Bearer $server_token" \
-            -H "Content-Type: application/json" \
-            -d "$json_payload" \
-            "${PORTAL_URL}/pam/bastion-cert" 2>/dev/null) || true
-        if [ -z "$response" ]; then
-            error "Failed to request bastion certificate (no response from ${PORTAL_URL}/pam/bastion-cert)"
-            return 1
-        fi
-    else
-        # Normal user path: the server token is root-only BY DESIGN. The single
-        # privileged call is performed by ob-cert-daemon (socket-activated, runs
-        # as root), reached through the unprivileged ob-cert-request client. The
-        # daemon derives the certificate's user from the connection's SO_PEERCRED
-        # — so it always mints for the connecting user, whatever we send — and
-        # the server token never leaves it. No sudo, no setuid, and minting is
-        # decoupled from the interactive sudo policy (Mode E).
-        debug "Server token not readable; requesting via ob-cert-daemon socket"
-        local rc=0
-        local client
-        client=$(command -v ob-cert-request 2>/dev/null) || client="/usr/bin/ob-cert-request"
-        # Protocol (newline-delimited): target_host, target_group, voucher, pubkey.
-        response=$(printf '%s\n%s\n%s\n%s\n' \
-            "$target_host" "$TARGET_GROUP" "$VOUCHER" "$pubkey" \
-            | "$client") || rc=$?
-        if [ -z "$response" ]; then
-            error "Failed to request bastion certificate via ob-cert-daemon (rc=$rc)."
-            error "Is ob-cert.socket enabled? (re-run ob-bastion-setup on this bastion)"
-            return 1
-        fi
+    local rc=0
+    local client
+    client=$(command -v ob-cert-request 2>/dev/null) || client="/usr/bin/ob-cert-request"
+    # Protocol (newline-delimited): target_host, target_group, voucher, pubkey.
+    response=$(printf '%s\n%s\n%s\n%s\n' \
+        "$target_host" "$TARGET_GROUP" "$VOUCHER" "$pubkey" \
+        | "$client") || rc=$?
+    if [ -z "$response" ]; then
+        error "Failed to request bastion certificate via ob-cert-daemon (rc=$rc)."
+        error "Is ob-cert.socket enabled? (re-run ob-bastion-setup on this bastion)"
+        return 1
     fi
 
     local cert

--- a/scripts/ob-scp
+++ b/scripts/ob-scp
@@ -175,12 +175,13 @@ main() {
     # Force -3: route every connection through the bastion so the source address
     # matches the cert pin (and so backend<->backend works at all).
     local rc=0
+    build_host_key_opts
     scp -3 \
         -i "$OB_EPH_KEY" \
         -o CertificateFile="$OB_EPH_CERT" \
         -o IdentitiesOnly=yes \
-        -o StrictHostKeyChecking=accept-new \
         "${SSH_OPTIONS_ARRAY[@]}" \
+        ${HOST_KEY_OPTS[@]+"${HOST_KEY_OPTS[@]}"} \
         "${SCP_ARGS[@]}" || rc=$?
 
     exit $rc

--- a/scripts/ob-sftp
+++ b/scripts/ob-sftp
@@ -151,12 +151,13 @@ main() {
     trap "rm -rf '$OB_EPH_DIR'" EXIT
 
     local rc=0
+    build_host_key_opts
     sftp \
         -i "$OB_EPH_KEY" \
         -o CertificateFile="$OB_EPH_CERT" \
         -o IdentitiesOnly=yes \
-        -o StrictHostKeyChecking=accept-new \
         "${SSH_OPTIONS_ARRAY[@]}" \
+        ${HOST_KEY_OPTS[@]+"${HOST_KEY_OPTS[@]}"} \
         "${SFTP_ARGS[@]}" || rc=$?
 
     exit $rc

--- a/scripts/ob-ssh
+++ b/scripts/ob-ssh
@@ -99,13 +99,14 @@ connect_via_cert() {
     # it to the backend to run, and the array keeps each word intact (no bastion
     # re-splitting / globbing). Empty array expands to nothing under `set -u`.
     local rc=0
+    build_host_key_opts
     ssh -i "$OB_EPH_KEY" \
         -o CertificateFile="$OB_EPH_CERT" \
         -o IdentitiesOnly=yes \
-        -o StrictHostKeyChecking=accept-new \
         "${tty_opt[@]}" \
         -p "$target_port" \
         "${SSH_OPTIONS_ARRAY[@]}" \
+        ${HOST_KEY_OPTS[@]+"${HOST_KEY_OPTS[@]}"} \
         -l "$target_user" \
         -- "$target_host" "${REMOTE_CMD[@]}" || rc=$?
 

--- a/tests/test_ob_ssh.sh
+++ b/tests/test_ob_ssh.sh
@@ -155,7 +155,7 @@ load_config 2>/dev/null
 
 # Output variables for verification
 echo "PORTAL_URL=$PORTAL_URL"
-echo "SERVER_TOKEN_FILE=$SERVER_TOKEN_FILE"
+echo "SERVER_TOKEN_FILE=${SERVER_TOKEN_FILE:-IGNORED}"
 echo "TARGET_GROUP=$TARGET_GROUP"
 echo "TIMEOUT=$TIMEOUT"
 echo "VERIFY_SSL=$VERIFY_SSL"
@@ -186,9 +186,12 @@ EOF
         all_good=false
         details+="PORTAL_URL wrong; "
     fi
-    if ! echo "$output" | grep -q "SERVER_TOKEN_FILE=/tmp/test_token"; then
+    # SERVER_TOKEN_FILE is accepted-but-ignored since #202: the key must still
+    # parse without error, but the library must not keep it -- nothing here
+    # reads the server token any more, ob-cert-daemon does.
+    if ! echo "$output" | grep -q "SERVER_TOKEN_FILE=IGNORED"; then
         all_good=false
-        details+="SERVER_TOKEN_FILE wrong; "
+        details+="SERVER_TOKEN_FILE should be ignored, not stored; "
     fi
     if ! echo "$output" | grep -q "TARGET_GROUP=mygroup"; then
         all_good=false
@@ -296,168 +299,73 @@ EOF
     fi
 }
 
-# Test 9: build_curl_opts without SSL skip
-test_curl_opts_ssl_verify() {
-    local test_script="$TEST_TMPDIR/test_curl_ssl.sh"
-    cat > "$test_script" <<'TESTSCRIPT'
-#!/bin/bash
-set -u
-source_file="$1"
-
-source "$source_file"
-
-VERIFY_SSL=true
-TIMEOUT=10
-
-build_curl_opts
-
-# Check for -k flag
-has_k=false
-for opt in "${CURL_OPTS[@]}"; do
-    if [ "$opt" = "-k" ]; then
-        has_k=true
-    fi
-done
-
-if $has_k; then
-    echo "HAS_K"
-else
-    echo "NO_K"
-fi
-TESTSCRIPT
-
-    chmod +x "$test_script"
-    local output
-    output=$("$test_script" "$LIB" 2>&1)
-
-    if [[ "$output" == "NO_K" ]]; then
-        test_pass "build_curl_opts without SSL skip: no -k flag"
+# Test 9: the library never talks to the portal itself any more (#202).
+# A `[ -r "$SERVER_TOKEN_FILE" ]` branch used to call /pam/bastion-cert directly
+# with the bearer token whenever the caller could read it -- root, or a lab that
+# had relaxed the 0600. That escape hatch around the SO_PEERCRED design is gone;
+# every caller now goes through ob-cert-daemon.
+test_no_direct_portal_call() {
+    local bad=""
+    grep -q 'pam/bastion-cert' "$LIB" && bad+="calls /pam/bastion-cert; "
+    grep -q 'get_server_token' "$LIB" && bad+="still reads the server token; "
+    grep -q 'Authorization: Bearer' "$LIB" && bad+="still sends a bearer token; "
+    if [ -z "$bad" ]; then
+        test_pass "cert lib has no direct portal path (ob-cert-daemon only)"
     else
-        test_fail "build_curl_opts without SSL skip: should not have -k flag"
+        test_fail "cert lib still has a privileged fallback" "$bad"
     fi
 }
 
-# Test 10: build_curl_opts with SSL skip
-test_curl_opts_ssl_skip() {
-    local test_script="$TEST_TMPDIR/test_curl_nossl.sh"
+# Tests 10-12: the host-key policy is a default, not a lock.
+#
+# ssh keeps the FIRST value given for an option, so the hardcoded
+# `-o StrictHostKeyChecking=accept-new` used to sit before SSH_OPTIONS and could
+# not be tightened by an operator at all. It is now emitted only when the
+# operator has not set the option themselves.
+_host_key_opts_for() {
+    local test_script="$TEST_TMPDIR/test_host_key_opts.sh"
     cat > "$test_script" <<'TESTSCRIPT'
 #!/bin/bash
 set -u
-source_file="$1"
-
-source "$source_file"
-
-VERIFY_SSL=false
-TIMEOUT=10
-
-build_curl_opts
-
-has_k=false
-for opt in "${CURL_OPTS[@]}"; do
-    if [ "$opt" = "-k" ]; then
-        has_k=true
-    fi
-done
-
-if $has_k; then
-    echo "HAS_K"
-else
-    echo "NO_K"
-fi
+source "$1"
+shift
+SSH_OPTIONS_ARRAY=()
+[ "$#" -gt 0 ] && read -r -a SSH_OPTIONS_ARRAY <<<"$1"
+build_host_key_opts
+printf '%s\n' ${HOST_KEY_OPTS[@]+"${HOST_KEY_OPTS[@]}"}
 TESTSCRIPT
-
     chmod +x "$test_script"
-    local output
-    output=$("$test_script" "$LIB" 2>&1)
+    "$test_script" "$LIB" "$@" 2>&1
+}
 
-    if [[ "$output" == "HAS_K" ]]; then
-        test_pass "build_curl_opts with SSL skip: has -k flag"
+test_host_key_opts_default() {
+    local out
+    out=$(_host_key_opts_for)
+    if [ "$out" = "-o
+StrictHostKeyChecking=accept-new" ]; then
+        test_pass "host key policy defaults to accept-new (TOFU)"
     else
-        test_fail "build_curl_opts with SSL skip: should have -k flag"
+        test_fail "host key policy default wrong" "Got: $out"
     fi
 }
 
-# Test 11: get_server_token reads JSON format
-test_get_token_json() {
-    local test_script="$TEST_TMPDIR/test_token_json.sh"
-    cat > "$test_script" <<'TESTSCRIPT'
-#!/bin/bash
-set -u
-source_file="$1"
-token_file="$2"
-
-source "$source_file"
-
-SERVER_TOKEN_FILE="$token_file"
-get_server_token 2>/dev/null
-TESTSCRIPT
-
-    chmod +x "$test_script"
-    local token_file="$TEST_TMPDIR/token_json"
-    echo '{"access_token": "mytoken123", "refresh_token": "rt"}' > "$token_file"
-
-    local output
-    output=$("$test_script" "$LIB" "$token_file" 2>&1)
-
-    if [[ "$output" == "mytoken123" ]]; then
-        test_pass "get_server_token reads JSON format"
+test_host_key_opts_operator_override() {
+    local out
+    out=$(_host_key_opts_for "-o StrictHostKeyChecking=yes -o GlobalKnownHostsFile=/etc/ssh/ssh_known_hosts")
+    if [ -z "$out" ]; then
+        test_pass "operator StrictHostKeyChecking=yes is not overridden by the default"
     else
-        test_fail "get_server_token reads JSON format" "Got: $output"
+        test_fail "default still emitted over the operator's setting" "Got: $out"
     fi
 }
 
-# Test 12: get_server_token reads plain text
-test_get_token_plaintext() {
-    local test_script="$TEST_TMPDIR/test_token_plain.sh"
-    cat > "$test_script" <<'TESTSCRIPT'
-#!/bin/bash
-set -u
-source_file="$1"
-token_file="$2"
-
-source "$source_file"
-
-SERVER_TOKEN_FILE="$token_file"
-get_server_token 2>/dev/null
-TESTSCRIPT
-
-    chmod +x "$test_script"
-    local token_file="$TEST_TMPDIR/token_plain"
-    echo "plaintoken456" > "$token_file"
-
-    local output
-    output=$("$test_script" "$LIB" "$token_file" 2>&1)
-
-    if [[ "$output" == "plaintoken456" ]]; then
-        test_pass "get_server_token reads plain text format"
+test_host_key_opts_override_joined_form() {
+    local out
+    out=$(_host_key_opts_for "-oStrictHostKeyChecking=yes")
+    if [ -z "$out" ]; then
+        test_pass "operator -oStrictHostKeyChecking=yes (joined form) is honoured"
     else
-        test_fail "get_server_token reads plain text format" "Got: $output"
-    fi
-}
-
-# Test 13: get_server_token rejects missing file
-test_get_token_missing() {
-    local test_script="$TEST_TMPDIR/test_token_missing.sh"
-    cat > "$test_script" <<'TESTSCRIPT'
-#!/bin/bash
-source_file="$1"
-
-source "$source_file"
-
-SERVER_TOKEN_FILE="/nonexistent/path/to/token"
-get_server_token 2>&1
-exit $?
-TESTSCRIPT
-
-    chmod +x "$test_script"
-    local output
-    local exit_code=0
-    output=$("$test_script" "$LIB" 2>&1) || exit_code=$?
-
-    if [ $exit_code -ne 0 ]; then
-        test_pass "get_server_token rejects missing file"
-    else
-        test_fail "get_server_token should reject missing file" "Exit code: $exit_code"
+        test_fail "joined -o form not recognised" "Got: $out"
     fi
 }
 
@@ -800,11 +708,10 @@ test_config_permissions_group_writable
 test_safe_config_parsing
 test_config_quotes
 test_config_comments
-test_curl_opts_ssl_verify
-test_curl_opts_ssl_skip
-test_get_token_json
-test_get_token_plaintext
-test_get_token_missing
+test_no_direct_portal_call
+test_host_key_opts_default
+test_host_key_opts_operator_override
+test_host_key_opts_override_joined_form
 test_parse_args_host_port
 test_parse_args_default_port
 test_parse_args_config_file


### PR DESCRIPTION
Closes #202 — both halves.

## 1. The privileged fallback is gone

`request_bastion_cert()` took a `[ -r "$SERVER_TOKEN_FILE" ]` branch that called `/pam/bastion-cert` directly with the bastion's bearer token whenever the caller could read the token file — root, or a lab that had relaxed the `0600`. An escape hatch around the SO_PEERCRED design, with none of the daemon's checks.

Root and unprivileged callers now take the same audited path through `ob-cert-request` → `ob-cert-daemon`. `get_server_token()` and `build_curl_opts()` went with it: the shared library no longer contacts the portal at all.

One correction to the issue's reading: `SERVER_TOKEN_FILE` is **not** dead config. `ob-cert-daemon` parses the same `ssh-proxy.conf` and reads the token path from it (`src/ob-cert-daemon.c:229`). The key stays; only the shell library stops using it.

## 2. The TOFU default could not be overridden — that was the real bug

The three connectors passed `-o StrictHostKeyChecking=accept-new` **before** the operator's `SSH_OPTIONS`. `ssh` keeps the **first** value it is given for an option, so a site that pre-seeded `known_hosts` had no way to refuse an unknown backend host key — the documented `SSH_OPTIONS` escape hatch silently did nothing for this option.

The default is now emitted only when `SSH_OPTIONS` does not set `StrictHostKeyChecking` itself (both the `-o X=y` and `-oX=y` spellings), so this works:

```
SSH_OPTIONS="-o StrictHostKeyChecking=yes -o GlobalKnownHostsFile=/etc/ssh/ssh_known_hosts"
```

The trade-off itself was documented nowhere, as the issue says. It now appears in `doc/admin-guide.md`, `man ob-ssh` and risk **R-S9** of the EBIOS study, each stating precisely what an attacker on the bastion→backend path gets (the first session's content) and what they do not (anything reusable — the ephemeral key never leaves the bastion, the certificate is source-address pinned), with the pre-seeded `known_hosts` remediation.

## Tests

`tests/test_ob_ssh.sh` loses the `get_server_token` / `build_curl_opts` cases (the functions no longer exist) and gains four: one asserting the library has no direct portal path left, and three on the host-key policy — default, operator override, joined `-o` form.

```
$ bash tests/test_ob_ssh.sh   → 22/22
$ bash tests/test_ob_scp.sh   → 7/7
$ bash tests/test_ob_sftp.sh  → 6/6
$ shellcheck -S warning scripts/ob-cert-lib.sh scripts/ob-{ssh,scp,sftp}  → clean
```

## Blast radius worth knowing

A container demo where `ob-ssh` is run as **root** and no `ob-cert.socket` exists used to work through the fallback and now fails with the daemon's message. The docker demos ship the token `0600`, so their documented `dwho` workflow already required the daemon; no integration test exercises `ob-ssh`.

https://claude.ai/code/session_011q88Fs4nFuUs7JMvmgbBTN