### PR TITLE
feat(sudo): --enable-sudo-fresh-otp, an LLNG token on every elevation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `auth required pam_deny.so`. Check with
   `grep '^auth' /etc/pam.d/sshd`.
 
+### Added
+
+- **`--enable-sudo-fresh-otp` on `ob-bastion-setup` and `ob-backend-setup`
+  (#178).** `sudo` keeps its own credential cache (`timestamp_timeout`, 15
+  minutes by default, idle-based and rearmed on each use). While it is valid,
+  `sudo` skips the PAM `auth` phase entirely, so `pam_openbastion` never runs and
+  no LLNG one-time token is asked for — a user who keeps elevating is not
+  prompted again, which is not what "a fresh SSO re-authentication for each
+  `sudo`" suggests.
+
+  What that does **not** weaken: each token is single-use and consumed by the
+  portal, and the `account` phase re-checks authorization live on every `sudo`,
+  so an LLNG-side revocation takes effect at once. What it weakens is the
+  freshness claim itself.
+
+  The new flag writes `Defaults:%open-bastion-sudo timestamp_timeout=0` into
+  `/etc/sudoers.d/open-bastion`, scoped to the SSO group so local break-glass
+  admins keep normal `sudo` behaviour. It stays **opt-in**: enabling it by
+  default would start prompting on every `sudo` across an upgraded fleet,
+  including inside scripts and long maintenance sessions. On a host that already
+  has the drop-in, the flag only *adds* the `Defaults:` line — the rest of the
+  file is left as the operator wrote it — and the result is `visudo -cf`
+  validated before installation, as before. `doc/pam-modes.md` and EBIOS risk
+  R-S16 now describe the trade-off and name the flag.
+
 ### Changed
 
 - **`ob-builder` artefacts that carry the client secret are no longer

--- a/doc/pam-modes.md
+++ b/doc/pam-modes.md
@@ -331,19 +331,27 @@ _token_ is useless (single use, short TTL), and a revoked _right_ is enforced
 immediately. What survives inside the window is the operator's own already
 authenticated terminal.
 
-If your policy requires a token prompt for **every** `sudo`, set
-`timestamp_timeout=0`. Put it in its own sudoers drop-in — `ob-bastion-setup`
-and `ob-backend-setup` regenerate `/etc/sudoers.d/open-bastion`, so anything
-written there is lost on the next run:
+If your policy requires a token prompt for **every** `sudo`, pass
+`--enable-sudo-fresh-otp` to `ob-bastion-setup` or `ob-backend-setup`. It scopes
+`timestamp_timeout=0` to the SSO group in `/etc/sudoers.d/open-bastion`, so SSO
+users go through the PAM `auth` phase — and therefore the LLNG token — on every
+elevation, while local break-glass admins keep normal `sudo` behaviour:
 
 ```bash
-cat > /etc/sudoers.d/open-bastion-local << 'EOF'
-# Require a fresh LLNG token for every sudo (no timestamp reuse).
-Defaults:%open-bastion-sudo timestamp_timeout=0
-EOF
-chmod 0440 /etc/sudoers.d/open-bastion-local
-visudo -c
+ob-bastion-setup --portal https://auth.example.com --max-security \
+                 --enable-sudo-fresh-otp
 ```
+
+```
+# /etc/sudoers.d/open-bastion
+Defaults:%open-bastion-sudo timestamp_timeout=0
+%open-bastion-sudo ALL=(ALL) ALL
+```
+
+Both setups validate the drop-in with `visudo -cf` before installing it, and on
+a host that already has the file they only **add** the `Defaults:` line rather
+than rewriting what is there. Run the setup again without the flag and the line
+stays: removing it is a deliberate edit, not a side effect.
 
 This is deliberately **not** the default: with `timestamp_timeout=0` every
 `sudo` in a shell loop or a long maintenance session needs a new token, which

--- a/doc/security/99-risk-reduce.md
+++ b/doc/security/99-risk-reduce.md
@@ -172,6 +172,21 @@ Le Mode E bloque l'escalade par conception (réauthentification SSO obligatoire)
 2. **Durée de token réduite** : Limiter la validité du token PAM-access à 5 minutes pour les opérations sudo
 3. **Audit renforcé** : Logger chaque utilisation de sudo avec le token ID pour traçabilité
 
