### PR TITLE
docs(llng): ship and document the locationRules for /device and /ssh admin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,65 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- **The portal `locationRules` that guard `/device` and the SSH CA admin routes
+  are now shipped and documented (#195).** Where the authorization for these
+  routes lives depends on the plugin version, and the two regimes fail in
+  opposite directions, so the guide states both:
+
+  - **Plugins ≤ `v0.5.2`** (every released version): the ssh-ca plugin performs
+    no authorization on `/ssh/admin`, `/ssh/certs` and `/ssh/revoke`. The vhost
+    rule is the only control, and without it any SSO account can list every
+    issued certificate and revoke anyone's — an org-wide SSH outage.
+  - **Plugins ≥ `0.6.0`**: `sshCaAdminRule` is the plugin's own control and it
+    is fail-closed. Unset, the three routes answer 403 to everyone, including
+    the users `locationRules` would let through — so a portal configured with
+    the vhost rule alone loses its admin UI on upgrade, incident handling
+    included. Both `docker-demo-cert` and `docker-demo-maxsec` now set
+    `sshCaAdminRule` alongside the vhost rules, so the demos keep working across
+    the version boundary.
+
+  `/device` is documented as the two layers it actually has:
+  `oidcRPMetaDataOptionsAllowDeviceAuthorization` is a `boolOrExpr` evaluated on
+  the approval **decision** per relying party — `= 1` is an activation flag, not
+  a permission, but any other value is compiled and evaluated against the
+  session — while `locationRules` on `^/device` gates the **page** for every RP
+  at once. The guide previously mentioned only the vhost layer, which is the
+  weaker of the two.
+
+  The two traps the guide calls out are real, but the mechanism given for each
+  was wrong and is corrected here. `^/device$` does **not** fail to fire: the
+  approval form posts to `PORTAL_URL/device` with `user_code` and `action` in
+  the body, so `REQUEST_URI` is `/device` and an anchored rule matches the
+  decision. What it misses is the page (`/device?user_code=...`) and a crafted
+  `POST /device?user_code=…&action=approve`. And restricting `/ssh/revoked` does
+  **not** break fleet-wide revocation propagation: backends fetch the KRL with
+  an anonymous `curl`, and a request with no session never reaches `grant()` —
+  it is served by the plugin's unauthenticated route. The real cost is a 403 on
+  a KRL fetch made with a session, by an administrator in a browser. The
+  `(\?|/|$)` guard is right either way.
+
+  `tests/test_ob_llng_location_rules.sh` pins all of it. The `/device` check now
+  compiles the rule and runs the page, decision and query-string-POST URIs
+  through it, replacing a textual heuristic that both skipped an anchored form
+  hidden inside an alternation and rejected a safe `^/device(\?.*)?$`. The
+  route-separation check gained `/ssh/adminfoo`, `/ssh/certsx` and
+  `/ssh/revoketoo`, so weakening one alternative cannot pass on the strength of
+  the others. A new check requires `sshCaAdminRule` wherever `sshCaActivation`
+  is on. And the drift check covers all four copies of the normative content —
+  the guide, both EBIOS documents and this file — instead of the guide alone.
+
+  The group names in the examples (`ob-approvers`, `ob-ssh-admins`) exist
+  nowhere in the shipped configuration: the guide now says to substitute your
+  own and to check they appear in the session, because a rule naming a group
+  nobody holds returns 403 for everyone and looks exactly like a rule that
+  works. The `lmConf-<n>.json` snippet is shown as a complete object to be
+  merged into the existing `locationRules`, since a second top-level
+  `locationRules` silently replaces the first. And the Manager table warns to
+  copy from the rendered page: pasted from the raw Markdown, the escaped `\|`
+  becomes a literal pipe in the compiled regexp, the key matches nothing,
+  `grant()` falls through to `default: accept`, and the admin routes stay open
+  with no error anywhere.
+
 - **Certificate-mode sshd PAM stacks now refuse password authentication
   (#180).** The `auth` path of the stacks written for the certificate/SSH-key
   modes consisted of a single `auth required pam_permit.so`, so

--- a/doc/llng-configuration.md
+++ b/doc/llng-configuration.md
@@ -147,6 +147,56 @@ device-authorization tuning, and SSH CA — are listed in a separate reference
 page: **[LemonLDAP::NG Plugin Parameters](llng-plugin-parameters.md)**. The
 defaults are fine for a standard setup.
 
+## Step 3b: Restrict `/device` and the SSH CA admin routes (REQUIRED)
+
+Two sets of portal routes are protected by **`locationRules` on the portal
+vhost** and by nothing else. Neither plugin enforces authorization on them, so a
+portal without these rules lets **any authenticated SSO user** use them.
+
+| Route                                    | Without a rule, any SSO user can…                                                  |
+| ---------------------------------------- | ---------------------------------------------------------------------------------- |
+| `/device`                                | approve or refuse a pending host enrolment — the "administrator approval" step      |
+| `/ssh/admin`, `/ssh/certs`, `/ssh/revoke` | list every issued certificate, and **revoke anyone's** — an org-wide SSH outage     |
+
+`oidcRPMetaDataOptionsAllowDeviceAuthorization = 1` means "any authenticated
+user may approve"; the value is not a permission in itself. The ssh-ca plugin
+performs no check at all on its admin routes and says so in a source comment.
+
+In the Manager, under **Virtual Hosts → your portal host → Rules**, add:
+
+| Regexp                             | Rule                                     |
+| ---------------------------------- | ---------------------------------------- |
+| `^/device`                         | `$groups =~ /\bob-approvers\b/`          |
+| `^/ssh/(admin\|certs\|revoke)(\?\|/\|$)` | `$groups =~ /\bob-ssh-admins\b/`         |
+
+Or, in `lmConf-<n>.json`:
+
+```json
+"locationRules": {
+  "auth.example.com": {
+    "^/device": "$groups =~ /\\bob-approvers\\b/",
+    "^/ssh/(admin|certs|revoke)(\\?|/|$)": "$groups =~ /\\bob-ssh-admins\\b/",
+    "default": "accept"
+  }
+}
+```
+
+Three details that are easy to get wrong:
+
+- **Do not anchor `/device` with `$`.** `grant()` matches against
+  `REQUEST_URI`, which carries the query string, so `^/device$` would not match
+  `/device?user_code=ABCD-EFGH` and the rule would never fire.
+- **Do not write `^/ssh/revoke` on its own.** It also matches `/ssh/revoked`,
+  the **public KRL** every backend downloads on a timer. Restricting that route
+  breaks revocation propagation fleet-wide. The `(\?|/|$)` group above is what
+  keeps them apart.
+- **Leave the user routes alone.** `/ssh/sign`, `/ssh/mycerts`, `/ssh/myrevoke`
+  and `/ssh` are the ordinary user's own certificate operations, and `/ssh/ca`
+  and `/ssh/revoked` are public by design.
+
+The shipped `docker-demo-cert` and `docker-demo-maxsec` configurations carry
+both rules (scoped to the demo user `dwho`) as a working example.
+
 ## Step 4: Generate and Import the SSH CA Key (optional)
 
 If you're using the SSH CA plugin for key-based authentication, you need to generate a CA key pair and import it into LemonLDAP::NG.

--- a/doc/llng-configuration.md
+++ b/doc/llng-configuration.md
@@ -147,55 +147,103 @@ device-authorization tuning, and SSH CA — are listed in a separate reference
 page: **[LemonLDAP::NG Plugin Parameters](llng-plugin-parameters.md)**. The
 defaults are fine for a standard setup.
 
-## Step 3b: Restrict `/device` and the SSH CA admin routes (REQUIRED)
+## Step 3b: Restrict `/device` and the SSH CA admin routes (required)
 
-Two sets of portal routes are protected by **`locationRules` on the portal
-vhost** and by nothing else. Neither plugin enforces authorization on them, so a
-portal without these rules lets **any authenticated SSO user** use them.
+Two sets of portal routes decide who may approve a host enrolment and who may
+revoke certificates. Where the authorization for them lives **depends on the
+plugin version**, and the two regimes fail in opposite directions:
 
-| Route                                    | Without a rule, any SSO user can…                                                  |
-| ---------------------------------------- | ---------------------------------------------------------------------------------- |
-| `/device`                                | approve or refuse a pending host enrolment — the "administrator approval" step      |
-| `/ssh/admin`, `/ssh/certs`, `/ssh/revoke` | list every issued certificate, and **revoke anyone's** — an org-wide SSH outage     |
+| Plugin version | `/ssh/admin`, `/ssh/certs`, `/ssh/revoke`                                           | If you configure nothing                                                                                   |
+| -------------- | ----------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| **≤ `v0.5.2`** | No check in the plugin. `locationRules` on the portal vhost is the **only** control | **Any authenticated SSO user** can list and revoke everyone's certificates — an org-wide SSH outage        |
+| **≥ `0.6.0`**  | `sshCaAdminRule` in the plugin, **fail-closed**                                     | **Nobody** administers: all three routes return 403, including the users `locationRules` would let through |
 
-`oidcRPMetaDataOptionsAllowDeviceAuthorization = 1` means "any authenticated
-user may approve"; the value is not a permission in itself. The ssh-ca plugin
-performs no check at all on its admin routes and says so in a source comment.
+Set both. `locationRules` is required today and remains defence in depth
+afterwards; `sshCaAdminRule` is the control from `0.6.0` on. Configuring only
+the vhost rule leaves a `0.6.0` portal with no working admin UI — including for
+the operator handling an incident.
 
-In the Manager, under **Virtual Hosts → your portal host → Rules**, add:
+`/device` is a separate story: the `oidc-device-authorization` plugin **does**
+carry a native control, and it has two layers that do different jobs.
 
-| Regexp                             | Rule                                     |
-| ---------------------------------- | ---------------------------------------- |
-| `^/device`                         | `$groups =~ /\bob-approvers\b/`          |
-| `^/ssh/(admin\|certs\|revoke)(\?\|/\|$)` | `$groups =~ /\bob-ssh-admins\b/`         |
+| Layer                                           | What it gates                                                                                                                                     |
+| ----------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `oidcRPMetaDataOptionsAllowDeviceAuthorization` | The **approval decision**, per relying party. It is a `boolOrExpr`: any value other than `1` is compiled and evaluated against the user's session |
+| `locationRules` on `^/device`                   | The **page**, for every RP at once                                                                                                                |
 
-Or, in `lmConf-<n>.json`:
+`= 1` means "any authenticated user may approve" — an activation flag, not a
+permission. Prefer the expression form when approvers differ per RP
+(`$groups =~ /\bdeviceadmins\b/`), and keep the vhost rule as the outer gate.
+
+### The vhost rules
+
+In the Manager, under **Virtual Hosts → your portal host → Access rules**, add:
+
+| Regexp                                   | Rule                             |
+| ---------------------------------------- | -------------------------------- |
+| `^/device`                               | `$groups =~ /\bob-approvers\b/`  |
+| `^/ssh/(admin\|certs\|revoke)(\?\|/\|$)` | `$groups =~ /\bob-ssh-admins\b/` |
+
+> **Copy these from the rendered page, not from the raw Markdown.** The `\|`
+> above is Markdown table escaping. Pasted literally into a rule, `\|` is a
+> **literal pipe** in the compiled Perl regexp: the alternation stops being an
+> alternation, the key matches nothing, `grant()` falls through to
+> `default: accept`, and the admin routes stay open to every SSO user — with no
+> error anywhere.
+
+`ob-approvers` and `ob-ssh-admins` are placeholders: **substitute your own
+groups**, and check they actually appear in the session (Manager → Sessions, or
+`$groups` in a test rule). A rule naming a group nobody has is a rule that
+returns 403 for everyone, which looks exactly like a rule that works.
+
+Or, in `lmConf-<n>.json`. These keys go **inside the existing `locationRules`
+object**, under your portal's own vhost key — a `locationRules` pasted as a
+second top-level key silently replaces the first, and your existing rules go
+with it:
 
 ```json
-"locationRules": {
-  "auth.example.com": {
-    "^/device": "$groups =~ /\\bob-approvers\\b/",
-    "^/ssh/(admin|certs|revoke)(\\?|/|$)": "$groups =~ /\\bob-ssh-admins\\b/",
-    "default": "accept"
+{
+  "locationRules": {
+    "auth.example.com": {
+      "^/device": "$groups =~ /\\bob-approvers\\b/",
+      "^/ssh/(admin|certs|revoke)(\\?|/|$)": "$groups =~ /\\bob-ssh-admins\\b/",
+      "default": "accept"
+    }
   }
 }
 ```
 
-Three details that are easy to get wrong:
+And, from `0.6.0`, the plugin-side rule (Manager → Plugins → SSH CA, or
+`"sshCaAdminRule"` in `lmConf-<n>.json`):
 
-- **Do not anchor `/device` with `$`.** `grant()` matches against
-  `REQUEST_URI`, which carries the query string, so `^/device$` would not match
-  `/device?user_code=ABCD-EFGH` and the rule would never fire.
+```json
+"sshCaAdminRule": "$groups =~ /\\bob-ssh-admins\\b/"
+```
+
+### Three details that are easy to get wrong
+
+- **Do not anchor `/device` with `$`.** Not for the reason you might expect: the
+  approval form posts to `PORTAL_URL/device` with `user_code` and `action` in
+  the **body**, so `REQUEST_URI` is `/device` and `^/device$` does match the
+  decision. What it misses is the **page** — `/device?user_code=ABCD-EFGH`
+  carries a query string, `grant()` matches against `REQUEST_URI`, and an
+  anchored rule lets that GET through ungated. It also lets through a crafted
+  `POST /device?user_code=…&action=approve`. Leave the rule unanchored and both
+  are covered.
 - **Do not write `^/ssh/revoke` on its own.** It also matches `/ssh/revoked`,
-  the **public KRL** every backend downloads on a timer. Restricting that route
-  breaks revocation propagation fleet-wide. The `(\?|/|$)` group above is what
-  keeps them apart.
+  the **public KRL**. This does not break fleet-wide propagation — backends
+  fetch the KRL with an anonymous `curl`, and a request with no session never
+  reaches `grant()` at all: it is served by the plugin's unauthenticated route.
+  What it does break is a KRL fetch made **with** a session — an administrator
+  in a browser gets a 403. The `(\?|/|$)` group above keeps the two routes
+  apart, which is the right hygiene either way.
 - **Leave the user routes alone.** `/ssh/sign`, `/ssh/mycerts`, `/ssh/myrevoke`
   and `/ssh` are the ordinary user's own certificate operations, and `/ssh/ca`
   and `/ssh/revoked` are public by design.
 
-The shipped `docker-demo-cert` and `docker-demo-maxsec` configurations carry
-both rules (scoped to the demo user `dwho`) as a working example.
+The shipped `docker-demo-cert` and `docker-demo-maxsec` configurations carry the
+vhost rules and `sshCaAdminRule`, scoped to the demo user `dwho`, as a working
+example on both plugin versions.
 
 ## Step 4: Generate and Import the SSH CA Key (optional)
 

--- a/doc/security/01-enrollment.md
+++ b/doc/security/01-enrollment.md
@@ -795,7 +795,26 @@ openssl s_client -connect auth.example.com:443 2>/dev/null | \
 
 **Remédiation configuration (côté LLNG) :**
 
-- Restreindre qui peut approuver les enrôlements (ACL sur `/device`)
+- Restreindre qui peut approuver les enrôlements par une `locationRules` sur le
+  vhost du portail. `oidcRPMetaDataOptionsAllowDeviceAuthorization = 1` signifie
+  « tout utilisateur authentifié » : la valeur n'est pas une permission, la règle
+  est le seul contrôle. Dans le Manager (Virtual Hosts → portail → Rules), ou
+  dans `lmConf-<n>.json` :
+
+  ```json
+  "locationRules": {
+    "auth.example.com": {
+      "^/device": "$groups =~ /\\bob-approvers\\b/",
+      "default": "accept"
+    }
+  }
+  ```
+
+  **Ne pas ancrer la fin** (`^/device$`) : `grant()` compare à `REQUEST_URI`, qui
+  porte la query string, si bien que la règle ne se déclencherait jamais sur
+  `/device?user_code=ABCD-EFGH`. Voir
+  [doc/llng-configuration.md](../llng-configuration.md#step-3b-restrict-device-and-the-ssh-ca-admin-routes-required)
+  pour la règle jumelle sur les routes d'administration `ssh-ca`.
 - Activer les notifications lors des approbations
 - Audit log des enrôlements avec IP source
 - Rotation périodique du `client_secret`
@@ -1467,6 +1486,12 @@ flowchart TB
 - [ ] `client_secret` stocké dans `/etc/open-bastion/openbastion.conf` (pas en CLI)
 - [ ] Fichier de config en permissions 0600
 - [ ] Accès au Manager LLNG restreint (risque : accès à la clé privée SSH CA)
+- [ ] **`locationRules` sur `^/device` déployée** et vérifiée (voir ci-dessous) —
+      sans elle, **tout utilisateur SSO authentifié** peut approuver un
+      enrôlement : la « two-person rule » n'existe pas
+- [ ] **`locationRules` sur `^/ssh/(admin|certs|revoke)(\?|/|$)` déployée** si le
+      plugin ssh-ca est activé — sans elle, tout utilisateur SSO peut lister
+      tous les certificats et **révoquer ceux de n'importe qui**
 - [ ] Canal de communication sécurisé avec l'administrateur LLNG établi
 - [ ] Administrateur LLNG disponible et prévenu
 

--- a/doc/security/01-enrollment.md
+++ b/doc/security/01-enrollment.md
@@ -795,11 +795,20 @@ openssl s_client -connect auth.example.com:443 2>/dev/null | \
 
 **Remédiation configuration (côté LLNG) :**
 
-- Restreindre qui peut approuver les enrôlements par une `locationRules` sur le
-  vhost du portail. `oidcRPMetaDataOptionsAllowDeviceAuthorization = 1` signifie
-  « tout utilisateur authentifié » : la valeur n'est pas une permission, la règle
-  est le seul contrôle. Dans le Manager (Virtual Hosts → portail → Rules), ou
-  dans `lmConf-<n>.json` :
+- Restreindre qui peut approuver les enrôlements. Il y a **deux couches**, et
+  elles ne gardent pas la même chose :
+  1. `oidcRPMetaDataOptionsAllowDeviceAuthorization` est un `boolOrExpr` évalué
+     sur la **décision** d'approbation, par RP. `= 1` signifie « tout
+     utilisateur authentifié peut approuver » — c'est un drapeau d'activation,
+     pas une permission ; toute autre valeur est compilée et évaluée contre la
+     session (`$groups =~ /\\bdeviceadmins\\b/`). C'est la couche à préférer
+     quand les approbateurs diffèrent d'un RP à l'autre.
+  2. Une `locationRules` sur `^/device` garde la **page**, pour tous les RP à la
+     fois. Elle reste utile comme porte extérieure, et elle est le seul contrôle
+     si l'option ci-dessus est laissée à `1`.
+
+  Dans le Manager (Virtual Hosts → portail → Access rules), ou dans
+  `lmConf-<n>.json`, en fusionnant dans l'objet `locationRules` existant :
 
   ```json
   "locationRules": {
@@ -810,11 +819,16 @@ openssl s_client -connect auth.example.com:443 2>/dev/null | \
   }
   ```
 
-  **Ne pas ancrer la fin** (`^/device$`) : `grant()` compare à `REQUEST_URI`, qui
-  porte la query string, si bien que la règle ne se déclencherait jamais sur
-  `/device?user_code=ABCD-EFGH`. Voir
+  **Ne pas ancrer la fin** (`^/device$`) — mais pas pour la raison qu'on croit :
+  le formulaire d'approbation poste sur `PORTAL_URL/device` avec `user_code` et
+  `action` dans le **corps**, donc `REQUEST_URI` vaut `/device` et une règle
+  ancrée matche bien la décision. Ce qu'elle laisse passer, c'est la **page**
+  `/device?user_code=ABCD-EFGH` — `grant()` compare à `REQUEST_URI`, qui porte
+  la query string — ainsi qu'un `POST /device?user_code=…&action=approve`
+  fabriqué. Une règle non ancrée couvre les deux. Voir
   [doc/llng-configuration.md](../llng-configuration.md#step-3b-restrict-device-and-the-ssh-ca-admin-routes-required)
   pour la règle jumelle sur les routes d'administration `ssh-ca`.
+
 - Activer les notifications lors des approbations
 - Audit log des enrôlements avec IP source
 - Rotation périodique du `client_secret`

--- a/doc/security/02-ssh-connection.md
+++ b/doc/security/02-ssh-connection.md
@@ -1456,6 +1456,14 @@ Contrairement à R-S19 (recorder tué) et R-S20 (action différée), ici le reco
 - [ ] `AuthorizedPrincipalsCommand /usr/local/sbin/ob-ssh-principals %u %f %i` dans sshd_config des backends
 - [ ] `/etc/open-bastion/allowed_bastions` configuré sur les backends (via `ob-backend-setup --allowed-bastions <client_ids>`)
 - [ ] Plugin `ssh-ca` LLNG actif (`sshCaActivation=1`)
+- [ ] **`locationRules` sur `^/ssh/(admin|certs|revoke)(\?|/|$)` déployée** sur le
+      vhost du portail : le plugin `ssh-ca` n'effectue **aucun** contrôle
+      d'autorisation sur ces routes, donc sans règle tout utilisateur SSO
+      authentifié liste tous les certificats émis et **révoque ceux de
+      n'importe qui** (panne SSH à l'échelle de l'organisation).
+      Attention à ne pas écrire `^/ssh/revoke` seul : cela capture aussi
+      `/ssh/revoked`, la KRL **publique** que chaque backend télécharge — la
+      restreindre casserait la propagation des révocations.
 - [ ] Socket Unix `/run/open-bastion/cert.sock` servi par `ob-cert-daemon` systemd socket-activated sur le bastion
 - [ ] Restriction réseau : backends accessibles uniquement depuis le bastion
 - [ ] `pamAccessBastionGroups` configuré côté LLNG (groupes autorisés à voucher, défaut : bastion)

--- a/doc/security/02-ssh-connection.md
+++ b/doc/security/02-ssh-connection.md
@@ -1457,13 +1457,26 @@ Contrairement à R-S19 (recorder tué) et R-S20 (action différée), ici le reco
 - [ ] `/etc/open-bastion/allowed_bastions` configuré sur les backends (via `ob-backend-setup --allowed-bastions <client_ids>`)
 - [ ] Plugin `ssh-ca` LLNG actif (`sshCaActivation=1`)
 - [ ] **`locationRules` sur `^/ssh/(admin|certs|revoke)(\?|/|$)` déployée** sur le
-      vhost du portail : le plugin `ssh-ca` n'effectue **aucun** contrôle
-      d'autorisation sur ces routes, donc sans règle tout utilisateur SSO
-      authentifié liste tous les certificats émis et **révoque ceux de
-      n'importe qui** (panne SSH à l'échelle de l'organisation).
+      vhost du portail. Ce que ce contrôle recouvre dépend de la version du
+      plugin, et les deux régimes échouent en sens inverse : - **≤ `v0.5.2`** (versions publiées) : le plugin n'effectue **aucun**
+      contrôle d'autorisation sur ces routes, la règle est le **seul**
+      contrôle, et sans elle tout utilisateur SSO authentifié liste tous les
+      certificats émis et **révoque ceux de n'importe qui** (panne SSH à
+      l'échelle de l'organisation). - **≥ `0.6.0`** : `sshCaAdminRule` est le contrôle intégré, et il est
+      **fail-closed** — non défini, les trois routes répondent 403 y compris
+      aux utilisateurs que la `locationRules` admettrait. Vérifier alors
+      **les deux** : `sshCaAdminRule` renseigné (sinon personne n'administre,
+      pas même en incident), et la `locationRules` conservée en défense en
+      profondeur.
+
       Attention à ne pas écrire `^/ssh/revoke` seul : cela capture aussi
-      `/ssh/revoked`, la KRL **publique** que chaque backend télécharge — la
-      restreindre casserait la propagation des révocations.
+      `/ssh/revoked`, la KRL **publique** que chaque backend télécharge. Cela ne
+      casse pas la propagation des révocations — les backends la tirent en
+      `curl` anonyme, et une requête sans session n'atteint jamais `grant()` :
+      elle est servie par la route non authentifiée du plugin. Ce que cela casse,
+      c'est un téléchargement fait **avec** une session (un administrateur en
+      navigateur), qui reçoit un 403.
+
 - [ ] Socket Unix `/run/open-bastion/cert.sock` servi par `ob-cert-daemon` systemd socket-activated sur le bastion
 - [ ] Restriction réseau : backends accessibles uniquement depuis le bastion
 - [ ] `pamAccessBastionGroups` configuré côté LLNG (groupes autorisés à voucher, défaut : bastion)

--- a/docker-demo-cert/lmConf-1.json
+++ b/docker-demo-cert/lmConf-1.json
@@ -164,6 +164,7 @@
   "pamAccessOfflineTtl": 86400,
 
   "sshCaActivation": 1,
+  "sshCaAdminRule": "$uid eq 'dwho'",
   "sshCaKeyType": "ed25519",
   "sshCaKeyRef": "ssh-ca",
   "sshCaCertDefaultValidity": 60,

--- a/docker-demo-cert/lmConf-1.json
+++ b/docker-demo-cert/lmConf-1.json
@@ -40,14 +40,17 @@
   "locationRules": {
     "auth.example.com": {
       "^/device": "$uid eq 'dwho'",
+      "^/ssh/(admin|certs|revoke)(\\?|/|$)": "$uid eq 'dwho'",
       "default": "accept"
     },
     "localhost": {
       "^/device": "$uid eq 'dwho'",
+      "^/ssh/(admin|certs|revoke)(\\?|/|$)": "$uid eq 'dwho'",
       "default": "accept"
     },
     "sso": {
       "^/device": "$uid eq 'dwho'",
+      "^/ssh/(admin|certs|revoke)(\\?|/|$)": "$uid eq 'dwho'",
       "default": "accept"
     }
   },

--- a/docker-demo-maxsec/lmConf-1.json
+++ b/docker-demo-maxsec/lmConf-1.json
@@ -164,6 +164,7 @@
   "pamAccessOfflineTtl": 86400,
 
   "sshCaActivation": 1,
+  "sshCaAdminRule": "$uid eq 'dwho'",
   "sshCaKeyType": "ed25519",
   "sshCaKeyRef": "ssh-ca",
   "sshCaCertDefaultValidity": 60,

--- a/docker-demo-maxsec/lmConf-1.json
+++ b/docker-demo-maxsec/lmConf-1.json
@@ -40,14 +40,17 @@
   "locationRules": {
     "auth.example.com": {
       "^/device": "$uid eq 'dwho'",
+      "^/ssh/(admin|certs|revoke)(\\?|/|$)": "$uid eq 'dwho'",
       "default": "accept"
     },
     "localhost": {
       "^/device": "$uid eq 'dwho'",
+      "^/ssh/(admin|certs|revoke)(\\?|/|$)": "$uid eq 'dwho'",
       "default": "accept"
     },
     "sso": {
       "^/device": "$uid eq 'dwho'",
+      "^/ssh/(admin|certs|revoke)(\\?|/|$)": "$uid eq 'dwho'",
       "default": "accept"
     }
   },

--- a/tests/test_ob_llng_location_rules.sh
+++ b/tests/test_ob_llng_location_rules.sh
@@ -89,26 +89,49 @@ PY
     fi
 }
 
-# ── Test 3: no /device rule is anchored with $ ──
-# `^/device$` would not match /device?user_code=..., so the rule would never
-# fire and the enrolment approval would stay open to every SSO user.
-test_device_rule_not_end_anchored() {
+# ── Test 3: the /device rule covers the page, not just the decision ──
+# `grant()` matches against REQUEST_URI, which carries the query string. The
+# approval form posts to PORTAL_URL/device with user_code and action in the
+# BODY (device.tpl), so REQUEST_URI is "/device" there and an end-anchored
+# `^/device$` does match the decision -- the trap is not that the rule never
+# fires. What an anchored rule misses is the page itself
+# (/device?user_code=...) and a crafted POST carrying the same parameters in
+# the query string: both go through ungated.
+#
+# Asserted by compiling the rule and running URIs through it, not by
+# pattern-matching the rule text. The textual heuristic this replaces had two
+# blind spots: it skipped any rule containing "|", so an anchored form hidden
+# in an alternation passed, and it rejected a safe `^/device(\?.*)?$` because
+# that ends with "$".
+test_device_rule_covers_page_and_decision() {
     local bad="" c
     for c in "${ALL_CONFIGS[@]}"; do
-        python3 - "$ROOT_DIR/$c" <<'PY' || bad="$bad $c"
-import json, sys
+        python3 - "$ROOT_DIR/$c" <<'PYEOF' || bad="$bad $c"
+import json, re, sys
+
+MUST_MATCH = [
+    "/device",                                     # the decision POST
+    "/device?user_code=ABCD-EFGH",                 # the page GET
+    "/device?user_code=ABCD-EFGH&action=approve",  # a crafted POST
+]
+
 conf = json.load(open(sys.argv[1]))
-for host_rules in conf.get("locationRules", {}).values():
-    for k in host_rules:
-        if k.startswith("^/device") and k.rstrip().endswith("$") and "|" not in k:
-            sys.exit(1)
+for host, host_rules in conf.get("locationRules", {}).items():
+    for pattern in host_rules:
+        if not pattern.startswith("^/device"):
+            continue
+        rx = re.compile(pattern)
+        for uri in MUST_MATCH:
+            if not rx.search(uri):
+                print(f"{host}: {pattern} fails to match {uri}", file=sys.stderr)
+                sys.exit(1)
 sys.exit(0)
-PY
+PYEOF
     done
     if [ -z "$bad" ]; then
-        pass "no ^/device rule is end-anchored (REQUEST_URI carries the query)"
+        pass "^/device rule matches the page, the decision and a query-string POST"
     else
-        fail "no ^/device rule is end-anchored" "offenders:$bad"
+        fail "^/device rule covers page and decision" "offenders:$bad"
     fi
 }
 
@@ -149,7 +172,11 @@ MUST_NOT   = ["/ssh/revoked",          # public KRL, downloaded by every backend
               "/ssh/ca",               # public CA key
               "/ssh/sign",             # the user's own certificate request
               "/ssh/mycerts", "/ssh/myrevoke",
-              "/ssh"]                  # the signing interface
+              "/ssh",                  # the signing interface
+              # Weakening one alternative must not pass because the others
+              # hold: `^/ssh/(admin\w*|certs|revoke)(\?|/|$)` would restrict a
+              # page served by the `*` leaf and otherwise go green.
+              "/ssh/adminfoo", "/ssh/certsx", "/ssh/revoketoo"]
 
 conf = json.load(open(sys.argv[1]))
 for host, host_rules in conf.get("locationRules", {}).items():
@@ -175,27 +202,83 @@ PY
     fi
 }
 
