### PR TITLE
fix(backend): stop an empty allowed_bastions from passing unnoticed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -452,6 +452,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     the other required settings, and shows it in the pre-flight banner. Pressing
     Enter is not an answer: it re-asks with the exposure spelled out, and leaves
     the list empty only on an explicit `y` to "Accept a hop from ANY bastion?".
+    Neither is an answer made only of whitespace or separators (`,,`, `" ; , "`),
+    which the normaliser collapses to the empty list just the same;
     `--allow-any-bastion` states that answer up front, for a lab or a host whose
     bastion is not enrolled yet;
   - leaving it empty prints a loud multi-line warning naming the exposure and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -437,6 +437,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   upgraded, so the refusal lands at login with an audited reason instead of on a
   hop a quarter of an hour later.
 
+- **An empty `allowed_bastions` no longer passes unnoticed (#182).**
+  `ob-backend-setup` created the backend allowlist empty, and an empty allowlist
+  means "accept a hop voucher from any vouched bastion" — in practice, from any
+  host enrolled in the project. That allowlist is the residual defence behind a
+  real gap on the SSO side (the pam-access plugin does no RP/audience binding on
+  `/pam/*` tokens and, with `pamAccessServerGroups` empty, takes `server_group`
+  from the request body), and the second defence,
+  `pamAccessBastionCertPinSourceAddress`, is off by default too.
+
+  Three changes, none of which can break an existing fleet on upgrade:
+
+  - `ob-backend-setup` **asks** for the list when run interactively, alongside
+    the other required settings, and shows it in the pre-flight banner;
+  - leaving it empty prints a loud multi-line warning naming the exposure and
+    the fix, instead of the previous one-line `info`;
+  - `ob-ssh-principals` logs an `authpriv.warning` **on every hop** it accepts
+    without checking which bastion it came from, so a running fleet shows the
+    condition in its logs rather than only in a setup transcript.
+
+  The empty-means-any semantic is deliberately unchanged: inverting it would
+  deny every hop the moment a backend upgrades. The list is now validated
+  (`[A-Za-z0-9._-]`, comma/semicolon/space separated) and normalised, so a typo
+  is refused at setup instead of silently matching nothing, and a
+  whitespace-only value no longer looks configured while meaning "any".
+
 ### Changed
 
 - **A failing `ctest` now keeps its log, and the concurrency test says why it

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -449,18 +449,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Three changes, none of which can break an existing fleet on upgrade:
 
   - `ob-backend-setup` **asks** for the list when run interactively, alongside
-    the other required settings, and shows it in the pre-flight banner;
+    the other required settings, and shows it in the pre-flight banner. Pressing
+    Enter is not an answer: it re-asks with the exposure spelled out, and leaves
+    the list empty only on an explicit `y` to "Accept a hop from ANY bastion?".
+    `--allow-any-bastion` states that answer up front, for a lab or a host whose
+    bastion is not enrolled yet;
   - leaving it empty prints a loud multi-line warning naming the exposure and
     the fix, instead of the previous one-line `info`;
   - `ob-ssh-principals` logs an `authpriv.warning` **on every hop** it accepts
     without checking which bastion it came from, so a running fleet shows the
-    condition in its logs rather than only in a setup transcript.
+    condition in its logs rather than only in a setup transcript. The same is
+    true of legacy mode (the allowlist file absent), which skips vouching
+    entirely and so accepts a direct SSO certificate — broader than an empty
+    list, and until now the only path that said nothing at all.
 
-  The empty-means-any semantic is deliberately unchanged: inverting it would
-  deny every hop the moment a backend upgrades. The list is now validated
-  (`[A-Za-z0-9._-]`, comma/semicolon/space separated) and normalised, so a typo
-  is refused at setup instead of silently matching nothing, and a
-  whitespace-only value no longer looks configured while meaning "any".
+  The empty-means-any semantic is deliberately unchanged, and a
+  **non-interactive** run (`--yes`, i.e. Ansible) still defaults to it:
+  inverting it, or making the list mandatory there, would deny every hop the
+  moment a backend upgrades. An unattended deployment that wants the protection
+  passes `--allowed-bastions` (Ansible: `ob_bastion_allowed_bastions`). Both
+  options are now in `--help`, where neither was.
+
+  The list is validated (`[A-Za-z0-9._-]`, comma/semicolon/space separated) and
+  normalised, so a typo is refused at setup instead of silently matching
+  nothing, and a whitespace-only value no longer looks configured while meaning
+  "any". The split is done with globbing off: word-splitting the raw list also
+  ran pathname expansion, so an entry containing a glob metacharacter that
+  matched a file in the current directory was rewritten to the match (`b[1]` →
+  the file `b1`) — the typo was accepted as a different, valid-looking id
+  instead of triggering the validation.
 
 ### Changed
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -211,11 +211,31 @@ If the file is present but empty, any vouched bastion is accepted. If the file i
 > user. The second defence,
 > `pamAccessBastionCertPinSourceAddress`, is also off by default.
 >
-> `ob-backend-setup` now asks for the list when run interactively, warns loudly
-> when it is left empty, and `ob-ssh-principals` logs an `authpriv.warning` on
-> every hop it accepts without checking which bastion it came from. The empty
-> semantic itself is unchanged: inverting it would deny every hop on an existing
-> fleet the moment it upgrades.
+> `ob-backend-setup` asks for the list when run interactively, and pressing
+> Enter is not an answer: it re-asks, and takes the empty list only on an
+> explicit `y` to _"Accept a hop from ANY bastion?"_ (or `--allow-any-bastion`,
+> which states the same answer up front). `ob-ssh-principals` then logs an
+> `authpriv.warning` on every hop it accepts without checking which bastion it
+> came from, so a running fleet shows the condition in its logs and not only in
+> a setup transcript.
+>
+> The empty semantic itself is unchanged, and a **non-interactive** run
+> (`--yes`, i.e. Ansible) still defaults to it: inverting it, or making the list
+> mandatory there, would deny every hop on an existing fleet the moment it
+> upgrades. An unattended deployment that wants the protection has to pass
+> `--allowed-bastions` (Ansible: `ob_bastion_allowed_bastions`).
+>
+> **Legacy mode is not a quieter version of this.** With
+> `/etc/open-bastion/allowed_bastions` _absent_ — a backend set up by a version
+> that predates vouching and never re-run — the helper skips vouching entirely
+> and accepts a direct SSO certificate, which is broader than an empty list.
+> That path also logs an `authpriv.warning` on every accepted connection; the
+> fix is to re-run `ob-backend-setup`.
+>
+> A **standalone** host (its own bastion, `--node-role standalone`) legitimately
+> has nothing to list, so it will warn on every hop. Either accept the log
+> volume or pass its own id from `ob-bastion-id`; a lab is the one place where
+> `--allow-any-bastion` is the honest answer.
 
 Required sshd settings (no `AcceptEnv` needed):
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -201,6 +201,22 @@ This writes `/etc/open-bastion/allowed_bastions` (0644 inside a 0711 directory) 
 If the file is present but empty, any vouched bastion is accepted. If the file is unreadable,
 `ob-ssh-principals` fails closed (denies the connection).
 
+> **Set this list.** An empty allowlist accepts a hop voucher from **any** host
+> enrolled in the project, and that allowlist is the residual defence behind a
+> real gap on the SSO side: the pam-access plugin performs no RP/audience
+> binding on `/pam/*` tokens, and when `pamAccessServerGroups` is empty — the
+> configuration recommended for multi-group projects — it takes `server_group`
+> straight from the request body. Any compromised enrolled host in the project
+> can therefore declare itself a bastion and mint a 12-hour hop voucher for a
+> user. The second defence,
+> `pamAccessBastionCertPinSourceAddress`, is also off by default.
+>
+> `ob-backend-setup` now asks for the list when run interactively, warns loudly
+> when it is left empty, and `ob-ssh-principals` logs an `authpriv.warning` on
+> every hop it accepts without checking which bastion it came from. The empty
+> semantic itself is unchanged: inverting it would deny every hop on an existing
+> fleet the moment it upgrades.
+
 Required sshd settings (no `AcceptEnv` needed):
 
 ```bash

--- a/doc/admin-guide.md
+++ b/doc/admin-guide.md
@@ -446,7 +446,10 @@ create_user_skel = /etc/skel
 # Comma, semicolon or whitespace-separated list of bastion_id values (the
 # per-device ids the portal assigns at enrolment — read one with ob-bastion-id;
 # NOT the OIDC client_id).
-# Leave empty to allow any vouched bastion; remove the file entirely for legacy mode.
+# Leave empty to allow any vouched bastion -- i.e. a hop voucher minted by ANY
+# host enrolled in the project, which is exactly what this list defends against;
+# ob-ssh-principals logs an authpriv.warning on every such hop.
+# Remove the file entirely for legacy mode.
 # Managed by ob-backend-setup --allowed-bastions <ids>  (Ansible: ob_bastion_allowed_bastions)
 # The file /etc/open-bastion/allowed_bastions is NOT read by pam_openbastion. It
 # is enforced by the ob-ssh-principals helper that sshd runs as

--- a/scripts/ob-backend-setup
+++ b/scripts/ob-backend-setup
@@ -301,6 +301,15 @@ if [ "$enforce" = 1 ]; then
             [ "$a" = "$bid" ] && { ok=1; break; }
         done
         [ "$ok" = 1 ] || exit 0
+    else
+        # An empty allowlist accepts a voucher from ANY enrolled bastion in the
+        # project, which is the residual defence behind the SSO-side gap where
+        # a compromised host can self-declare server_group: bastion. Say so on
+        # every hop rather than only at setup time, so it shows up in the logs
+        # of a running fleet (#182).
+        logger -t ob-ssh-principals -p authpriv.warning \
+            "allowed_bastions is empty: accepting a voucher from bastion '$bid' for user '$USERNAME' without checking which bastion it is" \
+            2>/dev/null || :
     fi
 fi
 
@@ -395,7 +404,13 @@ PRINCIPALS
     if [ -n "$BASTION_ALLOWED_IDS" ]; then
         info "Backend accepts bastions: $BASTION_ALLOWED_IDS"
     else
-        info "Backend accepts any vouched bastion (no bastion_id allowlist set)"
+        warn "allowed_bastions is EMPTY: this backend accepts a vouched"
+        warn "certificate from ANY bastion enrolled in the project, not only"
+        warn "from the ones you operate. That allowlist is the residual defence"
+        warn "behind the SSO-side gap where any enrolled host in the project can"
+        warn "declare itself a bastion and mint a hop voucher for a user."
+        warn "Fix it with:  ob-backend-setup --allowed-bastions <bastion_id>[,<id>...]"
+        warn "(the bastion_id of a bastion is printed by ob-bastion-id on it)"
     fi
 
     # Parent /run/open-bastion must be traversable by the principals helper user
@@ -1225,6 +1240,60 @@ prompt_required_settings() {
         IFS= read -r input
         CLIENT_ID="${input:-pam-access}"
     fi
+
+    prompt_allowed_bastions
+    normalize_allowed_bastions
+}
+
+# Validate and normalise the bastion_id allowlist.
+#
+# Entries must match the charset LLNG guarantees for a bastion_id
+# ([A-Za-z0-9._-]) -- the same one the principals helper enforces on the id it
+# reads out of a certificate key-id. Without this, a typo would sit in the
+# allowlist matching nothing (every hop denied, with no explanation), and a
+# whitespace-only value would silently mean "any bastion" while looking set.
+normalize_allowed_bastions() {
+    local raw normalized entry
+    raw=$(printf '%s' "$BASTION_ALLOWED_IDS" | tr ',;' '  ')
+    normalized=""
+    for entry in $raw; do
+        case "$entry" in
+            *[!A-Za-z0-9._-]*)
+                error "Invalid bastion id in the allowed-bastions list: '$entry'"
+                error "Ids are what 'ob-bastion-id' prints on a bastion ([A-Za-z0-9._-])."
+                exit 1
+                ;;
+        esac
+        normalized="${normalized:+$normalized }$entry"
+    done
+    BASTION_ALLOWED_IDS="$normalized"
+}
+
+# Ask which bastions this backend should accept hops from (#182).
+#
+# An empty allowlist means "any vouched bastion": the backend accepts a hop
+# voucher minted by any host enrolled in the project, which is exactly the
+# residual defence behind the SSO-side gap where a compromised enrolled host can
+# declare itself a bastion. Defaulting to that silently is what the issue is
+# about, so ask -- but do not make it mandatory: a single-bastion lab, and a
+# fleet whose bastions are not enrolled yet, both legitimately start empty.
+#
+# Non-interactive runs keep the empty default (an upgrade must not start
+# refusing hops that worked yesterday); they get the warning at the end of
+# install_principals_helper, and the helper logs one on every hop.
+prompt_allowed_bastions() {
+    [ -n "$BASTION_ALLOWED_IDS" ] && return 0
+    [ "$NON_INTERACTIVE" = "true" ] && return 0
+
+    local input
+    printf "\n" >&2
+    warn "Which bastions may hop to this backend?"
+    warn "Leave empty to accept ANY bastion enrolled in the project (the"
+    warn "current default, and a standing risk if any other host in the project"
+    warn "is compromised). Run 'ob-bastion-id' on each bastion to get its id."
+    printf "Allowed bastion ids (comma-separated, empty = any): " >&2
+    IFS= read -r input
+    BASTION_ALLOWED_IDS="$input"
 }
 
 # Interactive prompt after an enrollment failure (typically invalid_client).
@@ -2074,6 +2143,7 @@ main() {
     echo "Server Group:  $SERVER_GROUP"
     echo "Client ID:     $CLIENT_ID"
     echo "Create Users:  $CREATE_USERS"
+    echo "Allowed bastions: ${BASTION_ALLOWED_IDS:-<any vouched bastion>}"
     echo "Sudo via LLNG: $ENABLE_SUDO"
     if [ "$MAX_SECURITY" = "true" ]; then
         echo "Max Security: true (Mode E)"

--- a/scripts/ob-backend-setup
+++ b/scripts/ob-backend-setup
@@ -38,6 +38,7 @@ KRL_REFRESH_INTERVAL=30
 # bastion) this backend accepts certs from. Empty = accept any vouched bastion
 # (still rejects direct user SSO certs, which carry no bastion= key-id).
 BASTION_ALLOWED_IDS=""
+ALLOW_ANY_BASTION=false
 # nobody-readable allowlist consumed by the AuthorizedPrincipalsCommand helper
 # (openbastion.conf is 0600 root, so the helper cannot read the list from there).
 OB_ALLOWED_BASTIONS_FILE="/etc/open-bastion/allowed_bastions"
@@ -311,6 +312,15 @@ if [ "$enforce" = 1 ]; then
             "allowed_bastions is empty: accepting a voucher from bastion '$bid' for user '$USERNAME' without checking which bastion it is" \
             2>/dev/null || :
     fi
+else
+    # Legacy non-enforcing mode: no allowlist file at all, so this accepts a
+    # DIRECT SSO certificate too -- a broader hole than the empty list above,
+    # and until now the only silent one. A backend set up by any current
+    # version has the file; reaching this means an old setup that was never
+    # re-run, which is exactly what should be visible in the logs (#182).
+    logger -t ob-ssh-principals -p authpriv.warning \
+        "$ALLOWED_FILE is absent: legacy non-enforcing mode, accepting a certificate for user '$USERNAME' without requiring a bastion voucher (re-run ob-backend-setup)" \
+        2>/dev/null || :
 fi
 
 # Record the fingerprint keyed by the per-connection sshd anchor PID. OpenSSH
@@ -1253,8 +1263,15 @@ prompt_required_settings() {
 # allowlist matching nothing (every hop denied, with no explanation), and a
 # whitespace-only value would silently mean "any bastion" while looking set.
 normalize_allowed_bastions() {
-    local raw normalized entry
+    local raw normalized entry had_noglob
     raw=$(printf '%s' "$BASTION_ALLOWED_IDS" | tr ',;' '  ')
+    # Splitting $raw also runs PATHNAME EXPANSION, which would defeat the
+    # validation below instead of triggering it: an entry containing a glob
+    # metacharacter that happens to match a file in the current directory is
+    # rewritten to the match ('b[1]' -> the file 'b1'), so a typo is silently
+    # accepted as a different, valid-looking id. Split with globbing off.
+    case $- in *f*) had_noglob=1 ;; *) had_noglob=0 ;; esac
+    set -f
     normalized=""
     for entry in $raw; do
         case "$entry" in
@@ -1266,6 +1283,7 @@ normalize_allowed_bastions() {
         esac
         normalized="${normalized:+$normalized }$entry"
     done
+    [ "$had_noglob" = 1 ] || set +f
     BASTION_ALLOWED_IDS="$normalized"
 }
 
@@ -1281,19 +1299,39 @@ normalize_allowed_bastions() {
 # Non-interactive runs keep the empty default (an upgrade must not start
 # refusing hops that worked yesterday); they get the warning at the end of
 # install_principals_helper, and the helper logs one on every hop.
+#
+# An INTERACTIVE run is not an upgrade path, so there is nothing to preserve:
+# leaving the list empty there has to be a decision the operator took, not the
+# one they get for pressing Enter. Pressing Enter re-asks, with the exposure
+# spelled out, and only a "y" to "accept ANY bastion" leaves it empty.
+# --allow-any-bastion states that answer up front (a lab, or a host whose
+# bastion is not enrolled yet).
 prompt_allowed_bastions() {
     [ -n "$BASTION_ALLOWED_IDS" ] && return 0
     [ "$NON_INTERACTIVE" = "true" ] && return 0
+    [ "$ALLOW_ANY_BASTION" = "true" ] && return 0
 
     local input
     printf "\n" >&2
     warn "Which bastions may hop to this backend?"
-    warn "Leave empty to accept ANY bastion enrolled in the project (the"
-    warn "current default, and a standing risk if any other host in the project"
-    warn "is compromised). Run 'ob-bastion-id' on each bastion to get its id."
-    printf "Allowed bastion ids (comma-separated, empty = any): " >&2
-    IFS= read -r input
-    BASTION_ALLOWED_IDS="$input"
+    warn "Run 'ob-bastion-id' on each bastion to get its id."
+    while :; do
+        printf "Allowed bastion ids (comma-separated): " >&2
+        IFS= read -r input
+        if [ -n "$input" ]; then
+            BASTION_ALLOWED_IDS="$input"
+            return 0
+        fi
+        printf "\n" >&2
+        warn "An empty list accepts a hop voucher from ANY host enrolled in the"
+        warn "project that can declare itself a bastion to the SSO -- not only"
+        warn "from the bastions you operate (#182). It is the residual defence"
+        warn "behind an SSO-side gap, and this is the only place it gets set."
+        if confirm "Accept a hop from ANY bastion?"; then
+            return 0
+        fi
+        printf "\n" >&2
+    done
 }
 
 # Interactive prompt after an enrollment failure (typically invalid_client).
@@ -1863,6 +1901,18 @@ Options:
                           when --yes is used.
       --node-role ROLE    Node role recorded in the config and reported to the
                           SSO: bastion|standalone|backend (default: backend).
+      --allowed-bastions IDS
+                          Comma/space-separated bastion_id allowlist: only these
+                          bastions may hop to this backend. Get an id by running
+                          'ob-bastion-id' on the bastion. Prompted interactively
+                          if omitted. An EMPTY list accepts a hop from any host
+                          enrolled in the project that can declare itself a
+                          bastion to the SSO -- see SECURITY.md.
+      --allow-any-bastion Answer the prompt above with "any bastion", without
+                          being asked. Same (weaker) result as an empty list;
+                          the point is that it is written down. Non-interactive
+                          runs (--yes) already default to it, so that an upgrade
+                          does not start refusing hops that worked yesterday.
   -t, --token-file FILE   Read server token from file (use - for stdin)
   -c, --client-id ID      OIDC client_id for enrollment. Prompted interactively
                           if omitted (suggested: pam-access); required when
@@ -1956,6 +2006,13 @@ parse_args() {
                 fi
                 BASTION_ALLOWED_IDS="$2"
                 shift 2
+                ;;
+            --allow-any-bastion)
+                # Say up front that the empty list is the intended answer, so an
+                # interactive run does not stop to ask. Does not change what an
+                # empty list MEANS -- only who is on record for choosing it.
+                ALLOW_ANY_BASTION=true
+                shift
                 ;;
             -t|--token-file)
                 if [ -z "${2:-}" ] || [[ "${2:-}" == -* ]]; then

--- a/scripts/ob-backend-setup
+++ b/scripts/ob-backend-setup
@@ -1318,7 +1318,11 @@ prompt_allowed_bastions() {
     while :; do
         printf "Allowed bastion ids (comma-separated): " >&2
         IFS= read -r input
-        if [ -n "$input" ]; then
+        # Not [ -n "$input" ]: normalize_allowed_bastions collapses whitespace
+        # AND the separators to nothing, so "   ", ",," or " ; , " would all
+        # reach the empty list -- the very thing the explicit "y" below exists
+        # to gate -- while looking like an answer.
+        if [ -n "${input//[[:space:],;]/}" ]; then
             BASTION_ALLOWED_IDS="$input"
             return 0
         fi

--- a/tests/test_ob_backend_setup.sh
+++ b/tests/test_ob_backend_setup.sh
@@ -331,6 +331,42 @@ test_sudo_fresh_otp_optin() {
     fi
 }
 
+# ── The allowed-bastions list is validated and normalised (#182) ──
+#
+# The list is written to a world-readable file consumed by the principals
+# helper, which compares each entry against a bastion_id it has already
+# restricted to [A-Za-z0-9._-]. A typo outside that charset would sit there
+# matching nothing (every hop denied, unexplained), and a whitespace-only value
+# would silently mean "any bastion" while looking configured.
+test_allowed_bastions_normalised() {
+    local rc1 rc2 rc3
+    (
+        source_script "ob-backend-setup"
+        BASTION_ALLOWED_IDS="b1, b2 ;b3"
+        normalize_allowed_bastions
+        [ "$BASTION_ALLOWED_IDS" = "b1 b2 b3" ] && exit 0 || exit 1
+    )
+    rc1=$?
+    (
+        source_script "ob-backend-setup"
+        BASTION_ALLOWED_IDS="   "
+        normalize_allowed_bastions
+        [ -z "$BASTION_ALLOWED_IDS" ] && exit 0 || exit 1
+    )
+    rc2=$?
+    (
+        source_script "ob-backend-setup"
+        BASTION_ALLOWED_IDS="ok,bad id!"
+        normalize_allowed_bastions 2>/dev/null
+    )
+    rc3=$?
+    if [ "$rc1" -eq 0 ] && [ "$rc2" -eq 0 ] && [ "$rc3" -ne 0 ]; then
+        pass "allowed-bastions list normalised, blank collapses, junk rejected"
+    else
+        fail "allowed-bastions validation" "rc=$rc1/$rc2/$rc3"
+    fi
+}
+
 # ── Test 18: the generated sshd PAM auth stack is fail-closed (#180) ──
 # A bare "auth required pam_permit.so" made pam_authenticate() succeed for any
 # password if sshd ever ran the stack (PasswordAuthentication /
@@ -379,6 +415,7 @@ run_test test_trailing_slash
 run_test test_max_security
 run_test test_node_role_default
 run_test test_node_role_override
+run_test test_allowed_bastions_normalised
 
 run_test test_sudo_fresh_otp_optin
 run_test test_pam_sshd_fail_closed

--- a/tests/test_ob_backend_setup.sh
+++ b/tests/test_ob_backend_setup.sh
@@ -367,6 +367,136 @@ test_allowed_bastions_normalised() {
     fi
 }
 
+# ── A glob in the list must be refused, not silently rewritten (#236 review) ──
+#
+# Splitting the raw list runs pathname expansion as well as word splitting, so
+# 'b[1]' used to become whichever file matched in the CURRENT DIRECTORY -- the
+# typo was accepted as a different, valid-looking id instead of being refused.
+# The test runs from a directory seeded with files that the globs match, which
+# is the only condition under which the bug is observable.
+test_allowed_bastions_no_glob() {
+    local tmp rc out ok=1
+    tmp=$(mktemp -d)
+    : > "$tmp/b1"
+    : > "$tmp/b2"
+
+    # 'b[1]' matches the file b1; must still be rejected as an invalid id.
+    out=$(
+        cd "$tmp" || exit 99
+        source_script "ob-backend-setup"
+        BASTION_ALLOWED_IDS="b[1]"
+        normalize_allowed_bastions 2>&1
+        printf 'RESULT=%s\n' "$BASTION_ALLOWED_IDS"
+    )
+    rc=$?
+    [ "$rc" -ne 0 ] || { ok=0; echo "    (glob 'b[1]' accepted, rc=$rc: $out)"; }
+    grep -q 'RESULT=b1' <<<"$out" && { ok=0; echo "    (glob 'b[1]' rewritten to the file b1)"; }
+
+    # 'b*' matches two files; must not turn into a two-entry allowlist.
+    out=$(
+        cd "$tmp" || exit 99
+        source_script "ob-backend-setup"
+        BASTION_ALLOWED_IDS="b*"
+        normalize_allowed_bastions 2>&1
+        printf 'RESULT=%s\n' "$BASTION_ALLOWED_IDS"
+    )
+    rc=$?
+    [ "$rc" -ne 0 ] || { ok=0; echo "    (glob 'b*' accepted, rc=$rc: $out)"; }
+    grep -q 'RESULT=b1 b2' <<<"$out" && { ok=0; echo "    (glob 'b*' expanded to the cwd)"; }
+
+    # A legitimate list must still normalise with globbing restored afterwards.
+    out=$(
+        cd "$tmp" || exit 99
+        source_script "ob-backend-setup"
+        BASTION_ALLOWED_IDS="b1,b2"
+        normalize_allowed_bastions
+        printf 'RESULT=%s|GLOB=%s\n' "$BASTION_ALLOWED_IDS" "$(case $- in *f*) echo off ;; *) echo on ;; esac)"
+    )
+    grep -q 'RESULT=b1 b2|GLOB=on' <<<"$out" \
+        || { ok=0; echo "    (valid list broken, or globbing left disabled: $out)"; }
+
+    rm -rf "$tmp"
+    if [ "$ok" -eq 1 ]; then
+        pass "globs in the allowed-bastions list are refused, not expanded"
+    else
+        fail "globs in the allowed-bastions list are refused, not expanded"
+    fi
+}
+
+# ── An empty list must be an explicit interactive choice (#236 review) ──
+#
+# Pressing Enter used to accept "any bastion" -- the exposure #182 is about --
+# as the path of least resistance. It now re-asks and takes only an explicit
+# "y". Non-interactive runs keep the empty default: an upgrade must not start
+# refusing hops that worked yesterday.
+test_allowed_bastions_empty_is_explicit() {
+    local out ok=1
+
+    # Enter, then "n", then a real id: the empty answer must not stick.
+    out=$(
+        source_script "ob-backend-setup"
+        NON_INTERACTIVE=false
+        ALLOW_ANY_BASTION=false
+        BASTION_ALLOWED_IDS=""
+        # NOT a pipe: a pipeline would run the function in a subshell and
+        # throw away the assignment this test is about.
+        prompt_allowed_bastions >/dev/null 2>&1 <<<$'\nn\nb1'
+        printf 'RESULT=[%s]\n' "$BASTION_ALLOWED_IDS"
+    )
+    grep -q 'RESULT=\[b1\]' <<<"$out" \
+        || { ok=0; echo "    (declining 'any bastion' did not re-ask: $out)"; }
+
+    # Enter, then "y": empty, on the record.
+    out=$(
+        source_script "ob-backend-setup"
+        NON_INTERACTIVE=false
+        ALLOW_ANY_BASTION=false
+        BASTION_ALLOWED_IDS=""
+        prompt_allowed_bastions >/dev/null 2>&1 <<<$'\ny'
+        printf 'RESULT=[%s]\n' "$BASTION_ALLOWED_IDS"
+    )
+    grep -q 'RESULT=\[\]' <<<"$out" \
+        || { ok=0; echo "    (explicit 'y' did not leave the list empty: $out)"; }
+
+    # --allow-any-bastion answers up front, without a prompt (no stdin at all).
+    out=$(
+        source_script "ob-backend-setup"
+        NON_INTERACTIVE=false
+        ALLOW_ANY_BASTION=true
+        BASTION_ALLOWED_IDS=""
+        prompt_allowed_bastions >/dev/null 2>&1 </dev/null
+        printf 'RESULT=[%s]\n' "$BASTION_ALLOWED_IDS"
+    )
+    grep -q 'RESULT=\[\]' <<<"$out" \
+        || { ok=0; echo "    (--allow-any-bastion still prompted: $out)"; }
+
+    # A non-interactive run keeps the legacy empty default, unprompted.
+    out=$(
+        source_script "ob-backend-setup"
+        NON_INTERACTIVE=true
+        ALLOW_ANY_BASTION=false
+        BASTION_ALLOWED_IDS=""
+        prompt_allowed_bastions >/dev/null 2>&1 </dev/null
+        printf 'RESULT=[%s]\n' "$BASTION_ALLOWED_IDS"
+    )
+    grep -q 'RESULT=\[\]' <<<"$out" \
+        || { ok=0; echo "    (--yes run no longer keeps the empty default: $out)"; }
+
+    # Both options must be discoverable, since the prompt now depends on them.
+    local help
+    help=$(bash "$SCRIPT_DIR/ob-backend-setup" --help 2>&1)
+    grep -q -- '--allowed-bastions' <<<"$help" \
+        || { ok=0; echo "    (--allowed-bastions missing from --help)"; }
+    grep -q -- '--allow-any-bastion' <<<"$help" \
+        || { ok=0; echo "    (--allow-any-bastion missing from --help)"; }
+
+    if [ "$ok" -eq 1 ]; then
+        pass "empty allowed-bastions is an explicit choice, and both flags documented"
+    else
+        fail "empty allowed-bastions is an explicit choice, and both flags documented"
+    fi
+}
+
 # ── Test 18: the generated sshd PAM auth stack is fail-closed (#180) ──
 # A bare "auth required pam_permit.so" made pam_authenticate() succeed for any
 # password if sshd ever ran the stack (PasswordAuthentication /
@@ -416,6 +546,8 @@ run_test test_max_security
 run_test test_node_role_default
 run_test test_node_role_override
 run_test test_allowed_bastions_normalised
+run_test test_allowed_bastions_no_glob
+run_test test_allowed_bastions_empty_is_explicit
 
 run_test test_sudo_fresh_otp_optin
 run_test test_pam_sshd_fail_closed

--- a/tests/test_ob_backend_setup.sh
+++ b/tests/test_ob_backend_setup.sh
@@ -446,6 +446,23 @@ test_allowed_bastions_empty_is_explicit() {
     grep -q 'RESULT=\[b1\]' <<<"$out" \
         || { ok=0; echo "    (declining 'any bastion' did not re-ask: $out)"; }
 
+    # A separators-only answer must not slip past the gate either: the
+    # normaliser collapses whitespace AND ',;' to nothing, so each of these
+    # reaches the empty list while looking like an answer (#236 review).
+    local blank
+    for blank in '   ' ',,' ' ; , '; do
+        out=$(
+            source_script "ob-backend-setup"
+            NON_INTERACTIVE=false
+            ALLOW_ANY_BASTION=false
+            BASTION_ALLOWED_IDS=""
+            prompt_allowed_bastions >/dev/null 2>&1 <<<"$blank"$'\nn\nb1'
+            printf 'RESULT=[%s]\n' "$BASTION_ALLOWED_IDS"
+        )
+        grep -q 'RESULT=\[b1\]' <<<"$out" \
+            || { ok=0; echo "    (blank answer '$blank' bypassed the gate: $out)"; }
+    done
+
     # Enter, then "y": empty, on the record.
     out=$(
         source_script "ob-backend-setup"

--- a/tests/test_ob_ssh_principals_spool.sh
+++ b/tests/test_ob_ssh_principals_spool.sh
@@ -238,6 +238,37 @@ test_backend_wrong_bastion_denied() {
     fi
 }
 
+# ── Test 9b: an empty allowlist still accepts, but says so on every hop ──
+#
+# Empty means "any vouched bastion" (#182). That semantic is kept -- inverting
+# it would deny every hop on a fleet that upgrades -- but it must no longer be
+# invisible: the helper logs a warning to authpriv for each accepted hop.
+test_backend_empty_allowlist_warns() {
+    reset_spool
+    : > "$CONF_DIR/allowed_bastions"
+
+    # Capture what the helper would send to syslog by shadowing logger(1).
+    local bindir="$TMP/bin" logged="$TMP/logged"
+    mkdir -p "$bindir"
+    rm -f "$logged"
+    printf '#!/bin/sh\nprintf "%%s\\n" "$*" >> "%s"\n' "$logged" > "$bindir/logger"
+    chmod 755 "$bindir/logger"
+
+    local out
+    out=$(PATH="$bindir:$PATH" run_helper "$BACKEND_HELPER" "$USER_NAME" "$FP" \
+            "bastion=whatever;user=$USER_NAME;target=host" "ssh-ed25519" "$BLOB")
+
+    if [ "$out" != "$USER_NAME" ]; then
+        fail "Empty allowlist still accepts a vouched cert" "got '$out'"
+        return
+    fi
+    if [ -s "$logged" ] && grep -q 'allowed_bastions is empty' "$logged"; then
+        pass "Empty allowlist accepts but logs a warning naming the bastion"
+    else
+        fail "Empty allowlist logs a warning" "logged: $(cat "$logged" 2>/dev/null)"
+    fi
+}
+
 # ── Test 10: both sshd_config templates pass %t and %k ──
 test_sshd_config_tokens() {
     local bastion_line backend_line
@@ -275,6 +306,7 @@ run_test test_legacy_invocation
 run_test test_backend_vouched
 run_test test_backend_unvouched_denied
 run_test test_backend_wrong_bastion_denied
+run_test test_backend_empty_allowlist_warns
 run_test test_sshd_config_tokens
 run_test test_spool_format_marker
 

--- a/tests/test_ob_ssh_principals_spool.sh
+++ b/tests/test_ob_ssh_principals_spool.sh
@@ -262,10 +262,52 @@ test_backend_empty_allowlist_warns() {
         fail "Empty allowlist still accepts a vouched cert" "got '$out'"
         return
     fi
-    if [ -s "$logged" ] && grep -q 'allowed_bastions is empty' "$logged"; then
-        pass "Empty allowlist accepts but logs a warning naming the bastion"
+    # The claim is not just "a warning": the log has to identify WHICH hop was
+    # let through unchecked, or it cannot be acted on in a running fleet.
+    if [ -s "$logged" ] \
+       && grep -q 'allowed_bastions is empty' "$logged" \
+       && grep -q "'whatever'" "$logged" \
+       && grep -q "'$USER_NAME'" "$logged" \
+       && grep -q 'authpriv.warning' "$logged"; then
+        pass "Empty allowlist accepts but logs a warning naming the bastion and user"
     else
-        fail "Empty allowlist logs a warning" "logged: $(cat "$logged" 2>/dev/null)"
+        fail "Empty allowlist warning names the bastion and user" "logged: $(cat "$logged" 2>/dev/null)"
+    fi
+}
+
+# ── Test 9c: legacy mode (no allowlist file) is no longer the silent one ──
+#
+# With the file absent the helper skips vouching entirely, so it accepts a
+# DIRECT SSO certificate -- broader than the empty list of 9b, and until the
+# #236 review the only path that said nothing at all. Any backend set up by a
+# current version has the file; reaching this means a setup never re-run.
+test_backend_legacy_mode_warns() {
+    reset_spool
+    rm -f "$CONF_DIR/allowed_bastions"
+
+    local bindir="$TMP/bin" logged="$TMP/logged"
+    mkdir -p "$bindir"
+    rm -f "$logged"
+    printf '#!/bin/sh\nprintf "%%s\\n" "$*" >> "%s"\n' "$logged" > "$bindir/logger"
+    chmod 755 "$bindir/logger"
+
+    # A direct SSO cert: no "bastion=" key-id at all. Legacy mode accepts it.
+    local out
+    out=$(PATH="$bindir:$PATH" run_helper "$BACKEND_HELPER" "$USER_NAME" "$FP" \
+            "user@example.com" "ssh-ed25519" "$BLOB")
+
+    : > "$CONF_DIR/allowed_bastions"   # restore for any later test
+
+    if [ "$out" != "$USER_NAME" ]; then
+        fail "Legacy mode still accepts (semantic unchanged)" "got '$out'"
+        return
+    fi
+    if [ -s "$logged" ] \
+       && grep -q 'legacy non-enforcing mode' "$logged" \
+       && grep -q "'$USER_NAME'" "$logged"; then
+        pass "Missing allowlist file accepts but logs a legacy-mode warning"
+    else
+        fail "Missing allowlist file logs a warning" "logged: $(cat "$logged" 2>/dev/null)"
     fi
 }
 
@@ -307,6 +349,7 @@ run_test test_backend_vouched
 run_test test_backend_unvouched_denied
 run_test test_backend_wrong_bastion_denied
 run_test test_backend_empty_allowlist_warns
+run_test test_backend_legacy_mode_warns
 run_test test_sshd_config_tokens
 run_test test_spool_format_marker
 


### PR DESCRIPTION
Closes #182.

`ob-backend-setup` created the allowlist empty, and empty means "accept a hop voucher from any vouched bastion" — in practice, from any host enrolled in the project. As the issue explains, that allowlist is the residual defence behind a real SSO-side gap (no RP/audience binding on `/pam/*` tokens; with `pamAccessServerGroups` empty, `server_group` comes straight from the request body), and `pamAccessBastionCertPinSourceAddress` is off by default too.

## What changes

Three things, none of which can break an existing fleet on upgrade:

1. **`ob-backend-setup` asks.** The allowlist is prompted for alongside `server_group` and `client_id`, before any system change, and appears in the pre-flight banner. Non-interactive runs keep the empty default — an upgrade must not start refusing hops that worked yesterday.
2. **Leaving it empty is loud.** A multi-line `warn` naming the exposure and the fix (`--allowed-bastions <id>`, and where to get the ids), instead of the previous one-line `info`.
3. **Every hop says so.** `ob-ssh-principals` logs an `authpriv.warning` on each hop it accepts without checking which bastion it came from — so a *running* fleet shows the condition in its logs, not just in a setup transcript nobody kept.

## What deliberately does not change

The empty-means-any semantic. The issue floats inverting it to fail closed; that would deny every hop the moment a backend upgrades, on every deployment that never set the list. That is not a change to make behind an operator's back — the warning path above is the reversible half.

## Also fixed while here

The list was written to a world-readable file with no validation. It is now validated (`[A-Za-z0-9._-]`, comma/semicolon/space separated) and normalised:

- a typo outside that charset used to sit in the file matching nothing — **every hop denied, with no explanation**. It is now refused at setup, where the operator can see it.
- a whitespace-only value looked configured while meaning "any". It now collapses to empty and takes the empty-list warning.

## Documentation

`SECURITY.md` gains the "Set this list" note with the SSO-side interaction spelled out, and `doc/admin-guide.md`'s config comment stops describing the empty case neutrally.

## Tests

```
$ bash tests/test_ob_backend_setup.sh         → 21/21   (+ allowlist validation)
$ bash tests/test_ob_ssh_principals_spool.sh  → 12/12   (+ empty-allowlist warning)
$ bash tests/test_backend_cert_acceptance.sh  → PASS
```

The new spool test shadows `logger(1)` to capture what the helper sends to syslog, and asserts both halves: the hop is still accepted, and the warning names the bastion and the user.

https://claude.ai/code/session_011q88Fs4nFuUs7JMvmgbBTN