### PR TITLE
docs(ebios): derive every risk matrix from the sheets, and sweep the backlog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,6 +118,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   reusable is captured — is now documented in `doc/admin-guide.md`,
   `man ob-ssh` and risk R-S9 of the EBIOS study, where it had never been stated.
 
+- **Every EBIOS risk matrix now agrees with the risk sheets it summarises
+  (#213, #214, #215).** The five matrices in `doc/security/` were maintained by
+  hand and had drifted from the sheets: risks placed one column off, residual
+  scores no sheet states, the consolidated table missing 11 of the analysed risks
+  and carrying two identifiers (`R-S24`, `R-S25`) that had no sheet at all, and
+  `99-risk-reduce.md` stating three different values for `R-S18` on three lines.
+  An evaluator reads the matrix, not the sheets.
+
+  All five are now derived from the sheets, cell by cell, with no local
+  re-evaluation; the conditional "clients OIDC distincts" configuration, which
+  the enrolment matrix used to apply silently, has its own labelled matrix.
+  `R-S24` and `R-S25` gained full risk sheets in
+  `doc/security/02-ssh-connection.md` (vectors, mitigating factors, remediation,
+  residual score) rather than being dropped, and the service-account risks now
+  appear in the SSH matrices so those cover the whole study.
+
+  `tests/ebios_matrix_check.py`, run by `tests/test_ob_ebios_matrices.sh` in CI,
+  re-derives every matrix from the 39 sheets and fails on any divergence, any
+  missing analysed risk, and any identifier without a sheet — including the score
+  repeated in each `99-risk-reduce.md` section heading.
+
+  The backlog was swept against the shipped code at the same time: the
+  "privileged session collector" listed under R-S19 as *not retained* was
+  delivered by #157 (`ob-record-sink` is socket-activated, so the "new permanent
+  service" objection is void, and it writes root-owned files), and "session
+  recording" listed under R-S6 as an improvement is on by default and
+  fail-closed. Both are marked delivered, with what genuinely remains.
+
 - **A world- or group-readable `/etc/open-bastion/cache.key` is now rejected
   instead of used with a warning** (offline auth cache, desktop SSO). Versions
   up to 0.6.2 accepted such a key and merely logged a warning. `SECURITY.md`

--- a/doc/security/01-enrollment.md
+++ b/doc/security/01-enrollment.md
@@ -1114,18 +1114,27 @@ sequenceDiagram
 | Impact ↓ / Probabilité → | 1 - Très improbable | 2 - Peu probable | 3 - Probable | 4 - Très probable |
 | ------------------------ | ------------------- | ---------------- | ------------ | ----------------- |
 | **4 - Critique**         |                     | R3 R5 R7 R11 R13 | R4           |                   |
-| **3 - Important**        |                     | R8 R10           | R1 R2 R12    |                   |
-| **2 - Limité**           |                     | R0 R6 R9         |              |                   |
+| **3 - Important**        |                     | R2 R8 R10        | R1 R12       |                   |
+| **2 - Limité**           |                     | R0 R9            | R6           |                   |
 | **1 - Négligeable**      |                     |                  |              |                   |
 
 ### Après remédiation
 
+Configuration de référence : un `client_id` par projet, avec la segmentation
+`server_group` appliquée. Chaque case reprend le **score résiduel écrit dans la
+fiche** du risque ; aucune valeur conditionnelle n'est appliquée en silence ici
+(la variante « clients OIDC distincts » a sa propre matrice ci-dessous).
+
 | Impact ↓ / Probabilité → | 1 - Très improbable | 2 - Peu probable | 3 - Probable | 4 - Très probable |
 | ------------------------ | ------------------- | ---------------- | ------------ | ----------------- |
-| **4 - Critique**         | R5                  |                  |              |                   |
-| **3 - Important**        | R1 R3 R8 R12        | R2               |              |                   |
-| **2 - Limité**           | R4 R7 R9 R10 R11    | R6               |              |                   |
-| **1 - Négligeable**      | R0 R13              |                  |              |                   |
+| **4 - Critique**         | R4 R5               |                  |              |                   |
+| **3 - Important**        | R2 R3 R7 R8 R11 R12 | R1               |              |                   |
+| **2 - Limité**           | R0 R9 R10           |                  |              |                   |
+| **1 - Négligeable**      | R13                 | R6               |              |                   |
+
+> **R4 :** sa fiche donne `I=4 (ou 3 avec segmentation server_group)`. La matrice
+> retient la valeur non conditionnelle, `I=4` ; avec `pamAccessServerGroups`
+> renseigné, R4 descend en `I=3` aux côtés de R7 et R11.
 
 **Remédiations appliquées :**
 
@@ -1140,16 +1149,30 @@ sequenceDiagram
 
 > **Deux axes à ne pas confondre.** Le `server_group` sépare les _politiques_ **à l'intérieur** d'un projet (un même `client_id`) ; il ne borne le rayon d'impact des _credentials_ d'enrôlement que si le **mapping d'autorité `client_id → server_group`** (`pamAccessServerGroups` — à ne pas confondre avec les _règles_ d'accès par groupe `pamAccessSshRules`/`pamAccessSudoRules`) est renseigné. Quand un `client_id` couvre un projet **multi-groupes** (le modèle par défaut), l'isolation des credentials passe par des **`client_id` distincts par zone** (ligne « Clients OIDC distincts »), pas par le `server_group`.
 
-**Détail des améliorations avec clients OIDC distincts (voir section 5.2) :**
+### Après remédiation, variante « clients OIDC distincts » (configuration conditionnelle)
 
-| Risque  | Sans clients distincts | Avec clients distincts | Amélioration                                                       |
-| ------- | ---------------------- | ---------------------- | ------------------------------------------------------------------ |
-| **R0**  | P=1, I=2               | **P=1, I=1**           | Le secret compromis ne peut initier d'enrôlements que dans sa zone |
-| **R4**  | P=1, I=3               | **P=1, I=2**           | Le token volé n'est valide que pour le scope de sa zone            |
-| **R7**  | P=1, I=3               | **P=1, I=2**           | Le serveur malveillant ne peut usurper que sa zone                 |
-| **R11** | P=1, I=3               | **P=1, I=2**           | Le refresh_token compromis est limité à sa zone                    |
+Cette matrice ne s'applique **que si** un `client_id` distinct est déclaré par
+zone (voir section 5.2). Ce n'est pas la configuration par défaut, et elle n'est
+pas supposée acquise par la matrice précédente.
 