-# ── Test 6: the documentation ships the same rules ──
-# The production deployment is an operator's own portal, which this repository
-# does not configure; the guide is the deliverable, so it must not drift.
-test_documented() {
-    local doc="$ROOT_DIR/doc/llng-configuration.md" ok=1
-    grep -q '\^/device' "$doc" || { ok=0; echo "    (no ^/device rule documented)"; }
-    grep -q 'admin|certs|revoke' "$doc" || { ok=0; echo "    (no ^/ssh admin rule documented)"; }
-    grep -q '/ssh/revoked' "$doc" || { ok=0; echo "    (the /ssh/revoked trap is not called out)"; }
-    if [ "$ok" -eq 1 ]; then
-        pass "doc/llng-configuration.md documents both rules and the KRL trap"
+# ── Test 6: the shipped configs carry the plugin-side admin rule ──
+# From plugin 0.6.0 the ssh-ca admin routes are fail-closed on
+# `sshCaAdminRule`: unset, /ssh/admin, /ssh/certs and /ssh/revoke answer 403 to
+# everyone, including the users the vhost locationRules would let through. A
+# demo that ships the vhost rule alone stops demonstrating the admin flow the
+# day the portal image moves to 0.6.0, and does so silently.
+test_ssh_admin_plugin_rule_present() {
+    local bad="" c
+    for c in "${SSHCA_CONFIGS[@]}"; do
+        python3 - "$ROOT_DIR/$c" <<'PYEOF' || bad="$bad $c"
+import json, sys
+conf = json.load(open(sys.argv[1]))
+if not conf.get("sshCaActivation"):
+    sys.exit(0)   # plugin off: no admin routes to guard
+rule = (conf.get("sshCaAdminRule") or "").strip()
+sys.exit(0 if rule and rule != "0" else 1)
+PYEOF
+    done
+    if [ -z "$bad" ]; then
+        pass "ssh-ca configs set sshCaAdminRule (fail-closed from plugin 0.6.0)"
     else
-        fail "doc/llng-configuration.md documents both rules"
+        fail "ssh-ca configs set sshCaAdminRule" "missing:$bad"
+    fi
+}
+
+# ── Test 7: the documentation ships the same rules, in every copy ──
+# The production deployment is an operator's own portal, which this repository
+# does not configure; the guide is the deliverable, so it must not drift. The
+# same normative content lives in four places, and checking only one of them
+# lets the other three rot -- an `^/device$` example copied into a security
+# checklist would have gone green.
+test_documented() {
+    local ok=1 f
+    local guide="$ROOT_DIR/doc/llng-configuration.md"
+
+    grep -q '\^/device' "$guide" || { ok=0; echo "    (no ^/device rule documented)"; }
+    grep -q 'admin|certs|revoke' "$guide" || { ok=0; echo "    (no ^/ssh admin rule documented)"; }
+    grep -q '/ssh/revoked' "$guide" || { ok=0; echo "    (the /ssh/revoked trap is not called out)"; }
+    grep -q 'sshCaAdminRule' "$guide" || { ok=0; echo "    (sshCaAdminRule is not documented)"; }
+
+    # No copy may show an end-anchored /device rule as a rule. Matched on the
+    # quoted JSON key form so the prose explaining WHY it is wrong -- which has
+    # to name `^/device$` -- does not trip the check.
+    for f in doc/llng-configuration.md doc/security/01-enrollment.md \
+             doc/security/02-ssh-connection.md CHANGELOG.md; do
+        if grep -qE '"\^/device[^"]*\$"' "$ROOT_DIR/$f"; then
+            ok=0; echo "    ($f shows an end-anchored ^/device rule)"
+        fi
+    done
+
+    # Wherever the ssh admin rule appears, it keeps its (\?|/|$) guard: without
+    # it the rule swallows /ssh/revoked, the public KRL. Two spellings reach
+    # here: the JSON form `(\?|/|$)` and the Markdown table form
+    # `(\?\|/\|$)`, whose pipes are escaped for the cell separator, so the
+    # tail of either is matched as a fixed string.
+    for f in doc/llng-configuration.md doc/security/01-enrollment.md \
+             doc/security/02-ssh-connection.md CHANGELOG.md; do
+        if grep -q 'admin|certs|revoke' "$ROOT_DIR/$f" \
+           && ! grep -qF -e '|/|$)' -e '\|/\|$)' "$ROOT_DIR/$f"; then
+            ok=0; echo "    ($f shows the ssh admin rule without its (\?|/|\$) guard)"
+        fi
+    done
+
+    if [ "$ok" -eq 1 ]; then
+        pass "all four copies document the rules, unanchored and guarded"
+    else
+        fail "documentation copies agree"
     fi
 }
 
 echo "=== LLNG portal locationRules (#195) ==="
 run_test test_configs_are_valid_json
 run_test test_device_rule_present
-run_test test_device_rule_not_end_anchored
+run_test test_device_rule_covers_page_and_decision
 run_test test_ssh_admin_rule_present
 run_test test_ssh_rule_separates_routes
+run_test test_ssh_admin_plugin_rule_present
 run_test test_documented
 
 echo ""

--- a/tests/test_ob_llng_location_rules.sh
+++ b/tests/test_ob_llng_location_rules.sh
@@ -1,0 +1,203 @@
+#!/bin/bash
+#
+# Guards the portal locationRules that are the ONLY authorization on two sets of
+# routes (#195):
+#
+#   /device                        — approve or refuse a host enrolment.
+#                                    oidcRPMetaDataOptionsAllowDeviceAuthorization=1
+#                                    means "any authenticated user", so the rule
+#                                    is the whole control.
+#   /ssh/admin, /ssh/certs,        — list every issued certificate and revoke
+#   /ssh/revoke                      anyone's. The ssh-ca plugin performs no
+#                                    authorization on them at all.
+#
+# Two ways to get these rules wrong are load-bearing, and both are silent:
+#
+#   - `^/device$` never matches, because LLNG's grant() matches REQUEST_URI,
+#     which carries the query string (`/device?user_code=...`).
+#   - `^/ssh/revoke` also matches `/ssh/revoked`, the PUBLIC KRL every backend
+#     downloads on a timer. Restricting that route breaks revocation propagation
+#     fleet-wide while looking like a hardening step.
+#
+# So this test checks the shipped configurations carry the rules, and replays
+# the regexes against the real route list to prove they separate admin routes
+# from user and public ones.
+#
+
+set -uo pipefail
+
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+
+pass() { TESTS_PASSED=$((TESTS_PASSED + 1)); echo "  PASS: $1"; }
+fail() { TESTS_FAILED=$((TESTS_FAILED + 1)); echo "  FAIL: $1${2:+ - $2}"; }
+run_test() { TESTS_RUN=$((TESTS_RUN + 1)); "$@"; }
+
+# Configurations that enable the ssh-ca plugin and therefore expose the admin
+# routes. The token-only demos have no /ssh routes at all.
+SSHCA_CONFIGS=(
+    "docker-demo-cert/lmConf-1.json"
+    "docker-demo-maxsec/lmConf-1.json"
+)
+
+# Every shipped portal configuration: all of them expose /device.
+ALL_CONFIGS=(
+    "docker-demo-cert/lmConf-1.json"
+    "docker-demo-maxsec/lmConf-1.json"
+    "docker-demo-token/lmConf-1.json"
+    "docker-demo-token-svc/lmConf-1.json"
+    "quick-start/lmConf-1.json"
+)
+
+# ── Test 1: the shipped configs are valid JSON ──
+test_configs_are_valid_json() {
+    local bad="" c
+    for c in "${ALL_CONFIGS[@]}"; do
+        python3 -c "import json,sys; json.load(open(sys.argv[1]))" "$ROOT_DIR/$c" 2>/dev/null \
+            || bad="$bad $c"
+    done
+    if [ -z "$bad" ]; then
+        pass "shipped lmConf files are valid JSON"
+    else
+        fail "shipped lmConf files are valid JSON" "bad:$bad"
+    fi
+}
+
+# ── Test 2: every portal vhost restricts /device ──
+test_device_rule_present() {
+    local bad="" c
+    for c in "${ALL_CONFIGS[@]}"; do
+        python3 - "$ROOT_DIR/$c" <<'PY' || bad="$bad $c"
+import json, sys
+conf = json.load(open(sys.argv[1]))
+rules = conf.get("locationRules", {})
+if not rules:
+    sys.exit(1)
+for host, host_rules in rules.items():
+    if not any(k.startswith("^/device") for k in host_rules):
+        sys.exit(1)
+sys.exit(0)
+PY
+    done
+    if [ -z "$bad" ]; then
+        pass "every shipped portal vhost carries a ^/device rule"
+    else
+        fail "every shipped portal vhost carries a ^/device rule" "missing:$bad"
+    fi
+}
+
+# ── Test 3: no /device rule is anchored with $ ──
+# `^/device$` would not match /device?user_code=..., so the rule would never
+# fire and the enrolment approval would stay open to every SSO user.
+test_device_rule_not_end_anchored() {
+    local bad="" c
+    for c in "${ALL_CONFIGS[@]}"; do
+        python3 - "$ROOT_DIR/$c" <<'PY' || bad="$bad $c"
+import json, sys
+conf = json.load(open(sys.argv[1]))
+for host_rules in conf.get("locationRules", {}).values():
+    for k in host_rules:
+        if k.startswith("^/device") and k.rstrip().endswith("$") and "|" not in k:
+            sys.exit(1)
+sys.exit(0)
+PY
+    done
+    if [ -z "$bad" ]; then
+        pass "no ^/device rule is end-anchored (REQUEST_URI carries the query)"
+    else
+        fail "no ^/device rule is end-anchored" "offenders:$bad"
+    fi
+}
+
+# ── Test 4: ssh-ca configs restrict the admin routes ──
+test_ssh_admin_rule_present() {
+    local bad="" c
+    for c in "${SSHCA_CONFIGS[@]}"; do
+        python3 - "$ROOT_DIR/$c" <<'PY' || bad="$bad $c"
+import json, sys
+conf = json.load(open(sys.argv[1]))
+if not conf.get("sshCaActivation"):
+    sys.exit(0)   # plugin off: no /ssh routes to protect
+for host_rules in conf.get("locationRules", {}).values():
+    if not any(k.startswith("^/ssh") for k in host_rules):
+        sys.exit(1)
+sys.exit(0)
+PY
+    done
+    if [ -z "$bad" ]; then
+        pass "ssh-ca configs carry a ^/ssh admin rule on every vhost"
+    else
+        fail "ssh-ca configs carry a ^/ssh admin rule" "missing:$bad"
+    fi
+}
+
+# ── Test 5: the /ssh rule matches the admin routes and NOTHING else ──
+# This is the one that matters: /ssh/revoked is the public KRL, and /ssh/sign,
+# /ssh/mycerts, /ssh/myrevoke are ordinary user operations.
+test_ssh_rule_separates_routes() {
+    local bad="" c
+    for c in "${SSHCA_CONFIGS[@]}"; do
+        python3 - "$ROOT_DIR/$c" <<'PY' || bad="$bad $c"
+import json, re, sys
+
+MUST_MATCH = ["/ssh/admin", "/ssh/certs", "/ssh/certs?search=x",
+              "/ssh/revoke", "/ssh/revoke/42"]
+MUST_NOT   = ["/ssh/revoked",          # public KRL, downloaded by every backend
+              "/ssh/ca",               # public CA key
+              "/ssh/sign",             # the user's own certificate request
+              "/ssh/mycerts", "/ssh/myrevoke",
+              "/ssh"]                  # the signing interface
+
+conf = json.load(open(sys.argv[1]))
+for host, host_rules in conf.get("locationRules", {}).items():
+    for pattern in host_rules:
+        if not pattern.startswith("^/ssh"):
+            continue
+        rx = re.compile(pattern)
+        for uri in MUST_MATCH:
+            if not rx.search(uri):
+                print(f"{host}: {pattern} fails to match {uri}", file=sys.stderr)
+                sys.exit(1)
+        for uri in MUST_NOT:
+            if rx.search(uri):
+                print(f"{host}: {pattern} wrongly matches {uri}", file=sys.stderr)
+                sys.exit(1)
+sys.exit(0)
+PY
+    done
+    if [ -z "$bad" ]; then
+        pass "^/ssh rule covers admin routes and spares /ssh/revoked, /ssh/ca, user routes"
+    else
+        fail "^/ssh rule route separation" "wrong in:$bad"
+    fi
+}
+
+# ── Test 6: the documentation ships the same rules ──
+# The production deployment is an operator's own portal, which this repository
+# does not configure; the guide is the deliverable, so it must not drift.
+test_documented() {
+    local doc="$ROOT_DIR/doc/llng-configuration.md" ok=1
+    grep -q '\^/device' "$doc" || { ok=0; echo "    (no ^/device rule documented)"; }
+    grep -q 'admin|certs|revoke' "$doc" || { ok=0; echo "    (no ^/ssh admin rule documented)"; }
+    grep -q '/ssh/revoked' "$doc" || { ok=0; echo "    (the /ssh/revoked trap is not called out)"; }
+    if [ "$ok" -eq 1 ]; then
+        pass "doc/llng-configuration.md documents both rules and the KRL trap"
+    else
+        fail "doc/llng-configuration.md documents both rules"
+    fi
+}
+
+echo "=== LLNG portal locationRules (#195) ==="
+run_test test_configs_are_valid_json
+run_test test_device_rule_present
+run_test test_device_rule_not_end_anchored
+run_test test_ssh_admin_rule_present
+run_test test_ssh_rule_separates_routes
+run_test test_documented
+
+echo ""
+echo "Tests run: $TESTS_RUN, passed: $TESTS_PASSED, failed: $TESTS_FAILED"
+[ "$TESTS_FAILED" -eq 0 ]


### PR DESCRIPTION
Closes #195.

Two sets of portal routes are protected by a `locationRules` entry on the portal vhost **and by nothing else**:

| Route | Without a rule, any authenticated SSO user can… |
| --- | --- |
| `/device` | approve or refuse a pending host enrolment — the "administrator approval" the EBIOS study rests R0/R7 on |
| `/ssh/admin`, `/ssh/certs`, `/ssh/revoke` | list every issued certificate and **revoke anyone's** — an org-wide SSH outage |

`oidcRPMetaDataOptionsAllowDeviceAuthorization = 1` means "any authenticated user". It is not a permission. The ssh-ca plugin performs no authorization on its admin routes at all; its own source comment says `locationRules` handles it.

## What ships

- **`doc/llng-configuration.md`** — a new required Step 3b with ready-to-paste rules for both the Manager and `lmConf-<n>.json`.
- **`docker-demo-cert` and `docker-demo-maxsec`** — the two configurations that set `sshCaActivation: 1` now carry the `/ssh` rule on every vhost, next to the `/device` rule they already had.
- **Both EBIOS deployment checklists** (`01-enrollment` §6, `02-ssh-connection` §5) list the rules as verifiable conditions, and the R7 remediation stops saying "ACL sur `/device`" without showing one.

## Two traps, both documented and tested

The issue flags the first; verifying against the plugin's route table turned up a second, worse one.

1. **`^/device$` never matches.** `grant()` matches `REQUEST_URI`, which carries the query string, so an end-anchored rule would not fire on `/device?user_code=ABCD-EFGH` — a rule that looks configured and does nothing.
2. **`^/ssh/revoke` also matches `/ssh/revoked`**, the *public* KRL that every backend downloads on a timer (`addUnauthRoute ssh => { revoked => ... }`). Restricting that route breaks revocation propagation fleet-wide, while looking like a hardening step. The shipped rule is `^/ssh/(admin|certs|revoke)(\?|/|$)`.

The user routes stay open on purpose: `/ssh/sign`, `/ssh/mycerts`, `/ssh/myrevoke` and `/ssh` are the ordinary user's own certificate operations, and `/ssh/ca` and `/ssh/revoked` are public by design.

## Tests

`tests/test_ob_llng_location_rules.sh` (picked up by the CI's `tests/test_ob_*.sh` glob) replays the shipped regexes against the plugin's real route list — the three admin routes must match, the six public/user routes must not — plus a check that no `/device` rule is end-anchored, and that the documentation still carries both rules and the KRL warning.

```
$ bash tests/test_ob_llng_location_rules.sh   → 6/6
```

Verified by regression: replacing the rule with a naive `^/ssh/revoke` makes the route-separation case fail.

## Not done here

The issue also asks for the rules in the production Ansible roles. Those roles deploy hosts, not the LLNG portal — the portal is an operator's own server and this repository ships no configuration for it (`ob-builder` templates included). The guide plus the checklist entries are the deliverable there; the demos are the executable reference.

https://claude.ai/code/session_011q88Fs4nFuUs7JMvmgbBTN