+**Précision sur la fraîcheur de la réauthentification :** `sudo` possède son
+propre cache d'identifiants (`timestamp_timeout`, 15 min par défaut sur Debian,
+réarmé à chaque usage). Tant qu'il est valide, `sudo` **saute entièrement la
+phase PAM `auth`** : `pam_openbastion` n'est pas appelé et aucun token LLNG
+n'est demandé. Ce que cela n'affaiblit pas : le token est à usage unique et
+consommé côté portail, et la phase `account` — donc la vérification
+d'autorisation — s'exécute en direct à **chaque** `sudo`, si bien qu'une
+révocation LLNG prend effet immédiatement. Ce que cela affaiblit : la
+revendication « chaque élévation est adossée à une authentification SSO
+*fraîche* ». L'option `--enable-sudo-fresh-otp` d'`ob-bastion-setup` /
+`ob-backend-setup` écrit `Defaults:%open-bastion-sudo timestamp_timeout=0` et
+rétablit la revendication littérale ; elle reste **opt-in** parce qu'elle change
+la cadence des invites pour tous les utilisateurs SSO. Voir
+[doc/pam-modes.md](../pam-modes.md#how-often-you-are-actually-prompted-sudos-timestamp-cache).
+
 **Séparation des privilèges implémentée (enregistrement de session) :** le recording est streamé vers le puits root `ob-record-sink` (socket-activé, utilisateur dérivé de `SO_PEERCRED`), qui écrit des fichiers **root-owned** (`root:ob-sessions 0640`) dans une arborescence `root:ob-sessions 0750`. L'utilisateur enregistré n'a **aucun** accès (lister/lire/supprimer/tronquer), y compris sur ses propres enregistrements. L'enregistreur vivant sur le **bastion** (point de passage), être root sur un backend n'y échappe pas. Voir R-S18 ci-dessous.
 
 ### R-S18 _(P=1, I=1)_ - Effacement des enregistrements de session

--- a/scripts/ob-backend-setup
+++ b/scripts/ob-backend-setup
@@ -82,6 +82,10 @@ HARDENING_LIMITS_DST="/etc/security/limits.d/open-bastion.conf"
 HARDENING_AT_ALLOW="/etc/at.allow"
 HARDENING_CRON_ALLOW="/etc/cron.allow"
 ENABLE_HARDENING=false
+# Opt-in: scope `timestamp_timeout=0` to %open-bastion-sudo so SSO users present
+# a fresh LLNG token on every sudo instead of riding sudo's own credential cache
+# (#178). Off by default: it changes the prompt cadence for every SSO user.
+SUDO_FRESH_OTP=false
 # Result of setup_hardening, consumed by print_summary. One of:
 #   not-applied (default — step never ran or was opt-out)
 #   applied     (all sub-steps succeeded)
@@ -615,6 +619,9 @@ session    required     pam_unix.so
         echo "$pam_content"
         info "[DRY-RUN] Would create group open-bastion-sudo"
         info "[DRY-RUN] Would create /etc/sudoers.d/open-bastion with: %open-bastion-sudo ALL=(ALL) ALL"
+        if [ "$SUDO_FRESH_OTP" = "true" ]; then
+            info "[DRY-RUN] Would add: Defaults:%open-bastion-sudo timestamp_timeout=0"
+        fi
         return 0
     fi
 
@@ -638,32 +645,95 @@ session    required     pam_unix.so
     groupadd --system open-bastion-sudo 2>/dev/null || true
 
     local sudoers_file="/etc/sudoers.d/open-bastion"
-    if [ ! -f "$sudoers_file" ]; then
-        # Write to a temp file and validate with visudo before installing, so a
-        # malformed drop-in can never break sudo on the host.
-        local tmp_sudoers
+    write_open_bastion_sudoers "$sudoers_file" "# Open Bastion: defense-in-depth sudo authorization"
+}
+
+# Render the drop-in's contents. Split out of write_open_bastion_sudoers so the
+# exact bytes can be asserted in a test without root (install -o root would
+# fail) and without touching /etc.
+render_open_bastion_sudoers() {
+    local header="$1"
+
+    printf '%s\n' "$header"
+    printf '%s\n' "# Both group membership (managed by PAM session) AND LLNG token are required"
+    if [ "$SUDO_FRESH_OTP" = "true" ]; then
+        printf '%s\n' "# --enable-sudo-fresh-otp: no sudo credential caching for SSO users, so"
+        printf '%s\n' "# every elevation goes through the PAM auth phase and asks for an LLNG token."
+        printf '%s\n' "Defaults:%open-bastion-sudo timestamp_timeout=0"
+    fi
+    printf '%s\n' "%open-bastion-sudo ALL=(ALL) ALL"
+}
+
+# Install /etc/sudoers.d/open-bastion, optionally with the fresh-OTP Defaults.
+#
+# sudo caches its own credential (timestamp_timeout, 15 min by default, idle-based
+# and rearmed on every use). While that timestamp is valid sudo skips the PAM
+# AUTH phase entirely, so pam_openbastion never runs and no LLNG one-time token
+# is asked for -- a user who keeps sudoing is never prompted again (#178).
+#
+# What that does NOT weaken: authorization is re-checked live on every sudo (the
+# account phase always runs), so an LLNG-side revocation takes effect at once,
+# and each OTP is single-use on the portal. What it does weaken is the Mode E
+# claim that every elevation is backed by a *fresh* SSO authentication.
+#
+# --enable-sudo-fresh-otp scopes timestamp_timeout=0 to the SSO group, so those
+# users present a token on every sudo while local break-glass admins keep normal
+# sudo behaviour. It is opt-in: turning it on by default would start prompting
+# on every sudo across an upgraded fleet, including inside scripts.
+write_open_bastion_sudoers() {
+    local sudoers_file="$1" header="$2"
+    local tmp_sudoers rendered
+
+    rendered=$(render_open_bastion_sudoers "$header")
+
+    if [ -f "$sudoers_file" ]; then
+        # Never rewrite an operator's file behind their back; only add the
+        # Defaults line they explicitly asked for, and only if it is missing.
+        if [ "$SUDO_FRESH_OTP" != "true" ] \
+           || grep -q '^Defaults:%open-bastion-sudo[[:space:]].*timestamp_timeout=0' "$sudoers_file"; then
+            return 0
+        fi
         tmp_sudoers=$(mktemp)
         {
-            echo "# Open Bastion: defense-in-depth sudo authorization"
-            echo "# Both group membership (managed by PAM session) AND LLNG token are required"
-            echo "%open-bastion-sudo ALL=(ALL) ALL"
+            printf '%s\n' "# --enable-sudo-fresh-otp: no sudo credential caching for SSO users (#178)"
+            printf '%s\n' "Defaults:%open-bastion-sudo timestamp_timeout=0"
+            cat "$sudoers_file"
         } > "$tmp_sudoers"
         if visudo -cf "$tmp_sudoers" >/dev/null 2>&1; then
-            # Ensure the drop-in directory exists (created 0750 root:root only
-            # when missing, so we never relax an existing one), then install and
-            # CHECK the result — otherwise a failed install would leave sudo
-            # broken while we log success.
-            [ -d /etc/sudoers.d ] || install -d -m 0750 -o root -g root /etc/sudoers.d
+            backup_file "$sudoers_file"
             if install -m 0440 -o root -g root "$tmp_sudoers" "$sudoers_file"; then
-                info "Created $sudoers_file"
+                info "Added timestamp_timeout=0 for %open-bastion-sudo in $sudoers_file"
             else
-                warn "Failed to install $sudoers_file; sudo may not work for SSO users"
+                warn "Failed to update $sudoers_file"
             fi
         else
-            warn "Generated sudoers rule failed visudo validation; not installing"
+            warn "Updated sudoers rule failed visudo validation; leaving $sudoers_file untouched"
         fi
         rm -f "$tmp_sudoers"
+        return 0
     fi
+
+    # Write to a temp file and validate with visudo before installing, so a
+    # malformed drop-in can never break sudo on the host.
+    tmp_sudoers=$(mktemp)
+    printf '%s\n' "$rendered" > "$tmp_sudoers"
+    if visudo -cf "$tmp_sudoers" >/dev/null 2>&1; then
+        # Ensure the drop-in directory exists (created 0750 root:root only when
+        # missing, so we never relax an existing one), then install and CHECK the
+        # result -- otherwise a failed install would leave sudo broken while we
+        # log success.
+        [ -d /etc/sudoers.d ] || install -d -m 0750 -o root -g root /etc/sudoers.d
+        if install -m 0440 -o root -g root "$tmp_sudoers" "$sudoers_file"; then
+            info "Created $sudoers_file"
+            [ "$SUDO_FRESH_OTP" = "true" ] \
+                && info "SSO users must present a fresh LLNG token on every sudo (timestamp_timeout=0)"
+        else
+            warn "Failed to install $sudoers_file; sudo may not work for SSO users"
+        fi
+    else
+        warn "Generated sudoers rule failed visudo validation; not installing"
+    fi
+    rm -f "$tmp_sudoers"
 }
 
 # Configure sshd for max security (Mode E)