-**Résultat :** Seul R5 (usurpation du serveur LLNG) reste critique - c'est le point unique de défaillance irréductible.
+| Risque  | Fiche (client unique) | Avec clients distincts | Amélioration                                                       |
+| ------- | --------------------- | ---------------------- | ------------------------------------------------------------------ |
+| **R0**  | P=1, I=2              | **P=1, I=1**           | Le secret compromis ne peut initier d'enrôlements que dans sa zone |
+| **R4**  | P=1, I=4 (3 segmenté) | **P=1, I=2**           | Le token volé n'est valide que pour le scope de sa zone            |
+| **R7**  | P=1, I=3              | **P=1, I=2**           | Le serveur malveillant ne peut usurper que sa zone                 |
+| **R11** | P=1, I=3              | **P=1, I=2**           | Le refresh_token compromis est limité à sa zone                    |
+
+| Impact ↓ / Probabilité → | 1 - Très improbable | 2 - Peu probable | 3 - Probable | 4 - Très probable |
+| ------------------------ | ------------------- | ---------------- | ------------ | ----------------- |
+| **4 - Critique**         | R5                  |                  |              |                   |
+| **3 - Important**        | R2 R3 R8 R12        | R1               |              |                   |
+| **2 - Limité**           | R4 R7 R9 R10 R11    |                  |              |                   |
+| **1 - Négligeable**      | R0 R13              | R6               |              |                   |
+
+**Résultat :** dans la configuration de référence, R4 (vol du fichier token) et
+R5 (usurpation du serveur LLNG) restent en impact 4 ; avec des `client_id`
+distincts par zone, seul R5 y reste — c'est le point unique de défaillance
+irréductible, le seul que la segmentation ne borne pas.
 
 **Légende :**
 

--- a/doc/security/02-ssh-connection.md
+++ b/doc/security/02-ssh-connection.md
@@ -1381,23 +1381,23 @@ Contrairement à R-S19 (recorder tué) et R-S20 (action différée), ici le reco
 
 ### Avant remédiation
 
-| Impact ↓ / Probabilité → | 1 - Très improbable | 2 - Peu probable                                          | 3 - Probable | 4 - Très probable |
-| ------------------------ | ------------------- | --------------------------------------------------------- | ------------ | ----------------- |
-| **4 - Critique**         | R-S4                | R-S6 R-S17                                                |              |                   |
-| **3 - Important**        |                     | R-S3 R-S7 R-S11 R-S15 R-S13 R-S14 R-S18 R-S20 R-S21 R-S23 | R-S19        |                   |
-| **2 - Limité**           | R-S16 R-S22         | R-S9 R-S10 R-S12                                          | R-S8         |                   |
-| **1 - Négligeable**      |                     |                                                           |              |                   |
+| Impact ↓ / Probabilité → | 1 - Très improbable    | 2 - Peu probable                              | 3 - Probable | 4 - Très probable |
+| ------------------------ | ---------------------- | --------------------------------------------- | ------------ | ----------------- |
+| **4 - Critique**         | R-S4 R-S24 R-SA2       | R-S6 R-S17 R-SA1                              |              |                   |
+| **3 - Important**        | R-S5 R-S23 R-S25       | R-S3 R-S7 R-S13 R-S14 R-S15 R-S18 R-S20 R-S21 | R-S11 R-S19  |                   |
+| **2 - Limité**           | R-S9 R-S10 R-S16 R-S22 | R-S12                                         | R-S8         |                   |
+| **1 - Négligeable**      |                        |                                               |              |                   |
 
-> **Note :** R-S1 (brute-force mot de passe) et R-S2 (vol de clé SSH simple) sont **éliminés** par la cible de sécurité maximale (`AuthorizedKeysFile none` + certificat CA requis). R-S5 démarre à P=1 grâce aux certificats CA obligatoires. R-S18 est ici à P=2 (et non P=3) car le wrapper setgid empêche l'accès aux recordings d'autres utilisateurs, ce qui réduit la probabilité d'un effacement « croisé » même avant remédiation complète ; l'effacement de ses propres recordings reste possible (cf. fiche R-S18).
+> **Note :** R-S1 (brute-force mot de passe) et R-S2 (vol de clé SSH simple) sont **éliminés** par la cible de sécurité maximale (`AuthorizedKeysFile none` + certificat CA requis) : ils n'ont pas de fiche et n'apparaissent donc dans aucune matrice. R-S5 démarre à P=1 grâce aux certificats CA obligatoires. R-S18 est ici à P=2 (et non P=3) car le wrapper setgid empêche l'accès aux recordings d'autres utilisateurs, ce qui réduit la probabilité d'un effacement « croisé » même avant remédiation complète ; l'effacement de ses propres recordings reste possible (cf. fiche R-S18). Les risques de comptes de service (R-SA1, R-SA2, R-S24, R-S25) sont analysés en section 6 et figurent ici avec les autres, pour que la matrice couvre l'intégralité de l'étude.
 
 ### Après remédiation complète
 
-| Impact ↓ / Probabilité → | 1 - Très improbable                                                   | 2 - Peu probable | 3 - Probable | 4 - Très probable |
-| ------------------------ | --------------------------------------------------------------------- | ---------------- | ------------ | ----------------- |
-| **4 - Critique**         | R-S4                                                                  |                  |              |                   |
-| **3 - Important**        | R-S5 R-S23                                                            | R-S6             |              |                   |
-| **2 - Limité**           | R-S7 R-S9 R-S10 R-S11 R-S12 R-S13 R-S14 R-S16 R-S17 R-S20 R-S21 R-S22 | R-S8             |              |                   |
-| **1 - Négligeable**      | R-S15 R-S19                                                           | R-S3 R-S18       |              |                   |
+| Impact ↓ / Probabilité → | 1 - Très improbable                                             | 2 - Peu probable | 3 - Probable | 4 - Très probable |
+| ------------------------ | --------------------------------------------------------------- | ---------------- | ------------ | ----------------- |
+| **4 - Critique**         | R-S4 R-SA2                                                      |                  |              |                   |
+| **3 - Important**        | R-S5 R-S11 R-S23 R-S24                                          | R-S6 R-SA1       |              |                   |
+| **2 - Limité**           | R-S7 R-S9 R-S12 R-S13 R-S14 R-S16 R-S17 R-S20 R-S21 R-S22 R-S25 | R-S8             |              |                   |
+| **1 - Négligeable**      | R-S10 R-S15 R-S18 R-S19                                         | R-S3             |              |                   |
 
 **Profil de risque de la cible maximale :**
 
