### PR TITLE
fix(pam): make the SSH fingerprint binding usable under sudo and enforceable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -369,6 +369,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the R-S3 / R-S15 residual scores. Do **not** enable it in the token-only modes,
   where no fingerprint ever exists and every SSH login would be denied.
 
+  The portal is growing the server-side half of the same control:
+  `linagora/lemonldap-ng-plugins#86` caps a voucher that no fingerprint binds at
+  `pamAccessBastionVoucherUnboundTtl` (900 s instead of 12 h) and adds
+  `pamAccessRequireFingerprint` to refuse the unbound case outright. Once that
+  ships, a missing spool drop stops degrading silently and starts breaking
+  visibly: `ob-ssh` hops fail about fifteen minutes into the session with
+  `voucher_expired`. That is the better failure, but it is a failure — which is
+  the argument for turning `fingerprint_required` on **before** the portal is
+  upgraded, so the refusal lands at login with an audited reason instead of on a
+  hop a quarter of an hour later.
+
 ### Changed
 
 - **A failing `ctest` now keeps its log, and the concurrency test says why it

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -360,15 +360,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     the mtime of `/proc/<pid>` is the process start time, which makes the
     comparison exact.
   - A service-account authentication resting on a spool-derived fingerprint,
-    rather than on `sshd`'s own `SSH_USER_AUTH`, is logged at WARN and recorded
-    in the audit trail. It is a root grant whose integrity rests on `nobody`,
-    and the trail should be able to say so afterwards.
+    rather than on `sshd`'s own `SSH_USER_AUTH`, is logged at WARN and the
+    provenance is carried in the reason of the single audit success event. It is
+    a root grant whose integrity rests on `nobody`, and the trail should be able
+    to say so afterwards.
 
   The real fix — a socket-activated root daemon identifying its caller with
   `SO_PEERCRED`, the pattern `ob-cert-daemon` already uses — is tracked in
   [#249](https://github.com/linagora/open-bastion/issues/249).
   `doc/security/99-risk-reduce.md` states the residual plainly, next to the
   R-S3 / R-S15 reduction it underwrites.
+
+- **`fingerprint_required` is documented where an operator looks for it.** It is
+  condition of use **CE09** of the homologation dossier and the assumption
+  behind the R-S3 / R-S15 residual scores, but `doc/admin-guide.md`'s "SSH Key
+  Policy" section did not mention it, and the accepted alias
+  `ssh_fingerprint_required` appeared in no document at all.
 
 - **`fingerprint_required` now covers service accounts too, and their SSH check
   actually runs.** The service-account branch of `pam_sm_acct_mgmt` returned

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -338,6 +338,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `auth required pam_deny.so`. Check with
   `grep '^auth' /etc/pam.d/sshd`.
 
+- **Service-account `sudo` with `sudo_nopasswd = false` now works at all
+  (#194).** The fingerprint check read `SSH_USER_AUTH` only. That variable does
+  not exist in a `sudo` PAM handle, so the check could never succeed and the
+  branch always returned `PAM_AUTH_ERR` — leaving `sudo_nopasswd = true`, which
+  grants sudo with no proof of identity, as the only workable setting, and
+  pushing admins toward it. The fingerprint is now also recovered from the
+  principals spool (`/run/open-bastion/ssh-fp`), which the SSH session populated
+  and which `sudo` inherits through the process tree, so both settings do what
+  they say. On a host without the principals helper there is still no
+  fingerprint in either context and `sudo_nopasswd = false` refuses, which is
+  the fail-closed answer.
+
+### Security
+
+- **A missing SSH fingerprint drop is now visible, and can be made fatal
+  (#192).** When the principals spool exists but this session's drop is absent —
+  post-upgrade drift, a lost `tmpfiles.d` entry, or a password login on a
+  cert-aware host — the module dropped the fingerprint binding with a DEBUG line
+  and authorized the session anyway. `doc/security/99-risk-reduce.md` credits
+  that binding with reducing R-S3 and R-S15, and the bastion voucher TTL is only
+  capped by the SSO certificate expiry when a fingerprint was supplied, so a
+  provisioning failure silently removed a control the risk matrix depends on.
+
+  The missing drop is now logged at **WARN** (the spool directory being absent
+  altogether stays at DEBUG: that host simply does not use the helper), and a new
+  opt-in `fingerprint_required = true` refuses an SSH login whose fingerprint
+  cannot be recovered instead of authorizing without the binding. Enable it on
+  certificate-mode hosts — the EBIOS study now names it as a condition of use for
+  the R-S3 / R-S15 residual scores. Do **not** enable it in the token-only modes,
+  where no fingerprint ever exists and every SSH login would be denied.
+
 ### Changed
 
 - **A failing `ctest` now keeps its log, and the concurrency test says why it

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -338,6 +338,56 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `auth required pam_deny.so`. Check with
   `grep '^auth' /etc/pam.d/sshd`.
 
+- **The fingerprint spool is harder to forge, and what it is worth is now
+  written down (#235 review).** The spool's trust root is the `nobody` account:
+  `sshd` requires a non-privileged `AuthorizedPrincipalsCommandUser`, so the
+  helper that writes the drops runs as `nobody` and the directory must be
+  writable by it. Code execution as `nobody` can therefore read the deposited
+  fingerprints and write false ones, and none of the module's existing checks
+  (`O_NOFOLLOW`, `nlink == 1`, mode `0600`, drop owner == directory owner) is
+  designed against an attacker who is already inside that perimeter. Three
+  changes narrow it without changing its nature:
+
+  - The anchor `/proc/<pid>` must be a live process owned by **root**. The
+    anchor is chosen by process *name*, and `prctl(PR_SET_NAME)` accepts fifteen
+    characters while `sshd-session` is twelve — so a local user could put a
+    process by that name in the ancestry of their own `sudo` and choose which
+    drop was read. That half of the forge needed no privilege at all.
+  - A drop older than its anchor process is refused. Nothing removes a drop when
+    a session ends and the principals helper does not run for password logins,
+    so once a PID was recycled the new session inherited the previous
+    occupant's binding, with every ownership and mode check passing. On Linux
+    the mtime of `/proc/<pid>` is the process start time, which makes the
+    comparison exact.
+  - A service-account authentication resting on a spool-derived fingerprint,
+    rather than on `sshd`'s own `SSH_USER_AUTH`, is logged at WARN and recorded
+    in the audit trail. It is a root grant whose integrity rests on `nobody`,
+    and the trail should be able to say so afterwards.
+
+  The real fix — a socket-activated root daemon identifying its caller with
+  `SO_PEERCRED`, the pattern `ob-cert-daemon` already uses — is tracked in
+  [#249](https://github.com/linagora/open-bastion/issues/249).
+  `doc/security/99-risk-reduce.md` states the residual plainly, next to the
+  R-S3 / R-S15 reduction it underwrites.
+
+- **`fingerprint_required` now covers service accounts too, and their SSH check
+  actually runs.** The service-account branch of `pam_sm_acct_mgmt` returned
+  `PAM_SUCCESS` before the enforcement block, so the setting documented as
+  covering "every SSH login" skipped them. Worse, their account-phase check read
+  `SSH_USER_AUTH` alone — which a modern OpenSSH does not set for a plain public
+  key — and for a public-key login that is the *only* check that runs, since
+  `sshd` never calls `pam_authenticate()` on that path. It resolves through the
+  spool now, like the `sudo` path, and `fingerprint_required` is enforced before
+  the early return.
+
+- **A missing `.key` drop is no longer reported as a missing key binding.**
+  `read_spool_drop()` is shared between the `.fp` and `.key` suffixes and warned
+  identically for both. The `.key` drop only exists when `sshd` passes `%t` to
+  the helper; a host configured from the shorter `%u %f` form still shown in
+  places has none, and its absence is a missing capability the caller handles by
+  falling back, not a missing security binding. WARN for `.fp`, DEBUG for the
+  rest.
+
 - **Service-account `sudo` with `sudo_nopasswd = false` now works at all
   (#194).** The fingerprint check read `SSH_USER_AUTH` only. That variable does
   not exist in a `sudo` PAM handle, so the check could never succeed and the

--- a/config/openbastion.conf.example
+++ b/config/openbastion.conf.example
@@ -336,6 +336,21 @@ log_level = warn
 # Default: 256
 # ssh_key_min_ecdsa_bits = 256
 
+# Require the SSH key fingerprint binding on every SSH login
+# The fingerprint of the key that opened the session is sent to LLNG with
+# /pam/authorize, which lets the portal cross-check it against the user's
+# session and caps the bastion voucher lifetime at the SSO certificate's
+# expiry. It is recovered from /run/open-bastion/ssh-fp, written by the
+# AuthorizedPrincipalsCommand helper.
+# When that spool is missing - a provisioning failure, a lost tmpfiles.d
+# entry after an upgrade - the binding is dropped and the login is authorized
+# without it. Setting this to true refuses such a login instead.
+# Only enable it on hosts that run the principals helper (certificate modes):
+# in the token-only modes there is never a fingerprint and every SSH login
+# would be denied.
+# Default: false
+# fingerprint_required = false
+
 # ==============================================================================
 # Cache Brute-Force Protection (offline mode security)
 # ==============================================================================

--- a/doc/admin-guide.md
+++ b/doc/admin-guide.md
@@ -1105,7 +1105,37 @@ ssh_key_min_rsa_bits = 3072
 
 # Minimum ECDSA key size in bits (default: 256)
 ssh_key_min_ecdsa_bits = 256
+
+# Refuse an SSH session that carries no key fingerprint at all
+# (alias: ssh_fingerprint_required). Default: false.
+fingerprint_required = true
 ```
+
+### Requiring a fingerprint at all
+
+`fingerprint_required` is separate from the policy above: the policy says which
+keys are acceptable, this says whether a session without any identified key may
+proceed. It defaults to `false`, and `ssh_fingerprint_required` is accepted as
+an alias.
+
+Set it to `true` on hosts in a certificate or SSH-key mode, and leave it off on
+token modes, where there is never a fingerprint to find.
+
+It matters more than a hardening knob usually would. The fingerprint reaches
+LemonLDAP::NG through the spool the `ob-ssh-principals` helper writes; if that
+spool disappears — a `tmpfiles.d` entry lost across an upgrade, a helper that
+stopped running — the module calls `/pam/authorize` with no `fingerprint` field,
+the plugin treats it as optional, and the binding silently stops existing. The
+residual scores of R-S3 and R-S15 in `doc/security/` assume it does exist, which
+is why the homologation dossier carries it as condition of use **CE09**
+([08-dossier-homologation.md](security/08-dossier-homologation.md)).
+
+With `fingerprint_required = true` the session is refused at login, with an
+audited reason, instead of proceeding unbound. From plugin 0.6.0 the portal
+gains the matching half (`pamAccessRequireFingerprint`, and a 15-minute cap on
+unbound vouchers), which turns the same drift into onward-hop failures a quarter
+of an hour into a session — visible, but much further from the cause. See
+[UPGRADE-NOTES.md](../UPGRADE-NOTES.md).
 
 ### Key Type Aliases
 

--- a/doc/security/99-risk-reduce.md
+++ b/doc/security/99-risk-reduce.md
@@ -46,6 +46,36 @@
 > manifestera comme une panne. `fingerprint_required = true` fait échouer la
 > connexion au bon endroit (à l'ouverture de session, avec un motif audité)
 > plutôt que quinze minutes plus tard sur un rebond.
+>
+> **Ce que vaut le spool comme racine de confiance.** Le répertoire
+> `/run/open-bastion/ssh-fp` appartient à `nobody`, et ce n'est pas un choix :
+> `sshd` exige un utilisateur non privilégié pour
+> `AuthorizedPrincipalsCommandUser`, donc le helper qui écrit les drops tourne
+> sous ce compte et le répertoire doit lui appartenir. Il en découle qu'une
+> **exécution de code sous `nobody` permet de lire les empreintes déposées et
+> d'en écrire de fausses**. Les contrôles du module (`O_NOFOLLOW`, `nlink == 1`,
+> mode `0600`, propriétaire du drop = propriétaire du répertoire) protègent
+> contre un attaquant extérieur au périmètre de confiance, pas contre un
+> attaquant qui est `nobody`.
+>
+> Deux durcissements réduisent la surface sans changer cette nature : l'ancre
+> `/proc/<pid>` doit être un processus vivant appartenant à **root** (l'ancre
+> est choisie par nom de processus, et `prctl(PR_SET_NAME)` accepte quinze
+> caractères — « sshd-session » en fait douze, donc un utilisateur local pouvait
+> sinon choisir quel drop serait lu), et un drop plus ancien que son processus
+> ancre est refusé (rien ne supprime un drop en fin de session, et le helper ne
+> tourne pas pour une connexion par mot de passe : une réutilisation de PID
+> faisait sinon hériter le binding de l'occupant précédent). Enfin, toute
+> authentification de compte de service fondée sur une empreinte venue du spool
+> plutôt que de `sshd` est journalisée en **WARN** et tracée dans l'audit.
+>
+> La correction de fond est un démon root activé par socket qui reçoit les
+> empreintes et vérifie l'appelant par `SO_PEERCRED`, sur le modèle
+> d'`ob-cert-daemon` — le répertoire redevient alors `0700 root`. Suivie dans
+> [#249](https://github.com/linagora/open-bastion/issues/249). **Tant qu'elle
+> n'est pas faite, `sudo_allowed` sur un compte de service est un octroi de root
+> dont l'intégrité repose sur le compte `nobody` de l'hôte** : le minimiser
+> (piste 1 plus bas) n'est pas une recommandation de style.
 
 > **Note (R-S18, R-S19, R-S20, R-S21) :** Les scores résiduels indiqués ci-dessus pour R-S19, R-S20 et R-S21 supposent l'activation **simultanée** du hardening (PR1 #112, `--enable-hardening`) et de la trace auditd (PR2 #113, `--enable-audit-trace`). En l'absence d'activation, R-S19 reste à (P=3, I=3), R-S20 et R-S21 restent à (P=2, I=3) — tous trois en zone jaune. Voir [doc/hardening.md](../hardening.md) et [doc/audit.md](../audit.md) (documentations techniques en anglais) pour les détails opérationnels.
 
@@ -238,7 +268,7 @@ consommé côté portail, et la phase `account` — donc la vérification
 d'autorisation — s'exécute en direct à **chaque** `sudo`, si bien qu'une
 révocation LLNG prend effet immédiatement. Ce que cela affaiblit : la
 revendication « chaque élévation est adossée à une authentification SSO
-*fraîche* ». L'option `--enable-sudo-fresh-otp` d'`ob-bastion-setup` /
+_fraîche_ ». L'option `--enable-sudo-fresh-otp` d'`ob-bastion-setup` /
 `ob-backend-setup` écrit `Defaults:%open-bastion-sudo timestamp_timeout=0` et
 rétablit la revendication littérale ; elle reste **opt-in** parce qu'elle change
 la cadence des invites pour tous les utilisateurs SSO. Voir

--- a/doc/security/99-risk-reduce.md
+++ b/doc/security/99-risk-reduce.md
@@ -19,6 +19,20 @@
 
 > **Note :** R-S3 et R-S15 sont descendus de I=3 à I=1 grâce au **binding fingerprint SSH** introduit dans le plugin PamAccess ≥ 0.1.16. La vérification est effectuée côté LLNG à la fois sur `/pam/authorize` (à chaque ouverture de session SSH, phase PAM `account`) et sur `/pam/verify` (à chaque utilisation d'un token PAM pour sudo ou ré-authentification) : tant que l'empreinte de la clef SSH n'est pas présente, active et non révoquée dans la session persistante LLNG, ni la session SSH ni l'escalade sudo ne sont autorisées, indépendamment de la fraîcheur de la KRL locale. Voir [02-ssh-connection.md](02-ssh-connection.md) pour les détails.
 
+> **Note (condition d'emploi du binding fingerprint) :** la réduction ci-dessus
+> suppose que l'empreinte parvienne effectivement à LLNG. Elle est récupérée par
+> le module dans `/run/open-bastion/ssh-fp`, alimenté par
+> l'`AuthorizedPrincipalsCommand`. Si ce spool disparaît — dérive après mise à
+> jour, entrée `tmpfiles.d` manquante — le module appelle `/pam/authorize` sans
+> champ `fingerprint`, que le plugin traite comme optionnel : la mesure
+> disparaît silencieusement, et la durée de vie du voucher bastion n'est plus
+> bornée par l'expiration du certificat SSO. Deux garde-fous depuis la 0.6.3 :
+> l'absence du drop est journalisée en **WARN** (et non plus en DEBUG), et
+> l'option `fingerprint_required = true` d'`openbastion.conf` refuse la session
+> plutôt que de l'autoriser sans binding. **Activer cette option sur les hôtes en
+> mode certificat est une condition d'emploi du score résiduel R-S3 / R-S15**
+> (ne pas l'activer sur les modes token, où il n'y a jamais d'empreinte).
+
 > **Note (R-S18, R-S19, R-S20, R-S21) :** Les scores résiduels indiqués ci-dessus pour R-S19, R-S20 et R-S21 supposent l'activation **simultanée** du hardening (PR1 #112, `--enable-hardening`) et de la trace auditd (PR2 #113, `--enable-audit-trace`). En l'absence d'activation, R-S19 reste à (P=3, I=3), R-S20 et R-S21 restent à (P=2, I=3) — tous trois en zone jaune. Voir [doc/hardening.md](../hardening.md) et [doc/audit.md](../audit.md) (documentations techniques en anglais) pour les détails opérationnels.
 
 > **Comment lire cette matrice.** Elle consolide les **47 fiches de risque** des
@@ -372,6 +386,12 @@ Pistes :
 1. **Minimiser** : n'accorder `sudo_allowed` qu'aux comptes qui en ont
    réellement besoin ; préférer `sudo_nopasswd = false` et des règles `sudoers`
    restreintes à des commandes précises plutôt qu'un sudo total.
+   `sudo_nopasswd = false` est réellement utilisable depuis la 0.6.3 : le
+   contrôle d'empreinte ne lisait que `SSH_USER_AUTH`, absent d'un handle PAM
+   `sudo`, si bien qu'il échouait toujours et que `sudo_nopasswd = true` —
+   c'est-à-dire aucune preuve d'identité — était la seule configuration qui
+   fonctionnait. L'empreinte est désormais reprise du spool des principals, que
+   `sudo` hérite par l'arbre de processus.
 2. **Inventaire et rotation** : traiter chaque clé de service comme un secret de
    longue durée (coffre-fort, rotation périodique, révocation à la sortie d'un
    prestataire/outil). Recoupe le compte de secours de [R-S17](#r-s17-p1-i2---verrouillage-total-lockout).

--- a/doc/security/99-risk-reduce.md
+++ b/doc/security/99-risk-reduce.md
@@ -32,6 +32,20 @@
 > plutôt que de l'autoriser sans binding. **Activer cette option sur les hôtes en
 > mode certificat est une condition d'emploi du score résiduel R-S3 / R-S15**
 > (ne pas l'activer sur les modes token, où il n'y a jamais d'empreinte).
+>
+> **Ce que change la montée de version du portail.** La PR amont
+> `linagora/lemonldap-ng-plugins#86` (issue `#55`) ajoute le pendant serveur de
+> cette option : un voucher qu'aucune empreinte ne lie au certificat SSO est
+> plafonné à `pamAccessBastionVoucherUnboundTtl` (900 s au lieu de 12 h), et
+> `pamAccessRequireFingerprint` refuse carrément le cas non lié. Le mode de
+> défaillance d'un spool absent cesse alors d'être un affaiblissement silencieux
+> pour devenir une **coupure visible** : les rebonds `ob-ssh` échouent une
+> quinzaine de minutes après la connexion au bastion, avec
+> `reason: voucher_expired`. C'est le comportement souhaitable, mais il faut le
+> savoir avant la mise à jour — un spool cassé qui passait inaperçu se
+> manifestera comme une panne. `fingerprint_required = true` fait échouer la
+> connexion au bon endroit (à l'ouverture de session, avec un motif audité)
+> plutôt que quinze minutes plus tard sur un rebond.
 
 > **Note (R-S18, R-S19, R-S20, R-S21) :** Les scores résiduels indiqués ci-dessus pour R-S19, R-S20 et R-S21 supposent l'activation **simultanée** du hardening (PR1 #112, `--enable-hardening`) et de la trace auditd (PR2 #113, `--enable-audit-trace`). En l'absence d'activation, R-S19 reste à (P=3, I=3), R-S20 et R-S21 restent à (P=2, I=3) — tous trois en zone jaune. Voir [doc/hardening.md](../hardening.md) et [doc/audit.md](../audit.md) (documentations techniques en anglais) pour les détails opérationnels.
 

--- a/doc/service-accounts.md
+++ b/doc/service-accounts.md
@@ -97,7 +97,7 @@ ssh-keygen -lf /path/to/key.pub
 | ----------------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `key_fingerprint` | Yes      | SSH key fingerprint (SHA256:... or MD5:...)                                                                                                                                      |
 | `sudo_allowed`    | No       | Allow sudo access (default: false)                                                                                                                                               |
-| `sudo_nopasswd`   | No       | Sudo without password (default: false)                                                                                                                                           |
+| `sudo_nopasswd`   | No       | Sudo without re-proving the key (default: false) — see [Sudo and the key check](#sudo-and-the-key-check)                                                                          |
 | `gecos`           | No       | User description                                                                                                                                                                 |
 | `shell`           | No       | Login shell — must be in `approved_shells` (default: common shells) or the account is dropped                                                                                    |
 | `home`            | No       | Home directory — must be under `approved_home_prefixes` (default `/home:/var/home`) or the account is dropped                                                                    |
@@ -107,7 +107,8 @@ ssh-keygen -lf /path/to/key.pub
 ## How It Works
 
 1. Service account connects via SSH with its configured key
-2. PAM module extracts the SSH key fingerprint from `SSH_USER_AUTH` environment
+2. PAM module resolves the SSH key fingerprint — from `SSH_USER_AUTH` when sshd
+   exposes it, otherwise from the principals spool `/run/open-bastion/ssh-fp`
 3. PAM module checks if user is in `service-accounts.conf`
 4. If found, the SSH key fingerprint is validated against the configured value
 5. If fingerprint matches, account is authorized locally (no LLNG call needed)
@@ -250,6 +251,24 @@ certificate-vouching used by human users. Consequences:
   a hop is **not recorded**. Treat this as a deliberate audit bypass: if you need
   service-account activity audited, run it against the target directly (the
   target's own logs/auditd apply) rather than tunnelling through the bastion.
+
+## Sudo and the key check
+
+With `sudo_nopasswd = false`, a service account's `sudo` must re-prove the SSH
+key that opened the session. That check reads the fingerprint from the
+principals spool (`/run/open-bastion/ssh-fp`), which the account's SSH session
+populated and which `sudo` inherits through the process tree.
+
+Until 0.6.2 it read `SSH_USER_AUTH` only. That variable does not exist in a
+`sudo` PAM handle, so the check could never succeed and `sudo_nopasswd = false`
+was unusable — leaving `sudo_nopasswd = true`, which grants sudo with no proof of
+identity at all, as the only configuration that worked. That is fixed; both
+settings now do what they say.
+
+`sudo_nopasswd = false` requires the host to run the `AuthorizedPrincipalsCommand`
+helper (the certificate modes), since that is what writes the spool. On a host
+without it there is no fingerprint to recover in either context, and a service
+account's `sudo` is refused.
 
 ## Sudo bypasses the SSO token (including in Mode E)
 

--- a/include/config.h
+++ b/include/config.h
@@ -126,6 +126,9 @@ typedef struct {
     char *ssh_key_allowed_types;           /* Comma-separated allowed types: ed25519,ecdsa,rsa (default: all) */
     int ssh_key_min_rsa_bits;              /* Minimum RSA key size in bits (default: 2048) */
     int ssh_key_min_ecdsa_bits;            /* Minimum ECDSA key size in bits (default: 256) */
+    bool fingerprint_required;             /* Refuse an SSH login whose key fingerprint cannot be
+                                              recovered, instead of authorizing without the binding
+                                              (default: false) */
 
     /* Cache brute-force protection (#92) */
     bool cache_rate_limit_enabled;         /* Enable rate limiting for cache lookups (default: false) */

--- a/src/config.c
+++ b/src/config.c
@@ -154,6 +154,7 @@ void config_init(pam_openbastion_config_t *config)
     config->ssh_key_allowed_types = NULL;  /* NULL means all types allowed */
     config->ssh_key_min_rsa_bits = 2048;   /* NIST recommendation minimum */
     config->ssh_key_min_ecdsa_bits = 256;  /* P-256 minimum */
+    config->fingerprint_required = false;  /* opt-in: see #192 */
 
     /* Cache brute-force protection - disabled by default (#92) */
     config->cache_rate_limit_enabled = false;
@@ -737,6 +738,10 @@ static int parse_line(const char *key, const char *value, pam_openbastion_config
              strcmp(key, "ssh_min_rsa_bits") == 0) {
         /* Valid RSA sizes: 1024 (weak), 2048 (minimum recommended), 3072, 4096 */
         config->ssh_key_min_rsa_bits = parse_int(value, 2048, 1024, 16384);
+    }
+    else if (strcmp(key, "fingerprint_required") == 0 ||
+             strcmp(key, "ssh_fingerprint_required") == 0) {
+        SET_BOOL_FIELD(config->fingerprint_required, value, key);
     }
     else if (strcmp(key, "ssh_key_min_ecdsa_bits") == 0 ||
              strcmp(key, "ssh_min_ecdsa_bits") == 0) {

--- a/src/pam_openbastion.c
+++ b/src/pam_openbastion.c
@@ -1867,6 +1867,33 @@ static char *read_spool_drop(pam_handle_t *pamh, const char *suffix,
     }
 
     /*
+     * The anchor is chosen by process NAME (/proc/<pid>/comm), and a process
+     * can set its own name: prctl(PR_SET_NAME) takes 15 characters and
+     * "sshd-session" is twelve. So a local user can put a process called
+     * sshd-session in the ancestry of their own sudo and choose which drop
+     * this code reads. Require the anchor to be a live process owned by root,
+     * which sshd's per-connection monitor is and a user's own process is not.
+     *
+     * This does not make the spool trustworthy on its own -- see the comment
+     * on the directory ownership below -- but it removes the half of the forge
+     * that needs no privilege at all.
+     */
+    char anchor_path[64];
+    snprintf(anchor_path, sizeof(anchor_path), "/proc/%d", (int)anchor);
+    struct stat anchor_st;
+    if (stat(anchor_path, &anchor_st) != 0) {
+        OB_LOG_DEBUG(pamh, "SSH fp spool: anchor %d is gone", (int)anchor);
+        return NULL;
+    }
+    if (anchor_st.st_uid != 0) {
+        OB_LOG_ERR(pamh,
+                   "SSH fp spool: anchor %d is owned by uid %u, not root — "
+                   "refusing to read a drop keyed on it",
+                   (int)anchor, (unsigned)anchor_st.st_uid);
+        return NULL;
+    }
+
+    /*
      * Reject the spool directory itself if it is world/group-writable or
      * not owned by the expected principals helper user. We derive the
      * trusted uid from the directory's st_uid: the deployment scripts
@@ -1905,9 +1932,23 @@ static char *read_spool_drop(pam_handle_t *pamh, const char *suffix,
          * A password/keyboard-interactive login on a cert-aware host lands
          * here too, which is equally worth knowing.
          */
-        OB_LOG_WARN(pamh,
-                    "No SSH fingerprint drop at %s (errno=%d): this session "
-                    "carries no key binding", path, errno);
+        if (strcmp(suffix, "fp") == 0) {
+            OB_LOG_WARN(pamh,
+                        "No SSH fingerprint drop at %s (errno=%d): this session "
+                        "carries no key binding", path, errno);
+        } else {
+            /*
+             * The .key drop is written only when sshd passes %t (and %k) to
+             * the principals helper. The current setup scripts do; hosts
+             * configured from the shorter `%u %f` form still documented in
+             * places do not, and there the absence is a missing capability,
+             * not a missing security binding. WARNing on it would put a line
+             * in syslog on every login of those hosts, for something the
+             * caller handles by falling back.
+             */
+            OB_LOG_DEBUG(pamh,
+                         "No SSH %s drop at %s (errno=%d)", suffix, path, errno);
+        }
         return NULL;
     }
 
@@ -1931,6 +1972,30 @@ static char *read_spool_drop(pam_handle_t *pamh, const char *suffix,
                    "(uid=%u expected=%u, mode=%o, nlink=%lu) — refusing",
                    path, (unsigned)st.st_uid, (unsigned)dir_st.st_uid,
                    st.st_mode & 07777, (unsigned long)st.st_nlink);
+        close(fd);
+        unlink(path);
+        return NULL;
+    }
+
+    /*
+     * The drop must be younger than the process it is keyed on. Nothing
+     * removes a drop when its session ends, and the principals helper only
+     * runs for public-key authentication -- so once a PID is reused by a
+     * password or keyboard-interactive login, the previous occupant's
+     * fingerprint would be read as that session's binding, with every
+     * ownership and mode check passing.
+     *
+     * On Linux the mtime of /proc/<pid> is the process start time, so a drop
+     * older than the anchor belongs to a PID that has since been recycled.
+     * Equal seconds are fine: the helper writes the drop during the anchor's
+     * lifetime, and st_mtime truncates rather than rounds.
+     */
+    if (st.st_mtime < anchor_st.st_mtime) {
+        OB_LOG_ERR(pamh,
+                   "SSH spool file %s predates its anchor process %d "
+                   "(drop=%ld, anchor started %ld) — stale drop from a recycled "
+                   "PID, refusing",
+                   path, (int)anchor, (long)st.st_mtime, (long)anchor_st.st_mtime);
         close(fd);
         unlink(path);
         return NULL;
@@ -2255,8 +2320,10 @@ static char *extract_ssh_key_fingerprint(pam_handle_t *pamh)
  * Returns an allocated string (caller frees), or NULL when neither source has
  * one.
  */
-static char *resolve_ssh_key_fingerprint(pam_handle_t *pamh)
+static char *resolve_ssh_key_fingerprint(pam_handle_t *pamh, bool *from_spool)
 {
+    if (from_spool) *from_spool = false;
+
     char *fp = extract_ssh_key_fingerprint(pamh);
     if (fp) {
         return fp;
@@ -2264,6 +2331,7 @@ static char *resolve_ssh_key_fingerprint(pam_handle_t *pamh)
 
     fp = read_ssh_fp_from_spool(pamh);
     if (fp) {
+        if (from_spool) *from_spool = true;
         OB_LOG_DEBUG(pamh, "SSH fingerprint recovered from the spool: %s", fp);
     }
     return fp;
@@ -2806,7 +2874,8 @@ PAM_VISIBLE PAM_EXTERN int pam_sm_authenticate(pam_handle_t *pamh,
              * Extract the fingerprint from SSH_USER_AUTH and compare with configured value.
              * This requires ExposeAuthInfo=yes in sshd_config.
              */
-            char *ssh_fingerprint = resolve_ssh_key_fingerprint(pamh);
+            bool fp_from_spool = false;
+            char *ssh_fingerprint = resolve_ssh_key_fingerprint(pamh, &fp_from_spool);
             if (!ssh_fingerprint) {
                 OB_LOG_ERR(pamh, "Service account %s: cannot determine the SSH key "
                         "fingerprint -- neither SSH_USER_AUTH nor the principals "
@@ -2842,8 +2911,30 @@ PAM_VISIBLE PAM_EXTERN int pam_sm_authenticate(pam_handle_t *pamh,
                 return PAM_AUTH_ERR;
             }
 
-            OB_LOG_INFO(pamh, "Service account %s authenticated with fingerprint %s",
-                    user, ssh_fingerprint);
+            /*
+             * Say where the proof came from. SSH_USER_AUTH is asserted by sshd
+             * itself; a spool drop is asserted by whatever owns
+             * /run/open-bastion/ssh-fp, which sshd forces to be a non-root user
+             * (AuthorizedPrincipalsCommandUser, nobody in every shipped setup).
+             * A service account elevating on the strength of the second is a
+             * root grant whose integrity rests on that account, and the audit
+             * trail should be able to say so after the fact.
+             */
+            if (fp_from_spool) {
+                OB_LOG_WARN(pamh,
+                            "Service account %s authenticated with fingerprint %s "
+                            "taken from the principals spool, not from sshd: the "
+                            "binding is only as trustworthy as the spool owner",
+                            user, ssh_fingerprint);
+                if (audit_initialized) {
+                    audit_event.reason =
+                        "Service account: fingerprint from principals spool";
+                    audit_log_event(data->audit, &audit_event);
+                }
+            } else {
+                OB_LOG_INFO(pamh, "Service account %s authenticated with fingerprint %s",
+                        user, ssh_fingerprint);
+            }
             free(ssh_fingerprint);
         }
 
@@ -3641,16 +3732,45 @@ PAM_VISIBLE PAM_EXTERN int pam_sm_acct_mgmt(pam_handle_t *pamh,
         }
 
         /*
-         * Defense-in-depth fingerprint check for SSH sessions. sshd's
-         * AuthorizedKeysCommand already ensured the presented key matches
-         * what we published for this service account, but we re-verify
-         * the SHA256 fingerprint from SSH_USER_AUTH (ExposeAuthInfo yes)
-         * against the canonical value in service-accounts.conf. We do NOT
-         * fail closed when SSH_USER_AUTH is absent: the PAM `sudo` service
-         * never has it, and some OpenSSH builds omit it for non-cert keys.
+         * Fingerprint check for SSH sessions, and for a public-key login it is
+         * the ONLY one that runs: sshd does not call pam_authenticate() on that
+         * path, so the check in pam_sm_authenticate() never fires there.
+         *
+         * It resolves through the spool as well as SSH_USER_AUTH. Reading only
+         * SSH_USER_AUTH meant that on a modern OpenSSH, which does not set it
+         * for a plain public key, this check silently did nothing at all.
+         *
+         * Absence is still not fatal by default -- some OpenSSH builds omit
+         * SSH_USER_AUTH and some hosts have no principals helper -- but
+         * `fingerprint_required` now makes it fatal here too, which is what
+         * that setting says it does. Enforced before the PAM_SUCCESS below,
+         * because that early return used to skip the enforcement block at the
+         * end of this function entirely.
          */
         if (strcmp(service, "sshd") == 0 || strcmp(service, "ssh") == 0) {
-            char *ssh_fp = extract_ssh_key_fingerprint(pamh);
+            bool sa_fp_from_spool = false;
+            char *ssh_fp = resolve_ssh_key_fingerprint(pamh, &sa_fp_from_spool);
+            if (!ssh_fp && data->config.fingerprint_required) {
+                OB_LOG_ERR(pamh,
+                           "Service account %s: no SSH key fingerprint and "
+                           "fingerprint_required is set: refusing. Check that "
+                           "the AuthorizedPrincipalsCommand helper runs and that "
+                           "/run/open-bastion/ssh-fp exists.", user);
+                if (audit_initialized) {
+                    audit_event.event_type = AUDIT_AUTHZ_DENIED;
+                    audit_event.result_code = PAM_PERM_DENIED;
+                    audit_event.reason =
+                        "Service account: fingerprint_required with no binding";
+                    audit_event_set_end_time(&audit_event);
+                    audit_log_event(data->audit, &audit_event);
+                }
+                return PAM_PERM_DENIED;
+            }
+            if (ssh_fp && sa_fp_from_spool) {
+                OB_LOG_WARN(pamh,
+                            "Service account %s: SSH fingerprint taken from the "
+                            "principals spool, not from sshd", user);
+            }
             if (ssh_fp) {
                 int fp_result = service_accounts_validate_key(
                     &data->service_accounts, user, ssh_fp);

--- a/src/pam_openbastion.c
+++ b/src/pam_openbastion.c
@@ -1896,7 +1896,18 @@ static char *read_spool_drop(pam_handle_t *pamh, const char *suffix,
 
     int fd = open(path, O_RDONLY | O_NOFOLLOW | O_CLOEXEC);
     if (fd < 0) {
-        OB_LOG_DEBUG(pamh, "SSH spool drop not found at %s (errno=%d)", path, errno);
+        /*
+         * The spool directory exists, so this host DOES run the principals
+         * helper -- yet the drop for our sshd anchor is absent. That is the
+         * realistic provisioning-drift case (#192): the fingerprint binding
+         * that doc/security/99-risk-reduce.md credits for R-S3 and R-S15 has
+         * silently disappeared, and until now it said so only at DEBUG.
+         * A password/keyboard-interactive login on a cert-aware host lands
+         * here too, which is equally worth knowing.
+         */
+        OB_LOG_WARN(pamh,
+                    "No SSH fingerprint drop at %s (errno=%d): this session "
+                    "carries no key binding", path, errno);
         return NULL;
     }
 
@@ -2226,6 +2237,36 @@ static char *extract_ssh_key_fingerprint(pam_handle_t *pamh)
     }
 
     return fingerprint;
+}
+
+/*
+ * Resolve the fingerprint of the SSH key that opened this session, from either
+ * source that can carry it.
+ *
+ * SSH_USER_AUTH exists only inside an SSH PAM handle, and only when sshd was
+ * built/configured to expose it. Under `sudo` -- a different PAM service, run
+ * long after the SSH authentication -- it is never set, so a caller that only
+ * looked there could never authenticate a service account with sudo, leaving
+ * sudo_nopasswd=true (no proof of identity at all) as the only workable
+ * configuration (#194). The out-of-band spool written by the principals helper
+ * is keyed on the sshd-session anchor of the process tree, which `sudo`
+ * inherits, so it answers in both contexts.
+ *
+ * Returns an allocated string (caller frees), or NULL when neither source has
+ * one.
+ */
+static char *resolve_ssh_key_fingerprint(pam_handle_t *pamh)
+{
+    char *fp = extract_ssh_key_fingerprint(pamh);
+    if (fp) {
+        return fp;
+    }
+
+    fp = read_ssh_fp_from_spool(pamh);
+    if (fp) {
+        OB_LOG_DEBUG(pamh, "SSH fingerprint recovered from the spool: %s", fp);
+    }
+    return fp;
 }
 
 /*
@@ -2739,11 +2780,16 @@ PAM_VISIBLE PAM_EXTERN int pam_sm_authenticate(pam_handle_t *pamh,
             return PAM_AUTH_ERR;
         }
         /*
-         * Sudo context: there is no SSH_USER_AUTH because sudo is not an
-         * SSH service. When sudo_nopasswd is configured the admin has
-         * declared that a valid existing Unix session is sufficient, so
-         * skip the fingerprint check here. pam_sm_acct_mgmt will still
-         * enforce sudo_allowed below.
+         * Sudo context: sudo_nopasswd is the admin's declaration that a valid
+         * existing Unix session is sufficient, so skip the fingerprint check.
+         * pam_sm_acct_mgmt will still enforce sudo_allowed below.
+         *
+         * With sudo_nopasswd=false the check now runs and can succeed: sudo has
+         * no SSH_USER_AUTH, but resolve_ssh_key_fingerprint() falls back to the
+         * principals spool, which is keyed on the sshd anchor that sudo
+         * inherits (#194). Before that fallback the branch could only ever
+         * return PAM_AUTH_ERR, which made sudo_nopasswd=true -- no proof of
+         * identity at all -- the sole usable setting.
          */
         bool skip_fp_check =
             (strcmp(service, "sudo") == 0) && sa->sudo_nopasswd;
@@ -2760,10 +2806,11 @@ PAM_VISIBLE PAM_EXTERN int pam_sm_authenticate(pam_handle_t *pamh,
              * Extract the fingerprint from SSH_USER_AUTH and compare with configured value.
              * This requires ExposeAuthInfo=yes in sshd_config.
              */
-            char *ssh_fingerprint = extract_ssh_key_fingerprint(pamh);
+            char *ssh_fingerprint = resolve_ssh_key_fingerprint(pamh);
             if (!ssh_fingerprint) {
-                OB_LOG_ERR(pamh, "Service account %s: cannot extract SSH key fingerprint "
-                        "(is ExposeAuthInfo enabled in sshd_config?)", user);
+                OB_LOG_ERR(pamh, "Service account %s: cannot determine the SSH key "
+                        "fingerprint -- neither SSH_USER_AUTH nor the principals "
+                        "spool has one for this session", user);
 
                 if (audit_initialized) {
                     audit_event.event_type = AUDIT_AUTH_FAILURE;
@@ -3710,6 +3757,42 @@ PAM_VISIBLE PAM_EXTERN int pam_sm_acct_mgmt(pam_handle_t *pamh,
         audit_event.client_ip = client_ip;
         audit_event.tty = tty;
         audit_initialized = true;
+    }
+
+    /*
+     * Fail closed when the SSH key binding is required but absent (#192).
+     *
+     * Without this the binding degrades silently: a missing spool entry --
+     * post-upgrade drift, a missing tmpfiles.d entry -- makes
+     * extract_ssh_cert_info() return 0, /pam/authorize is called with no
+     * `fingerprint` field, and the SSO side treats the field as optional. The
+     * control that doc/security/99-risk-reduce.md credits for R-S3 and R-S15 is
+     * then gone with no operational signal, and the bastion voucher TTL is no
+     * longer capped by the SSO certificate expiry either.
+     *
+     * Off by default: hosts that do not run the principals helper (the token
+     * modes) never have a fingerprint to offer, and turning this on for them
+     * would deny every login. It is meant for cert-mode bastions and backends,
+     * where the binding is supposed to be present on every session.
+     */
+    if (data->config.fingerprint_required
+        && (strcmp(service, "sshd") == 0 || strcmp(service, "ssh") == 0)
+        && (!has_ssh_cert || !ssh_cert_info.key_fingerprint)) {
+        OB_LOG_ERR(pamh,
+                   "No SSH key fingerprint for %s and fingerprint_required is "
+                   "set: refusing. Check that the AuthorizedPrincipalsCommand "
+                   "helper runs and that /run/open-bastion/ssh-fp exists.",
+                   user);
+        if (has_ssh_cert) {
+            ob_ssh_cert_info_free(&ssh_cert_info);
+        }
+        if (audit_initialized) {
+            audit_event.result_code = PAM_PERM_DENIED;
+            audit_event.reason = "fingerprint_required: no SSH key binding available";
+            audit_event_set_end_time(&audit_event);
+            audit_log_event(data->audit, &audit_event);
+        }
+        return PAM_PERM_DENIED;
     }
 
     /*

--- a/src/pam_openbastion.c
+++ b/src/pam_openbastion.c
@@ -2861,6 +2861,15 @@ PAM_VISIBLE PAM_EXTERN int pam_sm_authenticate(pam_handle_t *pamh,
          */
         bool skip_fp_check =
             (strcmp(service, "sudo") == 0) && sa->sudo_nopasswd;
+        /*
+         * Hoisted so the single success event below can say where the proof
+         * came from. It used to be emitted as an extra audit_log_event() from
+         * inside the block, which inherited event_type AUDIT_AUTH_FAILURE from
+         * audit_event_init() and never set result_code or end_time: a malformed
+         * failure record for a successful authentication, whose reason the real
+         * success event then overwrote anyway.
+         */
+        bool fp_from_spool = false;
 
         if (skip_fp_check) {
             OB_LOG_INFO(pamh,
@@ -2874,7 +2883,6 @@ PAM_VISIBLE PAM_EXTERN int pam_sm_authenticate(pam_handle_t *pamh,
              * Extract the fingerprint from SSH_USER_AUTH and compare with configured value.
              * This requires ExposeAuthInfo=yes in sshd_config.
              */
-            bool fp_from_spool = false;
             char *ssh_fingerprint = resolve_ssh_key_fingerprint(pamh, &fp_from_spool);
             if (!ssh_fingerprint) {
                 OB_LOG_ERR(pamh, "Service account %s: cannot determine the SSH key "
@@ -2926,11 +2934,6 @@ PAM_VISIBLE PAM_EXTERN int pam_sm_authenticate(pam_handle_t *pamh,
                             "taken from the principals spool, not from sshd: the "
                             "binding is only as trustworthy as the spool owner",
                             user, ssh_fingerprint);
-                if (audit_initialized) {
-                    audit_event.reason =
-                        "Service account: fingerprint from principals spool";
-                    audit_log_event(data->audit, &audit_event);
-                }
             } else {
                 OB_LOG_INFO(pamh, "Service account %s authenticated with fingerprint %s",
                         user, ssh_fingerprint);
@@ -2967,7 +2970,10 @@ PAM_VISIBLE PAM_EXTERN int pam_sm_authenticate(pam_handle_t *pamh,
             audit_event.result_code = PAM_SUCCESS;
             audit_event.reason = skip_fp_check
                 ? "Service account (sudo_nopasswd, fingerprint check skipped)"
-                : "Service account (SSH key validated)";
+                : (fp_from_spool
+                   ? "Service account (SSH key validated from the principals "
+                     "spool, not from sshd)"
+                   : "Service account (SSH key validated)");
             audit_event_set_end_time(&audit_event);
             audit_log_event(data->audit, &audit_event);
         }

--- a/tests/test_config.c
+++ b/tests/test_config.c
@@ -600,6 +600,38 @@ static int test_load_config_file(void)
     return ok;
 }
 
+/*
+ * fingerprint_required (#192): off by default, settable from the config file
+ * and from a pam.d argument, under either spelling.
+ */
+static int test_fingerprint_required_default_off(void)
+{
+    pam_openbastion_config_t config;
+    config_init(&config);
+    int ok = (config.fingerprint_required == false);
+    config_free(&config);
+    return ok;
+}
+
+static int test_parse_fingerprint_required(void)
+{
+    pam_openbastion_config_t config;
+    config_init(&config);
+
+    const char *argv[] = { "fingerprint_required=true" };
+    config_parse_args(1, argv, &config);
+    int ok = (config.fingerprint_required == true);
+    config_free(&config);
+
+    config_init(&config);
+    const char *alias[] = { "ssh_fingerprint_required=true" };
+    config_parse_args(1, alias, &config);
+    ok = ok && (config.fingerprint_required == true);
+    config_free(&config);
+
+    return ok;
+}
+
 int main(void)
 {
     printf("Running configuration tests...\n\n");
@@ -624,6 +656,8 @@ int main(void)
     TEST(cache_rate_limit_defaults);
     TEST(parse_cache_rate_limit_args);
     TEST(cache_rate_limit_bounds);
+    TEST(fingerprint_required_default_off);
+    TEST(parse_fingerprint_required);
 #ifdef ENABLE_DESKTOP_SSO  /* Desktop SSO only and never compiled inside open-bastion core */
     TEST(oauth2_token_auth_defaults);
     TEST(parse_oauth2_token_auth_args);


### PR DESCRIPTION
Closes #194 and #192 — two defects in the same mechanism, so they land together.

## #194 — the binding could never be proved under `sudo`

The service-account path called `extract_ssh_key_fingerprint()`, which reads `SSH_USER_AUTH` and nothing else. That variable does not exist in a `sudo` PAM handle, so with `sudo_nopasswd = false` the branch **always** returned `PAM_AUTH_ERR`. The only workable configuration was `sudo_nopasswd = true` — which returns `PAM_SUCCESS` with no proof of identity at all — and admins were pushed toward it.

A new `resolve_ssh_key_fingerprint()` tries `SSH_USER_AUTH`, then falls back to the principals spool (`/run/open-bastion/ssh-fp`), keyed on the sshd-session anchor that `sudo` inherits through the process tree. That is the same source `pam_sm_acct_mgmt` already uses, and the same one visible in the `sudo:auth` logs quoted in #178 (`SSH fp recovered from spool`). Both settings now do what they say.

On a host that does not run the principals helper there is still no fingerprint in either context, and `sudo_nopasswd = false` refuses — the fail-closed answer.

## #192 — the binding disappeared quietly

A missing drop was logged at DEBUG and the session was authorized without the fingerprint, which the SSO side treats as optional. `doc/security/99-risk-reduce.md` credits this binding with reducing R-S3 and R-S15, and the bastion voucher TTL is only capped by the SSO certificate expiry when a fingerprint was supplied.

- **A missing drop while the spool directory exists now logs at WARN.** That is the realistic drift case the issue is about, and a password login on a cert-aware host lands there too. A missing spool *directory* stays at DEBUG on purpose: that host does not run the helper at all, and warning there would fire on every authentication in the token modes.
- **`fingerprint_required = true`** (opt-in, default `false`) refuses an SSH login whose fingerprint cannot be recovered. Enable it on certificate-mode hosts; in the token-only modes there is never a fingerprint and every SSH login would be denied. It is enforced in `pam_sm_acct_mgmt` before the authorization call, and the refusal is audited with its own reason.

## Documentation

- `doc/security/99-risk-reduce.md` — `fingerprint_required` is now stated as a **condition of use** for the R-S3 / R-S15 residual scores, since those scores assume the fingerprint actually reaches LLNG. R-S24 records that `sudo_nopasswd = false` is usable at last.
- `doc/service-accounts.md` — a new "Sudo and the key check" section saying what the check reads and what it requires.
- `config/openbastion.conf.example` — the new key, with the warning about the token modes.

## Tests

```
$ ctest --output-on-failure
100% tests passed, 0 tests failed out of 20
```

`tests/test_config.c` gains two cases: the setting defaults to off, and it parses under both spellings from a pam.d argument.

https://claude.ai/code/session_011q88Fs4nFuUs7JMvmgbBTN