@@ -1739,6 +1809,11 @@ Options:
   --no-sudo               Don't configure sudo with LLNG
   --no-create-user        Don't enable automatic user creation
   --max-security          Enable Mode E (SSO certificates only, sudo via LLNG token, KRL)
+  --enable-sudo-fresh-otp Require a fresh LLNG token on EVERY sudo for SSO users
+                          (writes `Defaults:%open-bastion-sudo timestamp_timeout=0`).
+                          Without it, sudo's own 15-minute credential cache lets a
+                          user keep elevating without being asked again. Local
+                          break-glass admins are unaffected. OFF by default.
   --enable-hardening      Apply system-wide containment hardening (logind KillUserProcesses,
                           mask atd, at/cron allow-lists, nproc limit). OFF by default —
                           modifies system-wide behaviour, opt in only on dedicated backend hosts.
@@ -1869,6 +1944,10 @@ parse_args() {
                 ;;
             --max-security)
                 MAX_SECURITY=true
+                shift
+                ;;
+            --enable-sudo-fresh-otp)
+                SUDO_FRESH_OTP=true
                 shift
                 ;;
             --enable-hardening)

--- a/scripts/ob-bastion-setup
+++ b/scripts/ob-bastion-setup
@@ -86,6 +86,10 @@ HARDENING_LIMITS_DST="/etc/security/limits.d/open-bastion.conf"
 HARDENING_AT_ALLOW="/etc/at.allow"
 HARDENING_CRON_ALLOW="/etc/cron.allow"
 ENABLE_HARDENING=false