@@ -1408,12 +1408,20 @@ Contrairement à R-S19 (recorder tué) et R-S20 (action différée), ici le reco
 - R-S15 (KRL stale) : **I=1** grâce au binding fingerprint sur `/pam/authorize` : une révocation LLNG interdit l'ouverture d'une session SSH à chaque nouvelle connexion, indépendamment de la fraîcheur de la KRL
 - R-S16 (escalade sudo) : **contrôlé par réauthentification SSO obligatoire**
 - R-S17 (lockout) : **contrôlé par compte de service secours** + procédure console documentée
-- R-S18 (effacement sessions) : **traçable mais reste effaçable techniquement** ; l'imputation tient grâce à syslog `auth.info` (start/end de session) et, si PR2 (#113) est activée, grâce au watch auditd `-w /var/lib/open-bastion/sessions/` qui trace l'événement d'effacement lui-même
+- R-S18 (effacement sessions) : **P=1, I=1 depuis la PR #157** — les enregistrements sont écrits par le puits root `ob-record-sink` dans une arborescence `root:ob-sessions 0750`, à laquelle l'utilisateur enregistré n'a aucun accès : l'effacement n'est plus techniquement possible pour lui, seul root du bastion le peut. L'imputation tient en outre grâce à syslog `auth.info` (start/end de session) et, si PR2 (#113) est activée, au watch auditd `-w /var/lib/open-bastion/sessions/`
 - R-S19 (évasion containment via `setsid`/`nohup`), R-S20 (action différée via `at`/`cron`/`systemd-run`), R-S21 (action non capturée par le pty) : **nouvellement identifiés** et mitigés par PR1 (#112) et PR2 (#113) sous condition d'activation opt-in
 - **Conditions d'activation :** ces nouveaux risques (R-S19, R-S20, R-S21) ne sont mitigés à leur niveau résiduel **que si** le hardening (PR1) ET la trace auditd (PR2) sont activés via `ob-bastion-setup --enable-hardening --enable-audit-trace`. En l'absence d'activation, ces risques restent en zone jaune (P=3, I=3 pour R-S19 ; P=2, I=3 pour R-S20 et R-S21). Voir [doc/hardening.md](../hardening.md) et [doc/audit.md](../audit.md) (documentations techniques en anglais) pour les détails opérationnels.
 - R-S22 (certificat vouché réutilisé vers un autre backend) : **P=1, I=2** — `target=` non vérifié par `ob-ssh-principals`, mais `source-address` impose le contrôle du bastion et l'allowlist par backend cloisonne les zones (piste : vérifier `target=` contre le FQDN local)
 - R-S23 (backend en mode hérité, `allowed_bastions` absent) : **P=1, I=3** — `ob-backend-setup` écrit toujours le fichier et `ob-ssh-principals` est fail-closed si illisible ; le risque résiduel ne concerne qu'un backend jamais configuré par le setup (piste : postinst écrivant un fichier vide par défaut)
-- Seuls risques résiduels significatifs en zone jaune (PR1 et PR2 activées) : R-S4 (CA compromise) et R-S6 (bastion compromis)
+- R-S24 (sudo de compte de service hors token SSO) : **P=1, I=3** — le droit vient de `service-accounts.conf` seul, sans appel LLNG ; `sudo_nopasswd = false` reste la configuration recommandée (l'empreinte de la clé y est revérifiée à chaque `sudo`)
+- R-S25 (hop de compte de service via ProxyJump) : **P=1, I=2** — non enregistré par le `ForceCommand` (canal `direct-tcpip`) ; à traiter par `AllowTcpForwarding no` ou par un accès direct aux cibles
+- Risques résiduels en zone jaune (PR1 et PR2 activées) : R-S4 et R-SA2 (P=1, I=4), R-SA1 (P=2, I=3), R-S6 (P=2, I=3), R-S8 (P=2, I=2)
+
+> **Comment lire ces matrices.** Chaque case reprend le score écrit dans la fiche
+> du risque, sans réévaluation locale : une case et une fiche ne peuvent pas
+> diverger. `tests/ebios_matrix_check.py` le vérifie mécaniquement sur les cinq
+> matrices de l'étude et échoue si l'une d'elles s'écarte de ses fiches, ou si un
+> risque analysé n'y figure pas.
 
 ---
 
@@ -1680,6 +1688,70 @@ sequenceDiagram
 | --------------- | :------------: |
 | **Probabilité** |       1        |
 | **Impact**      |       4        |
+
+#### R-S24 - Sudo de compte de service hors token SSO
+
+|                 | Score |
+| --------------- | :---: |
+| **Probabilité** |   1   |
+| **Impact**      |   4   |
+
+**Description :** Le droit sudo d'un compte de service provient **uniquement** de `service-accounts.conf` (`sudo_allowed` / `sudo_nopasswd`) : `pam_openbastion` l'accorde localement et renvoie un succès **sans aucun appel LLNG**, **y compris en Mode E** où un humain doit présenter un token LLNG frais. Une clé de service avec `sudo_allowed` est donc un privilège local permanent qui échappe à la porte sudo gouvernée par le SSO.
+
+**Vecteurs d'attaque :**
+
+- Vol de la clé privée d'un compte de service disposant de `sudo_allowed`
+- Réutilisation d'une clé d'automatisation exposée dans un dépôt, un artefact CI ou une sauvegarde
+- Prestataire ou outil sorti du périmètre sans retrait de sa clé du fichier
+
+**Facteurs atténuants structurels :**
+
+- Le fichier est local à chaque serveur : la portée d'une clé est bornée aux serveurs qui la déclarent
+- `service-accounts.conf` est root:root 0600, refusé s'il est un lien symbolique (`O_NOFOLLOW`)
+- PAM n'autorise que la **tentative** : `sudoers` décide encore _quelles_ commandes
+- Avec `sudo_nopasswd = false`, l'empreinte de la clé SSH est revérifiée à chaque `sudo` (voir #194) — le compte doit prouver la clé qui a ouvert la session
+
+**Remédiation :**
+
+1. **Minimiser** : n'accorder `sudo_allowed` qu'aux comptes qui en ont réellement besoin ; préférer `sudo_nopasswd = false` et des règles `sudoers` restreintes à des commandes précises
+2. **Inventaire et rotation** : traiter chaque clé de service comme un secret de longue durée (coffre-fort, rotation périodique, révocation à la sortie d'un prestataire)
+3. **Audit dédié** : journaliser et alerter sur l'usage sudo des comptes de service (clé auditd `-k` distincte), puisqu'il n'apparaît pas dans les logs d'autorisation LLNG
+
+|                 |                                Score résiduel                                 |
+| --------------- | :---------------------------------------------------------------------------: |
+| **Probabilité** |        1 (clé en coffre-fort, périmètre borné aux serveurs déclarants)        |
+| **Impact**      | 3 (root sur les serveurs déclarant la clé, sans passer par la porte sudo SSO) |
+
+#### R-S25 - Hop de compte de service via ProxyJump non enregistré
+
+|                 | Score |
+| --------------- | :---: |
+| **Probabilité** |   1   |
+| **Impact**      |   3   |
+
+**Description :** Un compte de service ne peut pas utiliser `ob-ssh` (pas de voucher SSO), mais un `ssh -J bastion compte@backend` natif fonctionne s'il est configuré des deux côtés et que le bastion autorise le forwarding TCP. Or le `ForceCommand` (enregistreur de session) **ne couvre pas le canal `direct-tcpip`** : un tel hop **n'est pas enregistré** sur le bastion.
+
+**Vecteurs d'attaque :**
+
+- Compte de service déclaré à la fois sur le bastion et sur un backend, avec `AllowTcpForwarding` laissé à `yes`
+- Usage légitime détourné : l'automatisation traverse le bastion sans laisser de trace de session
+
+**Facteurs atténuants structurels :**
+
+- Le hop reste tracé par `sshd` des deux côtés (ouverture de canal, authentification par clé, empreinte)
+- Les logs d'audit du backend (auditd, `journald`) s'appliquent normalement à la session résultante
+- La clé doit être déclarée **explicitement** sur les deux hôtes
+
+**Remédiation :**
+
+1. **Accès direct** : faire pointer les comptes de service directement sur les serveurs cibles plutôt que de les relayer par le bastion — la traçabilité repose alors sur les logs de la cible
+2. **`AllowTcpForwarding no` sur le bastion** : interdire explicitement le canal `direct-tcpip` quand aucun usage légitime ne l'exige
+3. **Inventaire** : recenser les comptes de service déclarés simultanément sur bastion et backend, qui sont les seuls à pouvoir emprunter ce chemin
+
+|                 |                              Score résiduel                               |
+| --------------- | :-----------------------------------------------------------------------: |
+| **Probabilité** |   1 (nécessite la clé déclarée des deux côtés et le forwarding ouvert)    |
+| **Impact**      | 2 (pas d'enregistrement de session ; sshd et l'audit de la cible tracent) |
 
 ### Recommandations
 

--- a/doc/security/99-risk-reduce.md
+++ b/doc/security/99-risk-reduce.md
@@ -2,22 +2,31 @@
 
 ## Matrice des Risques Résiduels (Mode E)
 
-| Impact ↓ / Probabilité → | 1 - Très improbable                                                | 2 - Peu probable | 3 - Probable | 4 - Très probable |
-| ------------------------ | ------------------------------------------------------------------ | ---------------- | ------------ | ----------------- |
-| **4 - Critique**         | R-S4, R-SA2                                                        | R-SA1            |              |                   |
-| **3 - Important**        | R5, R-S5, R-S11, R-S23, R-S24                                      | R-S6             |              |                   |
-| **2 - Limité**           | R-S7, R-S9, R-S10, R-S12, R-S16, R-S17, R-S20, R-S21, R-S22, R-S25 | R6, R-S8         |              |                   |
-| **1 - Négligeable**      | R0, R13, R-S14, R-S15, R-S19                                       | R-S3, R-S18      |              |                   |
+| Impact ↓ / Probabilité → | 1 - Très improbable                                                                    | 2 - Peu probable | 3 - Probable | 4 - Très probable |
+| ------------------------ | -------------------------------------------------------------------------------------- | ---------------- | ------------ | ----------------- |
+| **4 - Critique**         | R4, R5, R-S4, R-SA2                                                                    |                  |              |                   |
+| **3 - Important**        | R2, R3, R7, R8, R11, R12, R-S5, R-S11, R-S23, R-S24                                    | R1, R-S6, R-SA1  |              |                   |
+| **2 - Limité**           | R0, R9, R10, R-S7, R-S9, R-S12, R-S13, R-S14, R-S16, R-S17, R-S20, R-S21, R-S22, R-S25 | R-S8             |              |                   |
+| **1 - Négligeable**      | R13, R-S10, R-S15, R-S18, R-S19                                                        | R6, R-S3         |              |                   |
 
-> **Note :** R-S3 et R-S15 ont été descendus d'un cran sur l'axe Impact grâce au **binding fingerprint SSH** introduit dans le plugin PamAccess ≥ 0.1.16. La vérification est effectuée côté LLNG à la fois sur `/pam/authorize` (à chaque ouverture de session SSH, phase PAM `account`) et sur `/pam/verify` (à chaque utilisation d'un token PAM pour sudo ou ré-authentification) : tant que l'empreinte de la clef SSH n'est pas présente, active et non révoquée dans la session persistante LLNG, ni la session SSH ni l'escalade sudo ne sont autorisées, indépendamment de la fraîcheur de la KRL locale. Voir [02-ssh-connection.md](02-ssh-connection.md) pour les détails.
+> **Note :** R-S3 et R-S15 sont descendus de I=3 à I=1 grâce au **binding fingerprint SSH** introduit dans le plugin PamAccess ≥ 0.1.16. La vérification est effectuée côté LLNG à la fois sur `/pam/authorize` (à chaque ouverture de session SSH, phase PAM `account`) et sur `/pam/verify` (à chaque utilisation d'un token PAM pour sudo ou ré-authentification) : tant que l'empreinte de la clef SSH n'est pas présente, active et non révoquée dans la session persistante LLNG, ni la session SSH ni l'escalade sudo ne sont autorisées, indépendamment de la fraîcheur de la KRL locale. Voir [02-ssh-connection.md](02-ssh-connection.md) pour les détails.
 
 > **Note (R-S18, R-S19, R-S20, R-S21) :** Les scores résiduels indiqués ci-dessus pour R-S19, R-S20 et R-S21 supposent l'activation **simultanée** du hardening (PR1 #112, `--enable-hardening`) et de la trace auditd (PR2 #113, `--enable-audit-trace`). En l'absence d'activation, R-S19 reste à (P=3, I=3), R-S20 et R-S21 restent à (P=2, I=3) — tous trois en zone jaune. Voir [doc/hardening.md](../hardening.md) et [doc/audit.md](../audit.md) (documentations techniques en anglais) pour les détails opérationnels.
 
-**Zones de risque :**
+> **Comment lire cette matrice.** Elle consolide les **39 fiches de risque** des
+> deux études (R0–R13 pour l'enrôlement, R-S3–R-S25 et R-SA1/R-SA2 pour la
+> connexion SSH et les comptes de service) et reprend, case par case, le score
+> résiduel **écrit dans chaque fiche** — aucune case n'est une évaluation
+> autonome. `tests/ebios_matrix_check.py` le vérifie mécaniquement et échoue si
+> une case s'écarte de sa fiche, si un risque analysé manque, ou si un
+> identifiant y figure sans fiche. R-S1 et R-S2 sont éliminés par la cible Mode E
+> et n'ont donc pas de fiche.
 
-- Score ≥ 6 : Zone rouge (aucun risque dans cette zone en Mode E avec PR1 + PR2 activées)
-- Score 4-5 : Zone jaune → R-S4, R-SA2 (P=1, I=4), R-SA1 (P=2, I=4/3), R6, R-S8 (P=2, I=2), R-S6 (P=2, I=3)
-- Score ≤ 3 : Zone verte → Tous les autres risques (incluant R-S18 à P=2, I=1 = score 2)
+**Zones de risque** (score = P × I) **:**
+
+- Score ≥ 6 : Zone rouge → aucun risque dans cette zone en Mode E avec PR1 + PR2 activées
+- Score 4-5 : Zone jaune → R4, R5, R-S4, R-SA2 (P=1, I=4) ; R-S6 et R-SA1 (P=2, I=3) ; R-S8 (P=2, I=2)
+- Score ≤ 3 : Zone verte → tous les autres, y compris R6 et R-S3 (P=2, I=1 = score 2)
 
 **Risques éliminés ou ramenés en zone verte par le Mode E (avec PR1 et PR2 activées) :**
 
@@ -44,7 +53,7 @@ Pistes pour réduire la probabilité à quasi-zéro :
 2. mTLS : Le serveur PAM présente aussi un certificat client
 3. DANE (DNSSEC + TLSA) : Validation du certificat via DNS signé
 
-### R6 _(P=2, I=2)_ - Expiration device_code
+### R6 _(P=2, I=1)_ - Expiration device_code
 
 Pistes pour réduire P à 1 :
 
@@ -88,7 +97,13 @@ Pistes pour réduire P à 1 :
 Pistes pour réduire I à 2 :
 
 1. **Segmentation par zone (credentials d'enrôlement)** : par défaut un `client_id` = un **projet** (toutes ses machines partagent l'allowlist, et les groupes PAM séparent les _politiques_ à l'intérieur du projet — pas les _credentials_). Pour réduire le rayon d'impact d'un bastion compromis, **découper en plusieurs `client_id`** (un par zone de sécurité), chacun avec un `allowed_bastions` distinct par backend → un bastion compromis ne peut voucher que pour les backends de sa zone. C'est un arbitrage : plus d'isolation des credentials, mais autant de RP OIDC à gérer.
-2. **Session recording** : Enregistrement de toutes les sessions transitant par le bastion
+2. ~~**Session recording**~~ — **LIVRÉ et actif par défaut.** L'enregistrement de
+   toutes les sessions transitant par le bastion n'est pas une piste : il est
+   activé par défaut (`ob-bastion-setup` : « Session recording is a core bastion
+   guarantee and is ON by default »), le désactiver demande un
+   `--disable-session-recorder` explicite, et il est **fail-closed** — si le
+   puits est injoignable, `ob-session-recorder` refuse la session
+   (« Session recording is required but unavailable; access refused »).
 3. **Réduire `pamAccessBastionVoucherTtl`** (défaut 43200 s = 12 h) : borne la durée pendant laquelle un bastion compromis peut continuer à obtenir des certificats pour les utilisateurs récemment vouchés sans nouvelle connexion de leur part. Compromis ergonomie (les admins doivent se reconnecter plus souvent) vs exposition.
 
 ### R-S8 _(P=2, I=2)_ - Session persistante après révocation
@@ -156,7 +171,7 @@ Le timer `ob-heartbeat` rafraîchit l'access_token (TTL 3600 s) toutes les 5 min
 
 ## Pistes d'Amélioration - Spécifiques au Mode E
 
-### R-S15 _(P=1, I=2)_ - KRL non à jour
+### R-S15 _(P=1, I=1)_ - KRL non à jour
 
 Pistes pour réduire P à quasi-zéro :
 
@@ -265,6 +280,7 @@ Avant remédiation, ce risque est en **zone rouge** (P=2, I=4). La remédiation 
 > **Contrepartie en cas de panne LLNG :** le module ne sert jamais d'entrée périmée (elle est supprimée à la lecture) et un échec transitoire renvoie `NSS_STATUS_UNAVAIL` sans repli sur le cache. Le tampon de résolution vaut donc exactement `cache_ttl` (défaut **300 s**, `/etc/open-bastion/nss_openbastion.conf`), là où le cache persistant de `nscd` couvrait plusieurs dizaines de minutes. Augmenter `cache_ttl` (jusqu'à 86400 s) sur les hôtes exposés à ce risque.
 
 > **Trois limites à connaître en régime nominal**, détaillées dans le guide d'administration :
+>
 > 1. **Seul root remplit le cache** (le jeton serveur LLNG est `0600 root:root`) : une entrée qui expire sans qu'un processus root ne résolve l'utilisateur n'est pas renouvelée. Dans une session SSH inactive : `ls -l` en uid numériques, `whoami`/`id` en échec, `ssh`/`scp` sortant refusé (« You don't exist, go away! »). Toute résolution root (nouvelle session, `su`, `sudo`, `cron`) répare immédiatement ; l'authentification et l'autorisation ne sont pas affectées.
 > 2. **Les résultats négatifs ne sont cachés qu'en mémoire, par processus** : le cache fichier n'est peuplé que sur succès, volontairement, car il est alimenté depuis un chemin non authentifié (`sshd` résout le nom avant l'authentification) et l'y autoriser donnerait à un attaquant distant un moyen de remplir `/var/cache/nss_llng` d'inodes. Chaque tentative SSH avec un nom inexistant coûte donc une requête HTTPS `/pam/userinfo`. `nscd` ne couvrait ce cas que partiellement (cache négatif keyé par nom, 20 s). Borner côté connexions (`MaxStartups`, `fail2ban`/CrowdSec).
 > 3. **SELinux `enforcing` (Rocky/RHEL) non validé** : le cache est écrit depuis le domaine du processus appelant (`sshd_t`, `sudo_t`, `crond_t`). Si la politique par défaut le refuse, l'écriture échoue en silence et le cache partagé n'est jamais peuplé — vérifier par `ausearch -m avc` avant déploiement.
@@ -286,7 +302,16 @@ Cette section couvre les nouveaux risques R-S19, R-S20, R-S21 introduits par l'a
 
 Pistes pour aller plus loin :
 
-1. **Démon collecteur de session privilégié** : remplacer le pty recording local par un démon `ob-session-collector` qui reçoit le flux pty via socket Unix (`SO_PEERCRED`) et écrit dans des fichiers root-owned. Détecte la fermeture brutale du recorder via RST socket et marque la session comme `killed_prematurely` côté serveur. Architecture déjà décrite dans le brainstorm initial mais non retenue à ce stade pour éviter d'introduire un nouveau service permanent.
+1. ~~**Démon collecteur de session privilégié**~~ — **LIVRÉ (PR #157)**, voir
+   [R-S18](#r-s18-p1-i1---effacement-des-enregistrements-de-session). Cette piste
+   était listée « non retenue pour éviter d'introduire un nouveau service
+   permanent » : les deux objections sont caduques. Le puits `ob-record-sink` est
+   **activé par socket** (`systemd/ob-record.socket`), donc pas un service
+   permanent, et il écrit des fichiers **root-owned** (`src/ob-record-sink.c`,
+   `openat(..., O_NOFOLLOW, 0640)` dans une arborescence `root:ob-sessions 0750`),
+   l'utilisateur étant dérivé de `SO_PEERCRED`. Reste à faire de cette piste :
+   la détection de fermeture brutale du recorder (`killed_prematurely` côté
+   serveur), qui n'est pas implémentée.
 2. **Mandatory Access Control** : profil AppArmor / SELinux qui interdit `setsid` aux shells utilisateurs (rompre le canal d'évasion à la racine). Coût opérationnel élevé (rédaction et maintenance du profil par distribution) mais blocage fort.
 3. **`KillUserProcesses=yes` rendu obligatoire** : retirer l'opt-in et l'imposer en postinst. Abandonné à cause de la philosophie Debian (pas de modification système globale silencieuse). Pourrait être réintroduit comme paquet `open-bastion-strict` dédié, qui imposerait le hardening sans demande de confirmation.
 
@@ -316,6 +341,11 @@ des dérogations volontaires au contrôle centralisé : utiles pour l'automatisa
 
 ### R-S24 _(P=1, I=3)_ - Sudo de compte de service hors token SSO
 
+> **Fiche de risque :** l'analyse complète de R-S24 (vecteurs, facteurs
+> atténuants, remédiation, score résiduel) est en section 6 de
+> [02-ssh-connection.md](02-ssh-connection.md) ; la section ci-dessous n'est
+> que le volet « pistes » du plan de traitement.
+
 Le droit sudo d'un compte de service provient **uniquement** de
 `service-accounts.conf` (`sudo_allowed` / `sudo_nopasswd`) : `pam_openbastion`
 l'accorde localement et renvoie un succès **sans aucun appel LLNG**, **y compris
@@ -330,12 +360,17 @@ Pistes :
    restreintes à des commandes précises plutôt qu'un sudo total.
 2. **Inventaire et rotation** : traiter chaque clé de service comme un secret de
    longue durée (coffre-fort, rotation périodique, révocation à la sortie d'un
-   prestataire/outil). Recoupe le compte de secours de [R-S17](#r-s17-_p1-i2_---verrouillage-total-lockout).
+   prestataire/outil). Recoupe le compte de secours de [R-S17](#r-s17-p1-i2---verrouillage-total-lockout).
 3. **Audit dédié** : journaliser/alerter sur l'usage sudo des comptes de service
    (auditd `-k` distinct), puisqu'il n'apparaît pas dans les logs d'autorisation
    LLNG.
 
 ### R-S25 _(P=1, I=2)_ - Hop de compte de service via ProxyJump non enregistré
+
+> **Fiche de risque :** l'analyse complète de R-S25 (vecteurs, facteurs
+> atténuants, remédiation, score résiduel) est en section 6 de
+> [02-ssh-connection.md](02-ssh-connection.md) ; la section ci-dessous n'est
+> que le volet « pistes » du plan de traitement.
 
 Un compte de service ne peut pas utiliser `ob-ssh` (pas de voucher SSO), mais un
 `ssh -J bastion compte@backend` natif fonctionne s'il est configuré des deux

--- a/tests/ebios_matrix_check.py
+++ b/tests/ebios_matrix_check.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+"""
+Check that every EBIOS risk matrix in doc/security/ agrees with the risk sheets
+it summarises (#213, #214).
+
+Why this exists: the matrices were maintained by hand, next to the sheets they
+summarise, and drifted from them in at least thirteen places -- a risk shown one
+column to the left, a residual impact that no sheet states, a consolidated table
+missing eleven analysed risks and carrying two that had no sheet at all. An
+evaluator reads the matrix, not the sheets, so a matrix that disagrees with its
+own study is worse than no matrix.
+
+The rule enforced here is simple: a matrix cell is not a claim of its own. Every
+placement must be derivable from the (Probabilite, Impact) written in the
+corresponding sheet, and every analysed risk must appear exactly once.
+
+Run:  python3 tests/ebios_matrix_check.py
+"""
+
+import re
+import sys
+from pathlib import Path
+
+DOC = Path(__file__).resolve().parent.parent / "doc" / "security"
+
+ENROLLMENT = DOC / "01-enrollment.md"
+SSH = DOC / "02-ssh-connection.md"
+CONSOLIDATED = DOC / "99-risk-reduce.md"
+
+RISK_ID = r"R-?S?A?\d+"
+HEADING = re.compile(rf"^#{{3,4}}\s+({RISK_ID})\s*[-–—]\s", re.M)
+ANY_HEADING = re.compile(r"^#{1,6}\s", re.M)
+
+# A score table row: "| **Probabilite** | 1 (because ...) |"
+PROB_ROW = re.compile(r"^\|\s*\*\*Probabilit[ée]\*\*\s*\|\s*([0-9])", re.M)
+IMPACT_ROW = re.compile(r"^\|\s*\*\*Impact\*\*\s*\|\s*([0-9])", re.M)
+
+
+def sheets(path):
+    """Return {risk_id: {"initial": (P, I), "residual": (P, I), "level": n, "line": n}}.
+
+    A sheet runs from its own heading to the next heading of the same or a
+    higher level: stopping only at the next *risk* heading would make the last
+    sheet in a file swallow the matrices that follow it.
+    """
+    lines = path.read_text(encoding="utf-8").split("\n")
+
+    # Heading levels per line, with fenced code blocks blanked out: a shell
+    # comment inside a ``` block ("# FORTEMENT RECOMMANDE ...") is not a
+    # Markdown heading, and treating it as one truncates the sheet before its
+    # residual-score table.
+    level_of = [0] * len(lines)
+    fenced = False
+    for i, line in enumerate(lines):
+        if line.lstrip().startswith("```"):
+            fenced = not fenced
+            continue
+        if fenced:
+            continue
+        h = re.match(r"^(#{1,6})\s", line)
+        if h:
+            level_of[i] = len(h.group(1))
+
+    starts = []
+    for i, line in enumerate(lines):
+        if not 3 <= level_of[i] <= 4:
+            continue
+        m = re.match(rf"^#+\s+({RISK_ID})\s*[-\u2013\u2014]\s", line)
+        if m:
+            starts.append((i, level_of[i], m.group(1)))
+
+    found = {}
+    for n, (i, level, rid) in enumerate(starts):
+        end = len(lines)
+        for j in range(i + 1, len(lines)):
+            if level_of[j] and level_of[j] <= level:
+                end = j
+                break
+        body = "\n".join(lines[i:end])
+        probs = PROB_ROW.findall(body)
+        impacts = IMPACT_ROW.findall(body)
+        if len(probs) < 2 or len(impacts) < 2:
+            continue  # not a scored sheet (or an unscored backlog heading)
+        found[rid] = {
+            "initial": (int(probs[0]), int(impacts[0])),
+            "residual": (int(probs[-1]), int(impacts[-1])),
+            "level": level,
+            "line": i + 1,
+        }
+    return found
+
+
+def matrix(path, after_heading):
+    """Parse the 4x4 matrix that follows `after_heading`.
+
+    Returns {risk_id: (P, I)} and the line the matrix starts on.
+    """
+    text = path.read_text(encoding="utf-8")
+    start = text.index(after_heading) + len(after_heading)
+    table = text[start:]
+    placed = {}
+    line0 = text[:start].count("\n") + 1
+    for row in table.split("\n"):
+        row = row.strip()
+        if not row.startswith("|"):
+            if placed:
+                break  # table finished
+            continue
+        m = re.match(r"^\|\s*\*\*([0-9])\s*-", row)
+        if not m:
+            continue
+        impact = int(m.group(1))
+        cells = [c.strip() for c in row.strip("|").split("|")][1:]
+        for col, cell in enumerate(cells, start=1):
+            for rid in re.findall(rf"\b{RISK_ID}\b", cell):
+                placed[rid] = (col, impact)
+    return placed, line0
+
+
+def compare(label, expected, placed, kind, errors):
+    """`expected` is {rid: (P, I)}; `placed` is what the matrix says."""
+    for rid, want in sorted(expected.items()):
+        got = placed.get(rid)
+        if got is None:
+            errors.append(f"{label}: {rid} is analysed ({kind} P={want[0]}, I={want[1]}) "
+                          f"but absent from the matrix")
+        elif got != want:
+            errors.append(f"{label}: {rid} placed at P={got[0]}, I={got[1]} "
+                          f"but its sheet says P={want[0]}, I={want[1]}")
+    for rid in sorted(placed):
+        if rid not in expected:
+            errors.append(f"{label}: {rid} appears in the matrix but has no scored sheet")
+
+
+def main():
+    errors = []
+
+    enrol = sheets(ENROLLMENT)
+    ssh = sheets(SSH)
+
+    if len(enrol) < 14:
+        errors.append(f"01-enrollment.md: only {len(enrol)} scored sheets parsed, expected 14")
+    if len(ssh) < 23:
+        errors.append(f"02-ssh-connection.md: only {len(ssh)} scored sheets parsed, expected 23+")
+
+    checks = [
+        ("01-enrollment avant", ENROLLMENT, "## 3. Matrice des Risques\n\n### Avant remédiation\n",
+         {k: v["initial"] for k, v in enrol.items()}, "initial"),
+        ("01-enrollment après", ENROLLMENT, "### Après remédiation\n",
+         {k: v["residual"] for k, v in enrol.items()}, "residual"),
+        ("02-ssh avant", SSH, "## 4. Matrice des Risques\n\n### Avant remédiation\n",
+         {k: v["initial"] for k, v in ssh.items()}, "initial"),
+        ("02-ssh après", SSH, "### Après remédiation complète\n",
+         {k: v["residual"] for k, v in ssh.items()}, "residual"),
+    ]
+
+    for label, path, heading, expected, kind in checks:
+        try:
+            placed, _ = matrix(path, heading)
+        except ValueError:
+            errors.append(f"{label}: matrix heading not found ({heading.strip()!r})")
+            continue
+        compare(label, expected, placed, kind, errors)
+
+    # The consolidated matrix must cover EVERY analysed risk from both studies.
+    all_residual = {}
+    all_residual.update({k: v["residual"] for k, v in enrol.items()})
+    all_residual.update({k: v["residual"] for k, v in ssh.items()})
+    try:
+        placed, _ = matrix(CONSOLIDATED, "## Matrice des Risques Résiduels (Mode E)\n")
+    except ValueError:
+        placed = None
+        errors.append("99-risk-reduce.md: consolidated matrix heading not found")
+    if placed is not None:
+        compare("99-risk-reduce consolidée", all_residual, placed, "residual", errors)
+
+    # 99-risk-reduce.md repeats each score in its own section headings
+    # ("### R5 _(P=1, I=4)_ - ..."). Those must agree with the sheets too: the
+    # file used to state three different values for R-S18 on three lines.
+    text = CONSOLIDATED.read_text(encoding="utf-8")
+    for m in re.finditer(rf"^#{{2,4}}\s+({RISK_ID})\s+_\(P=([0-9]+)[^)]*?I=([0-9]+)", text, re.M):
+        rid, p, i = m.group(1), int(m.group(2)), int(m.group(3))
+        want = all_residual.get(rid)
+        if want is None:
+            errors.append(f"99-risk-reduce heading: {rid} has no scored sheet")
+        elif (p, i) != want:
+            line = text[:m.start()].count("\n") + 1
+            errors.append(f"99-risk-reduce heading (line {line}): {rid} says P={p}, I={i} "
+                          f"but its sheet says P={want[0]}, I={want[1]}")
+
+    if errors:
+        print(f"{len(errors)} matrix/sheet disagreement(s):\n")
+        for e in errors:
+            print(f"  - {e}")
+        return 1
+
+    total = len(all_residual)
+    print(f"OK: {total} risk sheets, every matrix cell derivable from its sheet")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_ob_ebios_matrices.sh
+++ b/tests/test_ob_ebios_matrices.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+#
+# Every EBIOS risk matrix in doc/security/ must agree with the risk sheets it
+# summarises (#213, #214).
+#
+# The matrices were maintained by hand next to the sheets and drifted from them
+# in at least thirteen places: a risk shown one column to the left, a residual
+# impact no sheet states, a consolidated table missing eleven analysed risks and
+# carrying two identifiers that had no sheet at all. An evaluator reads the
+# matrix, not the sheets, so a matrix that contradicts its own study is worse
+# than no matrix.
+#
+# The check is mechanical: a matrix cell is not a claim of its own, it must be
+# derivable from the (Probabilite, Impact) written in the corresponding sheet.
+# See tests/ebios_matrix_check.py.
+#
+
+set -uo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+
+if ! command -v python3 >/dev/null 2>&1; then
+    echo "  SKIP: python3 not available"
+    exit 0
+fi
+
+echo "=== EBIOS matrices vs risk sheets (#213, #214) ==="
+if python3 "$ROOT_DIR/tests/ebios_matrix_check.py"; then
+    echo ""
+    echo "Tests run: 1, passed: 1, failed: 0"
+    exit 0
+else
+    echo ""
+    echo "Tests run: 1, passed: 0, failed: 1"
+    exit 1
+fi


### PR DESCRIPTION
Closes #213, #214, #215 — three symptoms of one cause: the matrices were maintained by hand next to the sheets they summarise.

## What was wrong

| | |
| --- | --- |
| **#213** | Risks placed one column off (R2, R6 before remediation in `01`; R-S9, R-S10, R-S11, R-S23 in `02`); residual scores no sheet states (R-S10, R-S11, R-S18); `99-risk-reduce.md` stating **three** different values for R-S18 on three lines, and section headings (R6, R-S15) disagreeing with their own sheets |
| **#214** | The consolidated matrix — the one an evaluator reads as "the residual risk state of the product" — missing **11** analysed risks (R1–R4, R7–R12, R-S13) and carrying two identifiers, R-S24 and R-S25, with **no sheet anywhere** |
| **#215** | The backlog proposing as future work things already shipped, in one case naming its own contradiction without resolving it |

The enrolment matrix's "explained" rows deserve a special mention: they came from the **conditional** "clients OIDC distincts" configuration, applied silently. The matrix presented a conditional best case as the result.

## What this does

**Derives all five matrices from the sheets**, cell by cell, with no local re-evaluation. The conditional configuration now has its own labelled matrix instead of being folded into the main one, and R4's dual residual impact (`I=4`, or 3 with `server_group` segmentation) is stated where it is used.

**Writes real sheets for R-S24 and R-S25** in `doc/security/02-ssh-connection.md` — vectors, mitigating factors, remediation, residual score — rather than dropping them from the matrix, since both describe real gaps. The service-account risks (R-SA1, R-SA2, R-S24, R-S25) now also appear in the SSH matrices, so those cover the whole study rather than two thirds of it.

**Sweeps the backlog against the shipped code:**

- R-S19's "privileged session collector", listed as *not retained* "to avoid introducing a new permanent service", was delivered by #157. Both objections are void: `ob-record-sink` is **socket-activated**, not permanent, and it writes **root-owned** files. What genuinely remains of the piste — detecting a recorder killed mid-session — is stated as such rather than left implied.
- R-S6's "session recording" improvement is not merely implemented, it is on by default and **fail-closed**: `ob-session-recorder` refuses the session when the sink is unreachable.

## Why it will not drift again

`tests/ebios_matrix_check.py` (run by `tests/test_ob_ebios_matrices.sh`, picked up by the CI's `tests/test_ob_*.sh` glob) re-derives every matrix from the 39 sheets and fails on:

- any cell that disagrees with its sheet,
- any analysed risk missing from a matrix,
- any identifier in a matrix with no sheet behind it,
- any score repeated in a `99-risk-reduce.md` section heading that contradicts its sheet.

```
$ bash tests/test_ob_ebios_matrices.sh
OK: 39 risk sheets, every matrix cell derivable from its sheet
```

Verified by regression: dropping R4 from the consolidated matrix makes it fail with `R4 is analysed (residual P=1, I=4) but absent from the matrix`.

The parser had to skip fenced code blocks — a `# FORTEMENT RECOMMANDÉ ...` shell comment inside a ```` ``` ```` block was truncating sheets before their residual-score table.

## Also

A broken intra-document anchor to R-S17, and the claim that R-S3/R-S15 dropped "one notch" of impact (they dropped from 3 to 1).

## Not in scope

#216 (treatment plan with owners, priorities and due dates) and #217 (homologation perimeter, conditions of use, residual-risk acceptance) need decisions only the project owners can make — who owns what, by when, and what is accepted. #212 (the missing EBIOS RM workshops) and #218 (the LLNG plugin boundary) are separate pieces of analysis.

https://claude.ai/code/session_011q88Fs4nFuUs7JMvmgbBTN