+# Opt-in: scope `timestamp_timeout=0` to %open-bastion-sudo so SSO users present
+# a fresh LLNG token on every sudo instead of riding sudo's own credential cache
+# (#178). Off by default: it changes the prompt cadence for every SSO user.
+SUDO_FRESH_OTP=false
 # Result of setup_hardening, consumed by print_summary. One of:
 #   not-applied (default — step never ran or was opt-out)
 #   applied     (all sub-steps succeeded)
@@ -968,6 +972,9 @@ session    required     pam_unix.so
         echo "$pam_content"
         info "[DRY-RUN] Would create group open-bastion-sudo"
         info "[DRY-RUN] Would create /etc/sudoers.d/open-bastion with: %open-bastion-sudo ALL=(ALL) ALL"
+        if [ "$SUDO_FRESH_OTP" = "true" ]; then
+            info "[DRY-RUN] Would add: Defaults:%open-bastion-sudo timestamp_timeout=0"
+        fi
         return 0
     fi
 
@@ -989,34 +996,96 @@ session    required     pam_unix.so
 
     # Configure sudoers: only open-bastion-sudo group members can sudo (PAM also required)
     local sudoers_file="/etc/sudoers.d/open-bastion"
-    if [ ! -f "$sudoers_file" ]; then
-        # Write to a temp file and validate with visudo before installing, so a
-        # malformed drop-in can never break sudo on the host. (Mirrors
-        # ob-backend-setup; the previous echo-into-place version published the
-        # file before anything had checked it.)
-        local tmp_sudoers
+    local sudoers_header="# Open Bastion Mode E: defense-in-depth sudo authorization"
+    write_open_bastion_sudoers "$sudoers_file" "$sudoers_header"
+}
+
+# Render the drop-in's contents. Split out of write_open_bastion_sudoers so the
+# exact bytes can be asserted in a test without root (install -o root would
+# fail) and without touching /etc.
+render_open_bastion_sudoers() {
+    local header="$1"
+
+    printf '%s\n' "$header"
+    printf '%s\n' "# Both group membership (managed by PAM session) AND LLNG token are required"
+    if [ "$SUDO_FRESH_OTP" = "true" ]; then
+        printf '%s\n' "# --enable-sudo-fresh-otp: no sudo credential caching for SSO users, so"
+        printf '%s\n' "# every elevation goes through the PAM auth phase and asks for an LLNG token."
+        printf '%s\n' "Defaults:%open-bastion-sudo timestamp_timeout=0"
+    fi
+    printf '%s\n' "%open-bastion-sudo ALL=(ALL) ALL"
+}
+
+# Install /etc/sudoers.d/open-bastion, optionally with the fresh-OTP Defaults.
+#
+# sudo caches its own credential (timestamp_timeout, 15 min by default, idle-based
+# and rearmed on every use). While that timestamp is valid sudo skips the PAM
+# AUTH phase entirely, so pam_openbastion never runs and no LLNG one-time token
+# is asked for -- a user who keeps sudoing is never prompted again (#178).
+#
+# What that does NOT weaken: authorization is re-checked live on every sudo (the
+# account phase always runs), so an LLNG-side revocation takes effect at once,
+# and each OTP is single-use on the portal. What it does weaken is the Mode E
+# claim that every elevation is backed by a *fresh* SSO authentication.
+#
+# --enable-sudo-fresh-otp scopes timestamp_timeout=0 to the SSO group, so those
+# users present a token on every sudo while local break-glass admins keep normal
+# sudo behaviour. It is opt-in: turning it on by default would start prompting
+# on every sudo across an upgraded fleet, including inside scripts.
+write_open_bastion_sudoers() {
+    local sudoers_file="$1" header="$2"
+    local tmp_sudoers rendered
+
+    rendered=$(render_open_bastion_sudoers "$header")
+
+    if [ -f "$sudoers_file" ]; then
+        # Never rewrite an operator's file behind their back; only add the
+        # Defaults line they explicitly asked for, and only if it is missing.
+        if [ "$SUDO_FRESH_OTP" != "true" ] \
+           || grep -q '^Defaults:%open-bastion-sudo[[:space:]].*timestamp_timeout=0' "$sudoers_file"; then
+            return 0
+        fi
         tmp_sudoers=$(mktemp)
         {
-            echo "# Open Bastion Mode E: defense-in-depth sudo authorization"
-            echo "# Both group membership (managed by PAM session) AND LLNG token are required"
-            echo "%open-bastion-sudo ALL=(ALL) ALL"
+            printf '%s\n' "# --enable-sudo-fresh-otp: no sudo credential caching for SSO users (#178)"
+            printf '%s\n' "Defaults:%open-bastion-sudo timestamp_timeout=0"
+            cat "$sudoers_file"
         } > "$tmp_sudoers"
         if visudo -cf "$tmp_sudoers" >/dev/null 2>&1; then
-            # Ensure the drop-in directory exists (created 0750 root:root only
-            # when missing, so we never relax an existing one), then install and
-            # CHECK the result — otherwise a failed install would leave sudo
-            # broken while we log success.
-            [ -d /etc/sudoers.d ] || install -d -m 0750 -o root -g root /etc/sudoers.d
+            backup_file "$sudoers_file"
             if install -m 0440 -o root -g root "$tmp_sudoers" "$sudoers_file"; then
-                info "Created $sudoers_file"
+                info "Added timestamp_timeout=0 for %open-bastion-sudo in $sudoers_file"
             else
-                warn "Failed to install $sudoers_file; sudo may not work for SSO users"
+                warn "Failed to update $sudoers_file"
             fi
         else
-            warn "Generated sudoers rule failed visudo validation; not installing"
+            warn "Updated sudoers rule failed visudo validation; leaving $sudoers_file untouched"
         fi
         rm -f "$tmp_sudoers"
+        return 0
     fi
+
+    # Write to a temp file and validate with visudo before installing, so a
+    # malformed drop-in can never break sudo on the host.
+    tmp_sudoers=$(mktemp)
+    printf '%s\n' "$rendered" > "$tmp_sudoers"
+    if visudo -cf "$tmp_sudoers" >/dev/null 2>&1; then
+        # Ensure the drop-in directory exists (created 0750 root:root only when
+        # missing, so we never relax an existing one), then install and CHECK the
+        # result -- otherwise a failed install would leave sudo broken while we
+        # log success.
+        [ -d /etc/sudoers.d ] || install -d -m 0750 -o root -g root /etc/sudoers.d
+        if install -m 0440 -o root -g root "$tmp_sudoers" "$sudoers_file"; then
+            info "Created $sudoers_file"
+            [ "$SUDO_FRESH_OTP" = "true" ] \
+                && info "SSO users must present a fresh LLNG token on every sudo (timestamp_timeout=0)"
+        else
+            warn "Failed to install $sudoers_file; sudo may not work for SSO users"
+        fi
+    else
+        warn "Generated sudoers rule failed visudo validation; not installing"
+    fi
+    rm -f "$tmp_sudoers"
 }
 
 # Ensure /etc/nsswitch.conf has a usable "<db>: files openbastion ..." line.
@@ -1795,6 +1864,12 @@ print_summary() {
         echo "    - SSH: SSO-signed certificates only"
         echo "    - sudo: LLNG temporary token required"
         echo "    - KRL: mandatory, refreshed every ${KRL_REFRESH_INTERVAL} min"
+        if [ "$SUDO_FRESH_OTP" = "true" ]; then
+            echo "    - sudo: fresh LLNG token on EVERY elevation (timestamp_timeout=0)"
+        else
+            echo "    - sudo: sudo's own 15-min credential cache applies between"
+            echo "      elevations (use --enable-sudo-fresh-otp to require a token each time)"
+        fi
     fi
     if [ "$ENABLE_AUDIT_TRACE" = "true" ]; then
         echo "  ✓ Audit trace: applied (auditd rules + daily rotation)"
@@ -1849,6 +1924,11 @@ Options:
                           ($OB_TOKEN), in which case it is reused.
   -k, --insecure          Skip SSL certificate verification
   --max-security          Enable Mode E (SSO certificates only, sudo via LLNG token, KRL)
+  --enable-sudo-fresh-otp Require a fresh LLNG token on EVERY sudo for SSO users
+                          (writes `Defaults:%open-bastion-sudo timestamp_timeout=0`).
+                          Without it, sudo's own 15-minute credential cache lets a
+                          user keep elevating without being asked again. Local
+                          break-glass admins are unaffected. OFF by default.
   --enable-hardening      Apply system-wide containment hardening (logind KillUserProcesses,
                           mask atd, at/cron allow-lists, nproc limit). OFF by default —
                           modifies system-wide behaviour, opt in only on dedicated bastion hosts.
@@ -1968,6 +2048,10 @@ parse_args() {
                 ;;
             --max-security)
                 MAX_SECURITY=true
+                shift
+                ;;
+            --enable-sudo-fresh-otp)
+                SUDO_FRESH_OTP=true
                 shift
                 ;;
             --enable-hardening)

--- a/tests/test_ob_backend_setup.sh
+++ b/tests/test_ob_backend_setup.sh
@@ -283,6 +283,54 @@ test_node_role_override() {
     fi
 }
 
+# -- The fresh-OTP opt-in (#178) --
+#
+# sudo caches its own credential (timestamp_timeout, 15 min, idle-based and
+# rearmed on each use). While it is valid sudo skips the PAM auth phase
+# entirely, so pam_openbastion never runs and no LLNG one-time token is asked
+# for. --enable-sudo-fresh-otp scopes timestamp_timeout=0 to the SSO group so
+# every elevation goes through PAM. It must stay OFF by default: turning it on
+# changes the prompt cadence for every SSO user on an upgraded fleet.
+test_sudo_fresh_otp_optin() {
+    local off on ok=1
+
+    off=$(
+        source_script "ob-backend-setup"
+        SUDO_FRESH_OTP=false
+        render_open_bastion_sudoers "# header"
+    )
+    on=$(
+        source_script "ob-backend-setup"
+        SUDO_FRESH_OTP=true
+        render_open_bastion_sudoers "# header"
+    )
+
+    grep -q '^%open-bastion-sudo ALL=(ALL) ALL$' <<<"$off" \
+        || { ok=0; echo "    (default drop-in lost its sudo rule)"; }
+    grep -q 'timestamp_timeout' <<<"$off" \
+        && { ok=0; echo "    (timestamp_timeout applied without the flag)"; }
+    grep -q '^Defaults:%open-bastion-sudo timestamp_timeout=0$' <<<"$on" \
+        || { ok=0; echo "    (--enable-sudo-fresh-otp did not scope timestamp_timeout=0)"; }
+    grep -q '^%open-bastion-sudo ALL=(ALL) ALL$' <<<"$on" \
+        || { ok=0; echo "    (opt-in drop-in lost its sudo rule)"; }
+    grep -q 'enable-sudo-fresh-otp' <<<"$(bash "$SCRIPT_DIR/ob-backend-setup" --help 2>&1)" \
+        || { ok=0; echo "    (not documented in --help)"; }
+
+    if command -v visudo >/dev/null 2>&1; then
+        local tmp; tmp=$(mktemp)
+        printf '%s\n' "$on" > "$tmp"
+        visudo -cf "$tmp" >/dev/null 2>&1 \
+            || { ok=0; echo "    (opt-in drop-in fails visudo)"; }
+        rm -f "$tmp"
+    fi
+
+    if [ "$ok" -eq 1 ]; then
+        pass "--enable-sudo-fresh-otp is opt-in, scoped, and documented"
+    else
+        fail "--enable-sudo-fresh-otp is opt-in, scoped, and documented"
+    fi
+}
+
 # ── Test 18: the generated sshd PAM auth stack is fail-closed (#180) ──
 # A bare "auth required pam_permit.so" made pam_authenticate() succeed for any
 # password if sshd ever ran the stack (PasswordAuthentication /
@@ -332,6 +380,7 @@ run_test test_max_security
 run_test test_node_role_default
 run_test test_node_role_override
 
+run_test test_sudo_fresh_otp_optin
 run_test test_pam_sshd_fail_closed
 run_test test_pam_sudo_fail_closed
 

--- a/tests/test_ob_bastion_setup.sh
+++ b/tests/test_ob_bastion_setup.sh
@@ -319,13 +319,60 @@ test_portal_url_accepts_normal() {
     fi
 }
 
+# -- The fresh-OTP opt-in (#178) --
+#
+# sudo caches its own credential (timestamp_timeout, 15 min, idle-based and
+# rearmed on each use). While it is valid sudo skips the PAM auth phase
+# entirely, so pam_openbastion never runs and no LLNG one-time token is asked
+# for. --enable-sudo-fresh-otp scopes timestamp_timeout=0 to the SSO group so
+# every elevation goes through PAM. It must stay OFF by default: turning it on
+# changes the prompt cadence for every SSO user on an upgraded fleet.
+test_sudo_fresh_otp_optin() {
+    local off on ok=1
+
+    off=$(
+        source_script "ob-bastion-setup"
+        SUDO_FRESH_OTP=false
+        render_open_bastion_sudoers "# header"
+    )
+    on=$(
+        source_script "ob-bastion-setup"
+        SUDO_FRESH_OTP=true
+        render_open_bastion_sudoers "# header"
+    )
+
+    grep -q '^%open-bastion-sudo ALL=(ALL) ALL$' <<<"$off" \
+        || { ok=0; echo "    (default drop-in lost its sudo rule)"; }
+    grep -q 'timestamp_timeout' <<<"$off" \
+        && { ok=0; echo "    (timestamp_timeout applied without the flag)"; }
+    grep -q '^Defaults:%open-bastion-sudo timestamp_timeout=0$' <<<"$on" \
+        || { ok=0; echo "    (--enable-sudo-fresh-otp did not scope timestamp_timeout=0)"; }
+    grep -q '^%open-bastion-sudo ALL=(ALL) ALL$' <<<"$on" \
+        || { ok=0; echo "    (opt-in drop-in lost its sudo rule)"; }
+    grep -q 'enable-sudo-fresh-otp' <<<"$(bash "$SCRIPT_DIR/ob-bastion-setup" --help 2>&1)" \
+        || { ok=0; echo "    (not documented in --help)"; }
+
+    if command -v visudo >/dev/null 2>&1; then
+        local tmp; tmp=$(mktemp)
+        printf '%s\n' "$on" > "$tmp"
+        visudo -cf "$tmp" >/dev/null 2>&1 \
+            || { ok=0; echo "    (opt-in drop-in fails visudo)"; }
+        rm -f "$tmp"
+    fi
+
+    if [ "$ok" -eq 1 ]; then
+        pass "--enable-sudo-fresh-otp is opt-in, scoped, and documented"
+    else
+        fail "--enable-sudo-fresh-otp is opt-in, scoped, and documented"
+    fi
+}
 # -- Test 19: sudoers drop-in is validated before it is installed --
 # A malformed /etc/sudoers.d/open-bastion breaks sudo host-wide, so the rule is
 # written to a temp file, checked with visudo -cf, and only then installed 0440
 # -- the same sequence ob-backend-setup uses.
 test_sudoers_validated_before_install() {
     local body ok=1
-    body=$(sed -n '/^configure_max_security_sudo()/,/^}/p' "$SCRIPT_DIR/ob-bastion-setup")
+    body=$(sed -n '/^write_open_bastion_sudoers()/,/^}/p' "$SCRIPT_DIR/ob-bastion-setup")
 
     grep -q 'visudo -cf' <<<"$body" || { ok=0; echo "    (no visudo -cf)"; }
     grep -q 'install -m 0440 -o root -g root' <<<"$body" || { ok=0; echo "    (no install -m 0440)"; }
@@ -349,11 +396,12 @@ test_sudoers_rule_is_valid() {
     fi
 
     local body tmp
-    body=$(sed -n '/^configure_max_security_sudo()/,/^}/p' "$SCRIPT_DIR/ob-bastion-setup")
+    body=$(sed -n '/^write_open_bastion_sudoers()/,/^}/p' "$SCRIPT_DIR/ob-bastion-setup")
     tmp=$(mktemp)
-    # Replay exactly the lines the script writes into its temp sudoers file.
-    grep -oE '^[[:space:]]*echo "(#|%)[^"]*"' <<<"$body" \
-        | sed -E 's/^[[:space:]]*echo "//; s/"$//' > "$tmp"
+    # Replay exactly the lines the script writes into its temp sudoers file,
+    # including the opt-in Defaults line so both shapes are checked at once.
+    grep -oE "printf '%s\\\\n' \"(#|%|Defaults)[^\"]*\"" <<<"$body" \
+        | sed -E "s/^printf '%s\\\\n' \"//; s/\"\$//" > "$tmp"
 
     if [ ! -s "$tmp" ]; then
         rm -f "$tmp"
@@ -419,6 +467,7 @@ run_test test_node_role_invalid
 run_test test_node_role_default
 run_test test_portal_url_rejects_metacharacters
 run_test test_portal_url_accepts_normal
+run_test test_sudo_fresh_otp_optin
 run_test test_sudoers_validated_before_install
 run_test test_sudoers_rule_is_valid
 


### PR DESCRIPTION
Closes #178.

## The finding, restated

`sudo` keeps its own credential cache (`timestamp_timeout`, 15 min by default, idle-based and **rearmed on each use**). While it is valid, `sudo` skips the PAM `auth` phase entirely — `pam_openbastion` never runs, no LLNG one-time token is asked for. The issue's log excerpt shows exactly that: one `sudo:auth` line, then only `sudo:account` lines for minutes afterwards.

The issue's own analysis of what is *not* affected holds and is worth keeping in view: each token is single-use and consumed by the portal, and the `account` phase re-checks authorization live on every `sudo`, so an LLNG-side revocation takes effect immediately. What the cache weakens is the *freshness* claim, not authorization.

## The fix

`--enable-sudo-fresh-otp` on `ob-bastion-setup` and `ob-backend-setup` writes:

```
# /etc/sudoers.d/open-bastion
Defaults:%open-bastion-sudo timestamp_timeout=0
%open-bastion-sudo ALL=(ALL) ALL
```

Scoped to the SSO group, so local break-glass admins keep normal `sudo` behaviour — as the issue proposes.

**It is opt-in**, following the project's rule that invasive hardening is opted into rather than out of. Making it the default would start prompting on every `sudo` across an upgraded fleet, including inside scripts and long maintenance sessions, which is a behaviour change no operator asked for.

## Implementation notes

- The sudoers writer is split into `render_open_bastion_sudoers` (pure, testable without root) and `write_open_bastion_sudoers` (validates and installs), the same shape in both setup scripts.
- On a host that **already** has the drop-in, the flag only *adds* the `Defaults:` line and leaves the rest as the operator wrote it. Previously the whole block was skipped whenever the file existed, so an operator enabling this on an existing host would have got nothing.
- The result is still `visudo -cf` validated before installation, and the existing file is backed up first.
- `--dry-run` and the Mode E summary both report the state.

## Documentation

`doc/pam-modes.md` already described the trade-off (added in #227); it now names the supported way to close it, and **drops a wrong claim** that the setups regenerate the drop-in on every run — they only write it when absent, which is why the manual `open-bastion-local` workaround it suggested was never actually necessary.

EBIOS risk **R-S16** gains the same precision in French, with the flag stated as the condition for the literal Mode E claim.

## Tests

```
$ bash tests/test_ob_bastion_setup.sh   → 25/25   (+ fresh-OTP opt-in)
$ bash tests/test_ob_backend_setup.sh   → 21/21   (+ fresh-OTP opt-in)
$ bash tests/test_ob_pam_stacks.sh      → 28/28
```

The new case asserts both renderings, that the default carries no `timestamp_timeout` at all, that the flag is in `--help`, and — where `visudo` is available — that the opt-in drop-in parses.

https://claude.ai/code/session_011q88Fs4nFuUs7JMvmgbBTN