### PR TITLE
docs(ebios): add the missing workshops, the treatment plan and the dossier

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,7 @@ local-test/vm/
 build-verify/
 build-asan/
 bv/
+
+# Python bytecode from the EBIOS consistency checker
+__pycache__/
+*.pyc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Every EBIOS risk matrix now agrees with the risk sheets it summarises
+  (#213, #214, #215).** The five matrices in `doc/security/` were maintained by
+  hand and had drifted from the sheets: risks placed one column off, residual
+  scores no sheet states, the consolidated table missing 11 of the analysed risks
+  and carrying two identifiers (`R-S24`, `R-S25`) that had no sheet at all, and
+  `99-risk-reduce.md` stating three different values for `R-S18` on three lines.
+  An evaluator reads the matrix, not the sheets.
+
+  All five are now derived from the sheets, cell by cell, with no local
+  re-evaluation; the conditional "clients OIDC distincts" configuration, which
+  the enrolment matrix used to apply silently, has its own labelled matrix.
+  `R-S24` and `R-S25` gained full risk sheets in
+  `doc/security/02-ssh-connection.md` (vectors, mitigating factors, remediation,
+  residual score) rather than being dropped, and the service-account risks now
+  appear in the SSH matrices so those cover the whole study.
+
+  `tests/ebios_matrix_check.py`, run by `tests/test_ob_ebios_matrices.sh` in CI,
+  re-derives every matrix from the 39 sheets and fails on any divergence, any
+  missing analysed risk, and any identifier without a sheet — including the score
+  repeated in each `99-risk-reduce.md` section heading.
+
+  The backlog was swept against the shipped code at the same time: the
+  "privileged session collector" listed under R-S19 as *not retained* was
+  delivered by #157 (`ob-record-sink` is socket-activated, so the "new permanent
+  service" objection is void, and it writes root-owned files), and "session
+  recording" listed under R-S6 as an improvement is on by default and
+  fail-closed. Both are marked delivered, with what genuinely remains.
+
 - **A world- or group-readable `/etc/open-bastion/cache.key` is now rejected
   instead of used with a warning** (offline auth cache, desktop SSO). Versions
   up to 0.6.2 accepted such a key and merely logged a warning. `SECURITY.md`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,54 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `auth required pam_deny.so`. Check with
   `grep '^auth' /etc/pam.d/sshd`.
 
+### Added
+
+- **The missing EBIOS RM workshops, treatment plan and homologation dossier
+  (#212, #216, #217).** `doc/security/` was presented as an EBIOS RM study while
+  containing only workshop 4: the word "EBIOS" appeared nowhere inside it, there
+  were no essential assets, no risk sources, no strategic scenarios, and no
+  explicit likelihood or severity scales — the matrices assumed scales that were
+  never written down. There was also no treatment plan (25 free-text "pistes"
+  with no owner, priority, due date or status) and no decision artefact at all:
+  no perimeter of homologation, no conditions of use, no residual-risk
+  acceptance.
+
+  Five documents are added:
+
+  - `04-atelier1-cadrage-socle.md` — perimeter, business values, supporting
+    assets, the **severity and likelihood scales** the matrices were using
+    implicitly, the risk-zone definition, seven feared events, and the security
+    baseline with its gaps. Every one of the 39 risk sheets is attached to
+    exactly one feared event.
+  - `05-atelier2-sources-de-risque.md` — seven risk sources, six target
+    objectives, the SR/OV relevance grid, and why the discarded pairs were
+    discarded — including the LLNG portal administrator, who is not a risk the
+    product can reduce and is stated as a trust assumption instead.
+  - `06-atelier3-scenarios-strategiques.md` — ecosystem mapping with threat
+    levels, and seven strategic scenarios, each saying what the architecture
+    opposes **and what it does not**.
+  - `07-plan-de-traitement.md` — the treatment plan: 29 measures with the risk
+    they reduce, nature, priority, owner, due date and state, plus four measures
+    explicitly discarded with their reason. Delivered measures stay in the plan
+    with their PR reference — that is what was missing when two shipped measures
+    were still listed as future work.
+  - `08-dossier-homologation.md` — the decision artefacts: dossier front matter,
+    the homologation perimeter (**the LLNG portal and its four plugins are
+    inside it**), what is explicitly out with what is expected of the operator,
+    four trust assumptions, **fifteen conditions of use** with how to verify each
+    on target, and the residual-risk acceptance table.
+
+  Plus `doc/security/README.md`, which maps each document to its workshop.
+
+  Owner names, dates, product version and acceptance decisions are left as
+  `À COMPLÉTER`: they belong to the homologation authority, not to the analysis.
+  The dossier says so rather than inventing them.
+
+  The risk-zone definition is also unified: `01-enrollment.md` used thresholds on
+  (P, I) and `99-risk-reduce.md` used a score, with listings that did not match
+  either. There is now one definition (score = likelihood × severity) in
+  workshop 1, and the checker fails if a zone listing does not follow from it.
+
 ### Changed
 
 - **Every EBIOS risk matrix now agrees with the risk sheets it summarises

--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ The full, theme-organized index is in **[doc/README.md](doc/README.md)**. Highli
 - **Offline & resilience** — [Offline mode](doc/offline-mode.md) · [Cache administration](doc/offline-cache-admin.md)
 - **Security & hardening** — [Security features](doc/security.md) · [Hardening](doc/hardening.md) · [CrowdSec](doc/crowdsec.md)
 - **Reference** — [Canonical names & paths](doc/reference-paths.md) · [Configuration](doc/configuration.md) · [Troubleshooting](doc/troubleshooting.md) · [Desktop SSO](doc/desktop-sso.md) _(experimental/alpha)_ · [Competitors](doc/competitors.md)
-- **Security analysis (EBIOS)** — [threat model & risk study](doc/security/00-architecture.md)
+- **Security analysis (EBIOS RM)** — [full risk study](doc/security/README.md) _(French)_ · [conditions of use before deploying](doc/security/08-dossier-homologation.md#2-conditions-demploi)
 
 ## Troubleshooting
 

--- a/doc/README.md
+++ b/doc/README.md
@@ -70,14 +70,24 @@ Who can do what, where — and which knob lives on the SSO vs the server.
 | [Desktop SSO](desktop-sso.md)                   | LightDM greeter + LLNG login **(experimental / alpha)** |
 | [Competitors](competitors.md)                   | Comparison with other solutions                         |
 
-## Security analysis (EBIOS)
+## Security analysis (EBIOS Risk Manager)
 
-Detailed threat model and risk study, for audits and compliance (French).
+Full risk study following the ANSSI EBIOS RM method, for audits and compliance
+(French). Start at **[security/README.md](security/README.md)**, which maps each
+document to its workshop.
 
-| Document                                        | Description                      |
-| ----------------------------------------------- | -------------------------------- |
-| [Architecture](security/00-architecture.md)     | Security architecture overview   |
-| [Enrollment](security/01-enrollment.md)         | Server enrollment security       |
-| [SSH connection](security/02-ssh-connection.md) | SSH authentication flow security |
-| [Offboarding](security/03-offboarding.md)       | User and server offboarding      |
-| [Risk reduction](security/99-risk-reduce.md)    | Residual risks and mitigations   |
+| Workshop                    | Document                                                                                           | Description                                                     |
+| --------------------------- | -------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
+| —                           | [Architecture](security/00-architecture.md)                                                        | Security target and architecture overview                       |
+| **1** Scope and baseline    | [Atelier 1](security/04-atelier1-cadrage-socle.md)                                                 | Perimeter, business values, **scales**, feared events, baseline |
+| **2** Risk origins          | [Atelier 2](security/05-atelier2-sources-de-risque.md)                                             | Risk sources, target objectives, retained pairs                 |
+| **3** Strategic scenarios   | [Atelier 3](security/06-atelier3-scenarios-strategiques.md)                                        | Ecosystem mapping and seven strategic scenarios                 |
+| **4** Operational scenarios | [Enrollment](security/01-enrollment.md) · [SSH](security/02-ssh-connection.md)                     | 39 risk sheets with initial and residual scores                 |
+| **5** Treatment             | [Treatment plan](security/07-plan-de-traitement.md) · [Risk reduction](security/99-risk-reduce.md) | Dated, owned plan; consolidated residual matrix                 |
+| Decision                    | [Homologation dossier](security/08-dossier-homologation.md)                                        | Perimeter, **conditions of use**, residual risk acceptance      |
+| Operational                 | [Offboarding](security/03-offboarding.md)                                                          | User and server offboarding procedure                           |
+
+> Deploying? The fifteen **conditions of use** in
+> [the homologation dossier](security/08-dossier-homologation.md#2-conditions-demploi)
+> are the assumptions the residual scores depend on — and that the product does
+> not all enforce for you.

--- a/doc/security/01-enrollment.md
+++ b/doc/security/01-enrollment.md
@@ -1114,18 +1114,27 @@ sequenceDiagram
 | Impact ↓ / Probabilité → | 1 - Très improbable | 2 - Peu probable | 3 - Probable | 4 - Très probable |
 | ------------------------ | ------------------- | ---------------- | ------------ | ----------------- |
 | **4 - Critique**         |                     | R3 R5 R7 R11 R13 | R4           |                   |
-| **3 - Important**        |                     | R8 R10           | R1 R2 R12    |                   |
-| **2 - Limité**           |                     | R0 R6 R9         |              |                   |
+| **3 - Important**        |                     | R2 R8 R10        | R1 R12       |                   |
+| **2 - Limité**           |                     | R0 R9            | R6           |                   |
 | **1 - Négligeable**      |                     |                  |              |                   |
 
 ### Après remédiation
 
+Configuration de référence : un `client_id` par projet, avec la segmentation
+`server_group` appliquée. Chaque case reprend le **score résiduel écrit dans la
+fiche** du risque ; aucune valeur conditionnelle n'est appliquée en silence ici
+(la variante « clients OIDC distincts » a sa propre matrice ci-dessous).
+
 | Impact ↓ / Probabilité → | 1 - Très improbable | 2 - Peu probable | 3 - Probable | 4 - Très probable |
 | ------------------------ | ------------------- | ---------------- | ------------ | ----------------- |
-| **4 - Critique**         | R5                  |                  |              |                   |
-| **3 - Important**        | R1 R3 R8 R12        | R2               |              |                   |
-| **2 - Limité**           | R4 R7 R9 R10 R11    | R6               |              |                   |
-| **1 - Négligeable**      | R0 R13              |                  |              |                   |
+| **4 - Critique**         | R4 R5               |                  |              |                   |
+| **3 - Important**        | R2 R3 R7 R8 R11 R12 | R1               |              |                   |
+| **2 - Limité**           | R0 R9 R10           |                  |              |                   |
+| **1 - Négligeable**      | R13                 | R6               |              |                   |
+
+> **R4 :** sa fiche donne `I=4 (ou 3 avec segmentation server_group)`. La matrice
+> retient la valeur non conditionnelle, `I=4` ; avec `pamAccessServerGroups`
+> renseigné, R4 descend en `I=3` aux côtés de R7 et R11.
 
 **Remédiations appliquées :**
 
@@ -1140,16 +1149,30 @@ sequenceDiagram
 
 > **Deux axes à ne pas confondre.** Le `server_group` sépare les _politiques_ **à l'intérieur** d'un projet (un même `client_id`) ; il ne borne le rayon d'impact des _credentials_ d'enrôlement que si le **mapping d'autorité `client_id → server_group`** (`pamAccessServerGroups` — à ne pas confondre avec les _règles_ d'accès par groupe `pamAccessSshRules`/`pamAccessSudoRules`) est renseigné. Quand un `client_id` couvre un projet **multi-groupes** (le modèle par défaut), l'isolation des credentials passe par des **`client_id` distincts par zone** (ligne « Clients OIDC distincts »), pas par le `server_group`.
 
-**Détail des améliorations avec clients OIDC distincts (voir section 5.2) :**
+### Après remédiation, variante « clients OIDC distincts » (configuration conditionnelle)
 
-| Risque  | Sans clients distincts | Avec clients distincts | Amélioration                                                       |
-| ------- | ---------------------- | ---------------------- | ------------------------------------------------------------------ |
-| **R0**  | P=1, I=2               | **P=1, I=1**           | Le secret compromis ne peut initier d'enrôlements que dans sa zone |
-| **R4**  | P=1, I=3               | **P=1, I=2**           | Le token volé n'est valide que pour le scope de sa zone            |
-| **R7**  | P=1, I=3               | **P=1, I=2**           | Le serveur malveillant ne peut usurper que sa zone                 |
-| **R11** | P=1, I=3               | **P=1, I=2**           | Le refresh_token compromis est limité à sa zone                    |
+Cette matrice ne s'applique **que si** un `client_id` distinct est déclaré par
+zone (voir section 5.2). Ce n'est pas la configuration par défaut, et elle n'est
+pas supposée acquise par la matrice précédente.
 
-**Résultat :** Seul R5 (usurpation du serveur LLNG) reste critique - c'est le point unique de défaillance irréductible.
+| Risque  | Fiche (client unique) | Avec clients distincts | Amélioration                                                       |
+| ------- | --------------------- | ---------------------- | ------------------------------------------------------------------ |
+| **R0**  | P=1, I=2              | **P=1, I=1**           | Le secret compromis ne peut initier d'enrôlements que dans sa zone |
+| **R4**  | P=1, I=4 (3 segmenté) | **P=1, I=2**           | Le token volé n'est valide que pour le scope de sa zone            |
+| **R7**  | P=1, I=3              | **P=1, I=2**           | Le serveur malveillant ne peut usurper que sa zone                 |
+| **R11** | P=1, I=3              | **P=1, I=2**           | Le refresh_token compromis est limité à sa zone                    |
+
+| Impact ↓ / Probabilité → | 1 - Très improbable | 2 - Peu probable | 3 - Probable | 4 - Très probable |
+| ------------------------ | ------------------- | ---------------- | ------------ | ----------------- |
+| **4 - Critique**         | R5                  |                  |              |                   |
+| **3 - Important**        | R2 R3 R8 R12        | R1               |              |                   |
+| **2 - Limité**           | R4 R7 R9 R10 R11    |                  |              |                   |
+| **1 - Négligeable**      | R0 R13              | R6               |              |                   |
+
+**Résultat :** dans la configuration de référence, R4 (vol du fichier token) et
+R5 (usurpation du serveur LLNG) restent en impact 4 ; avec des `client_id`
+distincts par zone, seul R5 y reste — c'est le point unique de défaillance
+irréductible, le seul que la segmentation ne borne pas.
 
 **Légende :**
 

--- a/doc/security/01-enrollment.md
+++ b/doc/security/01-enrollment.md
@@ -1174,12 +1174,10 @@ R5 (usurpation du serveur LLNG) restent en impact 4 ; avec des `client_id`
 distincts par zone, seul R5 y reste — c'est le point unique de défaillance
 irréductible, le seul que la segmentation ne borne pas.
 
-**Légende :**
-
-- Zone verte (P≤1, I≤2) : Risque acceptable
-- Zone jaune (P≤2, I≤3) : Risque à surveiller
-- Zone orange (P≤2, I=4 ou P=3, I=3) : Risque à traiter
-- Zone rouge (P≥3, I≥3) : Risque critique
+**Légende :** les échelles de vraisemblance et de gravité, et les zones de
+risque (score = Vraisemblance × Gravité), sont définies une fois pour toute
+l'étude en
+[atelier 1, §1.4 à §1.5.1](04-atelier1-cadrage-socle.md#14-échelle-de-gravité).
 
 ---
 

--- a/doc/security/02-ssh-connection.md
+++ b/doc/security/02-ssh-connection.md
@@ -1358,23 +1358,23 @@ Contrairement à R-S19 (recorder tué) et R-S20 (action différée), ici le reco
 
 ### Avant remédiation
 
-| Impact ↓ / Probabilité → | 1 - Très improbable | 2 - Peu probable                                          | 3 - Probable | 4 - Très probable |
-| ------------------------ | ------------------- | --------------------------------------------------------- | ------------ | ----------------- |
-| **4 - Critique**         | R-S4                | R-S6 R-S17                                                |              |                   |
-| **3 - Important**        |                     | R-S3 R-S7 R-S11 R-S15 R-S13 R-S14 R-S18 R-S20 R-S21 R-S23 | R-S19        |                   |
-| **2 - Limité**           | R-S16 R-S22         | R-S9 R-S10 R-S12                                          | R-S8         |                   |
-| **1 - Négligeable**      |                     |                                                           |              |                   |
+| Impact ↓ / Probabilité → | 1 - Très improbable    | 2 - Peu probable                              | 3 - Probable | 4 - Très probable |
+| ------------------------ | ---------------------- | --------------------------------------------- | ------------ | ----------------- |
+| **4 - Critique**         | R-S4 R-S24 R-SA2       | R-S6 R-S17 R-SA1                              |              |                   |
+| **3 - Important**        | R-S5 R-S23 R-S25       | R-S3 R-S7 R-S13 R-S14 R-S15 R-S18 R-S20 R-S21 | R-S11 R-S19  |                   |
+| **2 - Limité**           | R-S9 R-S10 R-S16 R-S22 | R-S12                                         | R-S8         |                   |
+| **1 - Négligeable**      |                        |                                               |              |                   |
 
-> **Note :** R-S1 (brute-force mot de passe) et R-S2 (vol de clé SSH simple) sont **éliminés** par la cible de sécurité maximale (`AuthorizedKeysFile none` + certificat CA requis). R-S5 démarre à P=1 grâce aux certificats CA obligatoires. R-S18 est ici à P=2 (et non P=3) car le wrapper setgid empêche l'accès aux recordings d'autres utilisateurs, ce qui réduit la probabilité d'un effacement « croisé » même avant remédiation complète ; l'effacement de ses propres recordings reste possible (cf. fiche R-S18).
+> **Note :** R-S1 (brute-force mot de passe) et R-S2 (vol de clé SSH simple) sont **éliminés** par la cible de sécurité maximale (`AuthorizedKeysFile none` + certificat CA requis) : ils n'ont pas de fiche et n'apparaissent donc dans aucune matrice. R-S5 démarre à P=1 grâce aux certificats CA obligatoires. R-S18 est ici à P=2 (et non P=3) car le wrapper setgid empêche l'accès aux recordings d'autres utilisateurs, ce qui réduit la probabilité d'un effacement « croisé » même avant remédiation complète ; l'effacement de ses propres recordings reste possible (cf. fiche R-S18). Les risques de comptes de service (R-SA1, R-SA2, R-S24, R-S25) sont analysés en section 6 et figurent ici avec les autres, pour que la matrice couvre l'intégralité de l'étude.
 
 ### Après remédiation complète
 
-| Impact ↓ / Probabilité → | 1 - Très improbable                                                   | 2 - Peu probable | 3 - Probable | 4 - Très probable |
-| ------------------------ | --------------------------------------------------------------------- | ---------------- | ------------ | ----------------- |
-| **4 - Critique**         | R-S4                                                                  |                  |              |                   |
-| **3 - Important**        | R-S5 R-S23                                                            | R-S6             |              |                   |
-| **2 - Limité**           | R-S7 R-S9 R-S10 R-S11 R-S12 R-S13 R-S14 R-S16 R-S17 R-S20 R-S21 R-S22 | R-S8             |              |                   |
-| **1 - Négligeable**      | R-S15 R-S19                                                           | R-S3 R-S18       |              |                   |
+| Impact ↓ / Probabilité → | 1 - Très improbable                                             | 2 - Peu probable | 3 - Probable | 4 - Très probable |
+| ------------------------ | --------------------------------------------------------------- | ---------------- | ------------ | ----------------- |
+| **4 - Critique**         | R-S4 R-SA2                                                      |                  |              |                   |
+| **3 - Important**        | R-S5 R-S11 R-S23 R-S24                                          | R-S6 R-SA1       |              |                   |
+| **2 - Limité**           | R-S7 R-S9 R-S12 R-S13 R-S14 R-S16 R-S17 R-S20 R-S21 R-S22 R-S25 | R-S8             |              |                   |
+| **1 - Négligeable**      | R-S10 R-S15 R-S18 R-S19                                         | R-S3             |              |                   |
 
 **Profil de risque de la cible maximale :**
 
@@ -1385,12 +1385,20 @@ Contrairement à R-S19 (recorder tué) et R-S20 (action différée), ici le reco
 - R-S15 (KRL stale) : **I=1** grâce au binding fingerprint sur `/pam/authorize` : une révocation LLNG interdit l'ouverture d'une session SSH à chaque nouvelle connexion, indépendamment de la fraîcheur de la KRL
 - R-S16 (escalade sudo) : **contrôlé par réauthentification SSO obligatoire**
 - R-S17 (lockout) : **contrôlé par compte de service secours** + procédure console documentée
-- R-S18 (effacement sessions) : **traçable mais reste effaçable techniquement** ; l'imputation tient grâce à syslog `auth.info` (start/end de session) et, si PR2 (#113) est activée, grâce au watch auditd `-w /var/lib/open-bastion/sessions/` qui trace l'événement d'effacement lui-même
+- R-S18 (effacement sessions) : **P=1, I=1 depuis la PR #157** — les enregistrements sont écrits par le puits root `ob-record-sink` dans une arborescence `root:ob-sessions 0750`, à laquelle l'utilisateur enregistré n'a aucun accès : l'effacement n'est plus techniquement possible pour lui, seul root du bastion le peut. L'imputation tient en outre grâce à syslog `auth.info` (start/end de session) et, si PR2 (#113) est activée, au watch auditd `-w /var/lib/open-bastion/sessions/`
 - R-S19 (évasion containment via `setsid`/`nohup`), R-S20 (action différée via `at`/`cron`/`systemd-run`), R-S21 (action non capturée par le pty) : **nouvellement identifiés** et mitigés par PR1 (#112) et PR2 (#113) sous condition d'activation opt-in
 - **Conditions d'activation :** ces nouveaux risques (R-S19, R-S20, R-S21) ne sont mitigés à leur niveau résiduel **que si** le hardening (PR1) ET la trace auditd (PR2) sont activés via `ob-bastion-setup --enable-hardening --enable-audit-trace`. En l'absence d'activation, ces risques restent en zone jaune (P=3, I=3 pour R-S19 ; P=2, I=3 pour R-S20 et R-S21). Voir [doc/hardening.md](../hardening.md) et [doc/audit.md](../audit.md) (documentations techniques en anglais) pour les détails opérationnels.
 - R-S22 (certificat vouché réutilisé vers un autre backend) : **P=1, I=2** — `target=` non vérifié par `ob-ssh-principals`, mais `source-address` impose le contrôle du bastion et l'allowlist par backend cloisonne les zones (piste : vérifier `target=` contre le FQDN local)
 - R-S23 (backend en mode hérité, `allowed_bastions` absent) : **P=1, I=3** — `ob-backend-setup` écrit toujours le fichier et `ob-ssh-principals` est fail-closed si illisible ; le risque résiduel ne concerne qu'un backend jamais configuré par le setup (piste : postinst écrivant un fichier vide par défaut)
-- Seuls risques résiduels significatifs en zone jaune (PR1 et PR2 activées) : R-S4 (CA compromise) et R-S6 (bastion compromis)
+- R-S24 (sudo de compte de service hors token SSO) : **P=1, I=3** — le droit vient de `service-accounts.conf` seul, sans appel LLNG ; `sudo_nopasswd = false` reste la configuration recommandée (l'empreinte de la clé y est revérifiée à chaque `sudo`)
+- R-S25 (hop de compte de service via ProxyJump) : **P=1, I=2** — non enregistré par le `ForceCommand` (canal `direct-tcpip`) ; à traiter par `AllowTcpForwarding no` ou par un accès direct aux cibles
+- Risques résiduels en zone jaune (PR1 et PR2 activées) : R-S4 et R-SA2 (P=1, I=4), R-SA1 (P=2, I=3), R-S6 (P=2, I=3), R-S8 (P=2, I=2)
+
+> **Comment lire ces matrices.** Chaque case reprend le score écrit dans la fiche
+> du risque, sans réévaluation locale : une case et une fiche ne peuvent pas
+> diverger. `tests/ebios_matrix_check.py` le vérifie mécaniquement sur les cinq
+> matrices de l'étude et échoue si l'une d'elles s'écarte de ses fiches, ou si un
+> risque analysé n'y figure pas.
 
 ---
 
@@ -1657,6 +1665,70 @@ sequenceDiagram
 | --------------- | :------------: |
 | **Probabilité** |       1        |
 | **Impact**      |       4        |
+
+#### R-S24 - Sudo de compte de service hors token SSO
+
+|                 | Score |
+| --------------- | :---: |
+| **Probabilité** |   1   |
+| **Impact**      |   4   |
+
+**Description :** Le droit sudo d'un compte de service provient **uniquement** de `service-accounts.conf` (`sudo_allowed` / `sudo_nopasswd`) : `pam_openbastion` l'accorde localement et renvoie un succès **sans aucun appel LLNG**, **y compris en Mode E** où un humain doit présenter un token LLNG frais. Une clé de service avec `sudo_allowed` est donc un privilège local permanent qui échappe à la porte sudo gouvernée par le SSO.
+
+**Vecteurs d'attaque :**
+
+- Vol de la clé privée d'un compte de service disposant de `sudo_allowed`
+- Réutilisation d'une clé d'automatisation exposée dans un dépôt, un artefact CI ou une sauvegarde
+- Prestataire ou outil sorti du périmètre sans retrait de sa clé du fichier
+
+**Facteurs atténuants structurels :**
+
+- Le fichier est local à chaque serveur : la portée d'une clé est bornée aux serveurs qui la déclarent
+- `service-accounts.conf` est root:root 0600, refusé s'il est un lien symbolique (`O_NOFOLLOW`)
+- PAM n'autorise que la **tentative** : `sudoers` décide encore _quelles_ commandes
+- Avec `sudo_nopasswd = false`, l'empreinte de la clé SSH est revérifiée à chaque `sudo` (voir #194) — le compte doit prouver la clé qui a ouvert la session
+
+**Remédiation :**
+
+1. **Minimiser** : n'accorder `sudo_allowed` qu'aux comptes qui en ont réellement besoin ; préférer `sudo_nopasswd = false` et des règles `sudoers` restreintes à des commandes précises
+2. **Inventaire et rotation** : traiter chaque clé de service comme un secret de longue durée (coffre-fort, rotation périodique, révocation à la sortie d'un prestataire)
+3. **Audit dédié** : journaliser et alerter sur l'usage sudo des comptes de service (clé auditd `-k` distincte), puisqu'il n'apparaît pas dans les logs d'autorisation LLNG
+
+|                 |                                Score résiduel                                 |
+| --------------- | :---------------------------------------------------------------------------: |
+| **Probabilité** |        1 (clé en coffre-fort, périmètre borné aux serveurs déclarants)        |
+| **Impact**      | 3 (root sur les serveurs déclarant la clé, sans passer par la porte sudo SSO) |
+
+#### R-S25 - Hop de compte de service via ProxyJump non enregistré
+
+|                 | Score |
+| --------------- | :---: |
+| **Probabilité** |   1   |
+| **Impact**      |   3   |
+
+**Description :** Un compte de service ne peut pas utiliser `ob-ssh` (pas de voucher SSO), mais un `ssh -J bastion compte@backend` natif fonctionne s'il est configuré des deux côtés et que le bastion autorise le forwarding TCP. Or le `ForceCommand` (enregistreur de session) **ne couvre pas le canal `direct-tcpip`** : un tel hop **n'est pas enregistré** sur le bastion.
+
+**Vecteurs d'attaque :**
+
+- Compte de service déclaré à la fois sur le bastion et sur un backend, avec `AllowTcpForwarding` laissé à `yes`
+- Usage légitime détourné : l'automatisation traverse le bastion sans laisser de trace de session
+
+**Facteurs atténuants structurels :**
+
+- Le hop reste tracé par `sshd` des deux côtés (ouverture de canal, authentification par clé, empreinte)
+- Les logs d'audit du backend (auditd, `journald`) s'appliquent normalement à la session résultante
+- La clé doit être déclarée **explicitement** sur les deux hôtes
+
+**Remédiation :**
+
+1. **Accès direct** : faire pointer les comptes de service directement sur les serveurs cibles plutôt que de les relayer par le bastion — la traçabilité repose alors sur les logs de la cible
+2. **`AllowTcpForwarding no` sur le bastion** : interdire explicitement le canal `direct-tcpip` quand aucun usage légitime ne l'exige
+3. **Inventaire** : recenser les comptes de service déclarés simultanément sur bastion et backend, qui sont les seuls à pouvoir emprunter ce chemin
+
+|                 |                              Score résiduel                               |
+| --------------- | :-----------------------------------------------------------------------: |
+| **Probabilité** |   1 (nécessite la clé déclarée des deux côtés et le forwarding ouvert)    |
+| **Impact**      | 2 (pas d'enregistrement de session ; sshd et l'audit de la cible tracent) |
 
 ### Recommandations
 

--- a/doc/security/04-atelier1-cadrage-socle.md
+++ b/doc/security/04-atelier1-cadrage-socle.md
@@ -1,0 +1,167 @@
+# Atelier 1 — Cadrage et socle de sécurité
+
+> **Méthode :** EBIOS Risk Manager (ANSSI, 2018). Cet atelier définit le
+> périmètre étudié, les valeurs métier et biens supports, les événements
+> redoutés avec leur gravité, et le socle de sécurité applicable.
+>
+> **Statut du document :** voir [08-dossier-homologation.md](08-dossier-homologation.md)
+> pour la version, l'auteur, l'approbateur et le périmètre d'homologation.
+
+## 1.1 Objet et périmètre de l'étude
+
+Open Bastion est un point de passage SSH d'entreprise : les administrateurs
+ouvrent leurs sessions à travers un **bastion**, qui les enregistre, et rebondit
+vers des **backends** ; l'authentification, l'autorisation et l'escalade `sudo`
+sont gouvernées par un portail **LemonLDAP::NG (LLNG)** et sa chaîne de plugins.
+
+### Périmètre technique retenu
+
+| Dans le périmètre                                                                                                           | Hors périmètre                                               |
+| --------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
+| Module PAM `pam_openbastion.so` et module NSS `libnss_openbastion`                                                          | Le système d'exploitation hôte et son durcissement de base   |
+| Démons et clients : `ob-cert-daemon`, `ob-record-sink`, `ob-ssh`/`ob-scp`/`ob-sftp`                                         | `sshd` lui-même (OpenSSH amont)                              |
+| Scripts d'installation et d'enrôlement : `ob-bastion-setup`, `ob-backend-setup`, `ob-enroll`                                | Le réseau et sa segmentation                                 |
+| Le générateur de déploiements `ob-builder` et les artefacts qu'il produit                                                   | L'annuaire (LDAP/AD) derrière LLNG                           |
+| **Le portail LLNG et ses quatre plugins** : `pam-access`, `ssh-ca`, `oidc-device-authorization`, `oidc-device-organization` | Le socle LLNG cœur (portail, sessions, Manager) hors plugins |
+
+Le portail et sa chaîne de plugins sont **dans** le périmètre : c'est lui qui
+autorise chaque session et chaque `sudo`, signe les certificats et détient la
+clé de CA. Une étude qui s'arrêterait au bord du serveur ne dirait rien de la
+moitié des décisions de sécurité. Cette inclusion est une décision
+d'homologation, tracée comme telle en
+[08-dossier-homologation.md](08-dossier-homologation.md).
+
+### Cible de sécurité étudiée
+
+L'étude porte sur la **cible maximale (Mode E)** décrite en
+[00-architecture.md](00-architecture.md) : certificats CA obligatoires
+(`AuthorizedKeysFile none`), autorisation LLNG à chaque connexion, `sudo` par
+token LLNG à usage unique, KRL obligatoire, rebond bastion→backend par
+certificat éphémère vouché. Les modes moins restrictifs (A à D, voir
+[doc/pam-modes.md](../pam-modes.md)) réduisent le niveau de garantie ; ils ne
+sont pas la cible de cette étude et **ne sont pas homologués par elle**.
+
+## 1.2 Valeurs métier
+
+Les valeurs métier sont ce que l'organisation cherche à protéger, exprimé en
+termes de finalité et non de technique.
+
+| Id      | Valeur métier                            | Description                                                                                                       | Nature      |
+| ------- | ---------------------------------------- | ----------------------------------------------------------------------------------------------------------------- | ----------- |
+| **VM1** | Accès administrateur au SI               | La capacité, pour les seules personnes habilitées, d'administrer les serveurs de production                       | Processus   |
+| **VM2** | Traçabilité des actions d'administration | La preuve de qui a fait quoi, quand, sur quel serveur — opposable en cas d'incident ou de contrôle                | Information |
+| **VM3** | Confidentialité des sessions             | Le contenu des sessions d'administration (secrets manipulés, configurations, données consultées)                  | Information |
+| **VM4** | Continuité de l'exploitation             | La capacité à intervenir sur les serveurs, y compris en situation dégradée (panne du SSO, incident réseau)        | Processus   |
+| **VM5** | Maîtrise du cycle de vie des accès       | L'attribution, la révision et surtout la **révocation** effective des accès, notamment au départ d'un intervenant | Processus   |
+
+## 1.3 Biens supports
+
+| Id      | Bien support                                                  | Valeurs métier portées | Détenteur             |
+| ------- | ------------------------------------------------------------- | ---------------------- | --------------------- |
+| **BS1** | Clé privée de la CA SSH (détenue par le portail LLNG)         | VM1, VM3, VM5          | Administrateur LLNG   |
+| **BS2** | Portail LLNG et ses plugins (`/pam/*`, `/ssh/*`, `/device`)   | VM1, VM5               | Administrateur LLNG   |
+| **BS3** | Bastion : `sshd`, `pam_openbastion`, enregistreur de session  | VM1, VM2, VM3          | Équipe Open Bastion   |
+| **BS4** | Backends : `sshd`, `pam_openbastion`, `sudo`                  | VM1, VM3               | Équipe d'exploitation |
+| **BS5** | Enregistrements de session (`/var/lib/open-bastion/sessions`) | VM2                    | Équipe Open Bastion   |
+| **BS6** | Credentials d'enrôlement (`client_secret`, token serveur)     | VM1, VM5               | Équipe Open Bastion   |
+| **BS7** | Caches locaux (autorisation offline, NSS)                     | VM1, VM4               | Équipe Open Bastion   |
+| **BS8** | Comptes de service (`service-accounts.conf` et leurs clés)    | VM1, VM4               | Équipe d'exploitation |
+| **BS9** | KRL (liste de révocation des certificats)                     | VM5                    | Administrateur LLNG   |
+
+## 1.4 Échelle de gravité
+
+Cette échelle est celle qu'emploient — implicitement jusqu'ici — les colonnes
+« Impact » des matrices des ateliers 4 et 5. Elle est désormais explicite : une
+case de matrice se lit avec elle.
+
+| Niveau | Libellé         | Critère                                                                                                                 |
+| :----: | --------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| **4**  | **Critique**    | Compromission de l'ensemble du parc administré, ou perte totale et irrécupérable de la traçabilité                      |
+| **3**  | **Important**   | Compromission d'une zone (un `server_group`, un projet), ou perte de traçabilité sur un périmètre identifié             |
+| **2**  | **Limité**      | Compromission d'un serveur, ou dégradation temporaire de la traçabilité ou de la disponibilité, avec détection possible |
+| **1**  | **Négligeable** | Gêne opérationnelle sans perte de sécurité, ou incident intégralement tracé et réversible                               |
+
+## 1.5 Échelle de vraisemblance
+
+Employée par les colonnes « Probabilité » des matrices.
+
+| Niveau | Libellé             | Critère                                                                                                      |
+| :----: | ------------------- | ------------------------------------------------------------------------------------------------------------ |
+| **4**  | **Très probable**   | Se produira dans la durée de vie du système sans mesure supplémentaire ; exploitable sans compétence notable |
+| **3**  | **Probable**        | Plausible dans l'année ; exploitable par un attaquant motivé disposant d'un accès réseau                     |
+| **2**  | **Peu probable**    | Suppose une conjonction de conditions (accès privilégié, erreur de configuration, position réseau)           |
+| **1**  | **Très improbable** | Suppose la compromission préalable d'un bien support fortement protégé, ou un attaquant de niveau étatique   |
+
+## 1.5.1 Zones de risque
+
+Le **score** d'un risque est le produit Vraisemblance × Gravité. Cette
+définition unique s'applique à toutes les matrices de l'étude ; jusqu'ici,
+`01-enrollment.md` employait un zonage par seuils sur (P, I) et
+`99-risk-reduce.md` un zonage par score, avec des listes qui ne se recoupaient
+pas.
+
+| Zone       | Score | Traitement attendu                                                    |
+| ---------- | :---: | --------------------------------------------------------------------- |
+| **Verte**  |  ≤ 3  | Risque acceptable en l'état ; surveillance ordinaire                  |
+| **Jaune**  | 4 – 5 | Risque à surveiller ; mesure de traitement souhaitable, non bloquante |
+| **Orange** | 6 – 8 | Risque à traiter ; mesure requise ou acceptation formelle motivée     |
+| **Rouge**  |  ≥ 9  | Risque inacceptable ; traitement obligatoire avant mise en production |
+
+L'acceptation formelle des risques en zone orange est portée par
+[08-dossier-homologation.md](08-dossier-homologation.md).
+
+## 1.6 Événements redoutés
+
+Un événement redouté (ER) porte atteinte à une valeur métier. Il est indépendant
+du chemin d'attaque : les scénarios sont l'objet des ateliers 3 et 4.
+
+| Id      | Événement redouté                                                                     | Valeur métier | Critère DICP | Gravité |
+| ------- | ------------------------------------------------------------------------------------- | ------------- | ------------ | :-----: |
+| **ER1** | Un tiers non habilité obtient un accès administrateur à un ou plusieurs serveurs      | VM1           | I            |  **4**  |
+| **ER2** | Un accès administrateur légitime perdure après la révocation de son titulaire         | VM5           | I            |  **3**  |
+| **ER3** | Une action d'administration n'est pas enregistrée, ou son enregistrement est altéré   | VM2           | I, P         |  **3**  |
+| **ER4** | Le contenu d'une session d'administration est divulgué                                | VM3           | C            |  **3**  |
+| **ER5** | Les administrateurs ne peuvent plus accéder aux serveurs (verrouillage total)         | VM4           | D            |  **3**  |
+| **ER6** | La CA SSH est compromise : l'attaquant peut signer des certificats pour n'importe qui | VM1, VM5      | I, C         |  **4**  |
+| **ER7** | Un serveur non légitime est enrôlé et obtient des identités et des autorisations      | VM1           | I            |  **3**  |
+
+Correspondance avec les fiches de l'atelier 4 :
+
+| ER  | Fiches de risque associées                                                             |  Nb |
+| --- | -------------------------------------------------------------------------------------- | --: |
+| ER1 | R4, R8, R11, R-S3, R-S6, R-S11, R-S12, R-S13, R-S16, R-S22, R-S23, R-S24, R-SA1, R-SA2 |  14 |
+| ER2 | R12, R-S8, R-S15                                                                       |   3 |
+| ER3 | R-S5, R-S18, R-S19, R-S20, R-S21, R-S25                                                |   6 |
+| ER4 | R-S9                                                                                   |   1 |
+| ER5 | R6, R9, R10, R-S7, R-S10, R-S14, R-S17                                                 |   7 |
+| ER6 | R5, R-S4                                                                               |   2 |
+| ER7 | R0, R1, R2, R3, R7, R13                                                                |   6 |
+
+Les 39 fiches de l'atelier 4 sont rattachées, chacune à un et un seul événement
+redouté ; `tests/ebios_matrix_check.py` vérifie que la table ci-dessus les
+couvre toutes et n'en invente aucune.
+
+## 1.7 Socle de sécurité
+
+Le socle est l'ensemble des référentiels applicables et l'état des écarts.
+
+| Référentiel                                                | Applicabilité                                               | État                                                                                             |
+| ---------------------------------------------------------- | ----------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
+| **Guide ANSSI « Recommandations pour l'admin sécurisée »** | Structurant : bastion, point de passage unique, traçabilité | Conforme sur l'architecture ; écarts tracés en atelier 5                                         |
+| **ISO/IEC 27002:2022** § 8.2 (droits d'accès privilégiés)  | Directement applicable                                      | Conforme : attribution via LLNG, révision par les groupes, révocation immédiate côté portail     |
+| **ISO/IEC 27002:2022** § 8.15 (journalisation)             | Directement applicable                                      | Conforme sous condition d'emploi : enregistrement fail-closed activé, auditd opt-in (PR2)        |
+| **ISO/IEC 27002:2022** § 8.5 (authentification sécurisée)  | Directement applicable                                      | Conforme : certificats CA + réauthentification SSO pour `sudo`                                   |
+| **Politique de mots de passe de l'organisation**           | Sans objet sur la cible Mode E                              | Aucun mot de passe SSH n'est accepté (`AuthorizedKeysFile none`, PAM `auth` fail-closed)         |
+| **Durcissement système (CIS, ANSSI-BP-028)**               | Applicable à l'hôte, hors périmètre de l'étude              | À la charge de l'exploitant ; `--enable-hardening` couvre le confinement de session (voir R-S19) |
+
+Les écarts au socle qui restent ouverts sont portés par le plan de traitement en
+[07-plan-de-traitement.md](07-plan-de-traitement.md), et les hypothèses que le
+socle suppose vérifiées sont les **conditions d'emploi** de
+[08-dossier-homologation.md](08-dossier-homologation.md).
+
+---
+
+Ateliers suivants : [Atelier 2 — sources de risque](05-atelier2-sources-de-risque.md) ·
+[Atelier 3 — scénarios stratégiques](06-atelier3-scenarios-strategiques.md) ·
+Atelier 4 — scénarios opérationnels : [enrôlement](01-enrollment.md) et
+[connexion SSH](02-ssh-connection.md) · [Atelier 5 — traitement](07-plan-de-traitement.md)

--- a/doc/security/05-atelier2-sources-de-risque.md
+++ b/doc/security/05-atelier2-sources-de-risque.md
@@ -1,0 +1,84 @@
+# Atelier 2 — Sources de risque et objectifs visés
+
+> **Méthode :** EBIOS Risk Manager (ANSSI, 2018), atelier 2. On identifie
+> **qui** pourrait vouloir porter atteinte aux valeurs métier de
+> [l'atelier 1](04-atelier1-cadrage-socle.md), **ce qu'il chercherait à
+> obtenir**, et on retient les couples SR/OV (source de risque / objectif visé)
+> les plus pertinents pour la suite de l'étude.
+
+## 2.1 Sources de risque identifiées
+
+| Id      | Source de risque                            | Motivation                                       | Ressources                                               | Activité                     |
+| ------- | ------------------------------------------- | ------------------------------------------------ | -------------------------------------------------------- | ---------------------------- |
+| **SR1** | Attaquant externe opportuniste              | Gain financier (rançongiciel, revente d'accès)   | Faibles : outillage public, scans de masse               | Élevée, permanente           |
+| **SR2** | Attaquant externe ciblé (groupe organisé)   | Espionnage, sabotage, revente d'accès privilégié | Élevées : 0-day possible, temps long, ingénierie sociale | Moyenne, campagne dirigée    |
+| **SR3** | Administrateur légitime malveillant         | Contournement du contrôle, dissimulation d'actes | Très élevées : accès légitime, connaissance du SI        | Faible mais impact maximal   |
+| **SR4** | Administrateur légitime maladroit           | Aucune — erreur                                  | Accès légitime                                           | Élevée (l'erreur est banale) |
+| **SR5** | Prestataire ou intervenant externe          | Dépassement de mandat, persistance après mission | Accès légitime borné dans le temps                       | Moyenne                      |
+| **SR6** | Compte technique / automatisation détournée | Aucune propre : vecteur pour SR1/SR2             | Clé de longue durée, souvent sans MFA ni rotation        | Moyenne, silencieuse         |
+| **SR7** | Administrateur du portail LLNG              | Contournement du contrôle depuis l'autorité      | Maximales : détient la CA, décide des autorisations      | Très faible, impact maximal  |
+
+SR7 est dans l'étude parce que le portail est **dans le périmètre**
+([atelier 1, §1.1](04-atelier1-cadrage-socle.md#périmètre-technique-retenu)) :
+qui administre LLNG peut signer un certificat pour n'importe qui et s'autoriser
+n'importe où. C'est un pouvoir concentré, que l'architecture ne cherche pas à
+contraindre — elle le trace.
+
+## 2.2 Objectifs visés
+
+| Id      | Objectif visé                                                    | Événements redoutés associés |
+| ------- | ---------------------------------------------------------------- | ---------------------------- |
+| **OV1** | Obtenir un accès administrateur durable au parc                  | ER1, ER6                     |
+| **OV2** | Conserver un accès après avoir perdu son habilitation            | ER2                          |
+| **OV3** | Agir sans laisser de trace exploitable                           | ER3                          |
+| **OV4** | Exfiltrer des secrets manipulés en session                       | ER4                          |
+| **OV5** | Empêcher l'exploitation (sabotage, extorsion)                    | ER5                          |
+| **OV6** | Introduire un serveur sous contrôle dans le périmètre administré | ER7                          |
+
+## 2.3 Couples SR/OV et pertinence
+
+Notation de la pertinence : **F** (forte, retenue pour la suite), **M**
+(moyenne, couverte mais non structurante), **f** (faible, hors étude).
+
+| SR ↓ / OV →                       | OV1 accès durable | OV2 survivre à la révocation | OV3 agir sans trace | OV4 exfiltrer | OV5 empêcher l'exploitation | OV6 enrôler un serveur |
+| --------------------------------- | :---------------: | :--------------------------: | :-----------------: | :-----------: | :-------------------------: | :--------------------: |
+| **SR1** externe opportuniste      |       **F**       |              f               |          f          |       M       |              M              |           f            |
+| **SR2** externe ciblé             |       **F**       |              M               |        **F**        |     **F**     |              M              |         **F**          |
+| **SR3** admin malveillant         |         M         |            **F**             |        **F**        |     **F**     |              M              |         **F**          |
+| **SR4** admin maladroit           |         f         |              f               |          f          |       f       |            **F**            |           M            |
+| **SR5** prestataire               |         M         |            **F**             |          M          |       M       |              f              |           f            |
+| **SR6** compte technique détourné |       **F**       |            **F**             |        **F**        |       M       |              f              |           f            |
+| **SR7** admin du portail LLNG     |       **F**       |            **F**             |        **F**        |     **F**     |            **F**            |         **F**          |
+
+### Couples retenus pour l'atelier 3
+
+Six couples structurent les scénarios stratégiques :
+
+| Couple        | Formulation                                                                                         | Traité par |
+| ------------- | --------------------------------------------------------------------------------------------------- | ---------- |
+| **SR2 × OV1** | Un attaquant ciblé obtient un accès administrateur durable au parc                                  | SS1, SS2   |
+| **SR2 × OV6** | Un attaquant ciblé fait enrôler un serveur sous son contrôle et récupère identités et autorisations | SS3        |
+| **SR3 × OV3** | Un administrateur légitime agit sans laisser de trace exploitable                                   | SS4        |
+| **SR5 × OV2** | Un prestataire conserve un accès après la fin de sa mission                                         | SS5        |
+| **SR6 × OV1** | Une clé d'automatisation détournée donne un accès privilégié permanent, hors du contrôle SSO        | SS6        |
+| **SR4 × OV5** | Une erreur d'exploitation rend le parc inaccessible (verrouillage total)                            | SS7        |
+
+### Couples écartés, et pourquoi
+
+- **SR1 × OV1** est réel mais entièrement couvert par SS1 : l'opportuniste
+  emprunte le même chemin que l'attaquant ciblé, avec moins de moyens. Le
+  traiter séparément n'ajouterait aucune mesure.
+- **SR7 × tout** n'est pas écarté mais **n'est pas traitable par le produit** :
+  l'administrateur du portail est l'autorité dont dépend tout le modèle. Il est
+  traité comme une **hypothèse de confiance** en
+  [08-dossier-homologation.md](08-dossier-homologation.md) — c'est-à-dire une
+  condition d'emploi (accès Manager restreint et tracé, clé de CA protégée), pas
+  un risque que l'on prétend réduire. Le dire explicitement vaut mieux que de
+  laisser croire que l'architecture s'en protège.
+- **SR4 × OV6** (enrôlement d'un serveur par erreur) est couvert par la règle
+  d'approbation `/device` : voir R0, R7 et la condition d'emploi correspondante.
+
+---
+
+Atelier précédent : [Atelier 1 — cadrage et socle](04-atelier1-cadrage-socle.md) ·
+Atelier suivant : [Atelier 3 — scénarios stratégiques](06-atelier3-scenarios-strategiques.md)

--- a/doc/security/06-atelier3-scenarios-strategiques.md
+++ b/doc/security/06-atelier3-scenarios-strategiques.md
@@ -1,0 +1,212 @@
+# Atelier 3 — Écosystème et scénarios stratégiques
+
+> **Méthode :** EBIOS Risk Manager (ANSSI, 2018), atelier 3. On cartographie les
+> parties prenantes de l'écosystème et leur niveau de menace, puis on construit
+> les **scénarios stratégiques** : les chemins de haut niveau par lesquels une
+> source de risque atteint son objectif. Les chemins techniques détaillés sont
+> l'objet de l'atelier 4 ([enrôlement](01-enrollment.md),
+> [connexion SSH](02-ssh-connection.md)).
+
+## 3.1 Cartographie de l'écosystème
+
+Le niveau de menace d'une partie prenante combine sa **dépendance** (à quel point
+le système en dépend), sa **pénétration** (l'accès dont elle dispose), sa
+**maturité** cyber et sa **confiance**. Échelle : 1 (faible) à 4 (élevé) pour
+dépendance et pénétration ; 1 (faible) à 4 (élevée) pour maturité et confiance.
+
+| Partie prenante                                       | Dépendance | Pénétration | Maturité | Confiance | Niveau de menace |
+| ----------------------------------------------------- | :--------: | :---------: | :------: | :-------: | :--------------: |
+| **Portail LLNG** (et son exploitant)                  |     4      |      4      |    3     |     4     |    **Élevé**     |
+| Annuaire LDAP/AD amont                                |     4      |      3      |    3     |     4     |      Moyen       |
+| Administrateurs internes                              |     3      |      4      |    3     |     3     |    **Élevé**     |
+| Prestataires d'infogérance                            |     2      |      3      |    2     |     2     |    **Élevé**     |
+| Automatisations (Ansible, CI/CD)                      |     3      |      3      |    2     |     3     |      Moyen       |
+| Éditeur / chaîne d'approvisionnement (paquets `.deb`) |     3      |      2      |    3     |     3     |      Moyen       |
+| Hébergeur / fournisseur d'infrastructure              |     3      |      2      |    3     |     3     |      Faible      |
+| Postes de travail des administrateurs                 |     3      |      3      |    2     |     2     |    **Élevé**     |
+
+Quatre parties prenantes ressortent en niveau élevé, et ce sont celles que les
+scénarios stratégiques suivent : le portail (autorité), les administrateurs
+(accès légitime), les prestataires (accès légitime borné, maturité plus faible)
+et leurs postes de travail (le maillon que le bastion ne contrôle pas).
+
+```mermaid
+flowchart LR
+    Poste["Poste admin<br/>(menace élevée)"] --> Bastion
+    Presta["Prestataire<br/>(menace élevée)"] --> Bastion
+    Admin["Admin interne<br/>(menace élevée)"] --> Bastion
+    Auto["Automatisation<br/>(menace moyenne)"] -.clé de service.-> Backend
+    LLNG["Portail LLNG<br/>(menace élevée — autorité)"] -->|CA, autorisation, voucher| Bastion
+    LLNG -->|autorisation, token sudo| Backend
+    LDAP["Annuaire<br/>(menace moyenne)"] --> LLNG
+    Bastion["Bastion<br/>point de passage enregistré"] --> Backend["Backends"]
+    Paquet["Chaîne APT<br/>(menace moyenne)"] -.paquets signés.-> Bastion
+    Paquet -.-> Backend
+```
+
+## 3.2 Scénarios stratégiques
+
+Chaque scénario relie un couple SR/OV de
+[l'atelier 2](05-atelier2-sources-de-risque.md) à un événement redouté de
+[l'atelier 1](04-atelier1-cadrage-socle.md), en passant par des parties
+prenantes. La gravité est celle de l'ER atteint.
+
+### SS1 — Rebond depuis un poste d'administrateur compromis
+
+**SR2 × OV1 → ER1.** L'attaquant compromet le poste de travail d'un
+administrateur (hameçonnage, chaîne logicielle du poste), y récupère le matériel
+d'authentification SSH, et se présente au bastion comme cet administrateur.
+
+**Parties prenantes traversées :** poste admin → bastion → backends.
+
+**Ce que l'architecture oppose :** la clé seule ne suffit pas — il faut un
+certificat signé par la CA LLNG, de durée bornée, révocable par KRL ; le portail
+réautorise à chaque connexion et l'empreinte de la clé est liée à la session SSO.
+La session est enregistrée sur le bastion.
+
+**Ce qu'elle n'oppose pas :** si le poste est compromis pendant que le
+certificat est valide, l'attaquant est cet administrateur. Le contrôle se
+déplace vers la détection (enregistrement, `auth.info`) et la révocation.
+
+**Gravité : 4.** Fiches détaillées : R-S3, R-S6, R-S11, R-S22.
+
+### SS2 — Compromission du bastion lui-même
+
+**SR2 × OV1 → ER1, ER3, ER4.** Le bastion est le point de passage : qui le
+contrôle voit passer toutes les sessions et peut demander des certificats de
+rebond au nom des utilisateurs déjà vouchés.
+
+**Parties prenantes traversées :** bastion → portail LLNG → backends.
+
+**Ce que l'architecture oppose :** le bastion ne détient pas la CA ; il ne peut
+obtenir un certificat de rebond que pour un utilisateur ayant récemment ouvert
+une session sur lui (voucher), pour la durée `pamAccessBastionVoucherTtl` ; les
+backends n'acceptent que les bastions de leur `allowed_bastions` et le
+certificat est épinglé sur l'adresse source du bastion.
+
+**Ce qu'elle n'oppose pas :** l'enregistrement de session vit sur le bastion.
+Root du bastion est hors périmètre de confiance de la traçabilité — c'est une
+hypothèse explicite, pas une protection.
+
+**Gravité : 4.** Fiches détaillées : R-S6, R-S9, R-S22, R-S23.
+
+### SS3 — Enrôlement d'un serveur sous contrôle de l'attaquant
+
+**SR2 × OV6 → ER7.** L'attaquant obtient (ou devine, ou intercepte) de quoi
+enrôler une machine à lui dans le parc : elle reçoit alors des identités, des
+autorisations, et devient un point d'observation légitime.
+
+**Parties prenantes traversées :** chaîne APT ou credentials d'enrôlement →
+portail LLNG (`/device`) → parc.
+
+**Ce que l'architecture oppose :** le flux RFC 8628 exige une approbation humaine
+sur le portail, PKCE rend l'interception du `device_code` inutile, CrowdSec
+limite le brute-force du `user_code`, et le `client_secret` est cloisonnable par
+zone.
+
+**Ce qu'elle n'oppose pas sans configuration :** l'approbation `/device` est
+ouverte à **tout utilisateur SSO authentifié** tant qu'une `locationRules` ne la
+restreint pas. C'est une **condition d'emploi**, pas une propriété du produit
+(voir [08-dossier-homologation.md](08-dossier-homologation.md)).
+
+**Gravité : 3.** Fiches détaillées : R0, R1, R2, R3, R7, R13.
+
+### SS4 — Administrateur légitime agissant hors traçabilité
+
+**SR3 × OV3 → ER3.** L'administrateur habilité cherche à agir sans que son
+action soit imputable : contourner le bastion, s'évader du confinement de
+session, ou différer l'action hors de la session enregistrée.
+
+**Parties prenantes traversées :** admin interne → bastion → backends.
+
+**Ce que l'architecture oppose :** le contournement du bastion est bloqué par
+`AuthorizedKeysFile none` + `TrustedUserCAKeys` + `AuthorizedPrincipalsCommand`
+sur les backends ; l'enregistrement est écrit par un puits root auquel
+l'utilisateur enregistré n'a aucun accès ; le confinement de session et la trace
+auditd ferment l'évasion et l'action différée.
+
+**Ce qu'elle n'oppose que sous condition :** le confinement (`--enable-hardening`)
+et la trace auditd (`--enable-audit-trace`) sont **opt-in**. Sans eux, R-S19 à
+R-S21 restent en zone jaune.
+
+**Gravité : 3.** Fiches détaillées : R-S5, R-S18, R-S19, R-S20, R-S21, R-S25.
+
+### SS5 — Persistance d'un prestataire après la fin de sa mission
+
+**SR5 × OV2 → ER2.** L'intervenant garde un moyen d'accès qui survit à la
+clôture de son compte : session ouverte, certificat encore valide, clé de compte
+de service qu'il a installée.
+
+**Parties prenantes traversées :** prestataire → portail LLNG → parc.
+
+**Ce que l'architecture oppose :** l'autorisation est revérifiée en direct à
+chaque connexion et à chaque `sudo`, donc la désactivation du compte LLNG coupe
+l'accès immédiatement ; la KRL révoque les certificats ; l'empreinte de la clé
+est liée à la session SSO.
+
+**Ce qu'elle n'oppose pas :** une session déjà ouverte survit jusqu'à sa
+fermeture (R-S8), et une clé de **compte de service** n'est pas gouvernée par
+LLNG du tout — sa révocation est une modification de fichier sur chaque serveur.
+
+**Gravité : 3.** Fiches détaillées : R12, R-S8, R-S15, R-SA1 ; procédure en
+[03-offboarding.md](03-offboarding.md).
+
+### SS6 — Détournement d'une clé d'automatisation
+
+**SR6 × OV1 → ER1.** Une clé de compte de service — Ansible, sauvegarde, CI —
+fuit (dépôt, artefact de build, sauvegarde) et donne un accès privilégié
+permanent qui ne passe par aucune porte SSO.
+
+**Parties prenantes traversées :** automatisation → backends.
+
+**Ce que l'architecture oppose :** le fichier `service-accounts.conf` est local
+à chaque serveur (portée bornée), root-only, et l'empreinte de la clé est
+vérifiée ; avec `sudo_nopasswd = false`, l'empreinte est revérifiée à chaque
+`sudo`.
+
+**Ce qu'elle n'oppose pas :** le droit `sudo` d'un compte de service ne passe pas
+par LLNG, même en Mode E. C'est un privilège local permanent, assumé et tracé.
+
+**Gravité : 4.** Fiches détaillées : R-S24, R-S25, R-SA1, R-SA2.
+
+### SS7 — Verrouillage total par erreur d'exploitation
+
+**SR4 × OV5 → ER5.** Une erreur — panne prolongée du portail, cache offline
+expiré, certificats expirés, aucun compte de secours — rend le parc
+inaccessible. La source de risque n'a aucune intention : c'est le scénario que
+la sécurité elle-même crée.
+
+**Parties prenantes traversées :** portail LLNG → bastion et backends.
+
+**Ce que l'architecture oppose :** cache d'autorisation offline, comptes de
+service de secours, accès console hors-bande documenté, rafraîchissement du
+token serveur à la demande.
+
+**Ce qu'elle n'oppose pas :** un déploiement sans compte de secours ni accès
+console **n'est pas récupérable**. C'est une condition d'emploi.
+
+**Gravité : 3.** Fiches détaillées : R6, R9, R10, R-S7, R-S10, R-S14, R-S17.
+
+## 3.3 Synthèse
+
+| Scénario | Couple SR/OV | ER atteint | Gravité | Zone de traitement                                       |
+| -------- | ------------ | ---------- | :-----: | -------------------------------------------------------- |
+| **SS1**  | SR2 × OV1    | ER1        |    4    | Certificats courts + KRL + binding d'empreinte           |
+| **SS2**  | SR2 × OV1    | ER1/3/4    |    4    | Voucher borné, `allowed_bastions`, `source-address`      |
+| **SS3**  | SR2 × OV6    | ER7        |    3    | Approbation `/device` restreinte, PKCE, CrowdSec         |
+| **SS4**  | SR3 × OV3    | ER3        |    3    | Puits d'enregistrement root, confinement, auditd         |
+| **SS5**  | SR5 × OV2    | ER2        |    3    | Réautorisation en direct, KRL, procédure d'offboarding   |
+| **SS6**  | SR6 × OV1    | ER1        |    4    | Portée locale des clés, empreinte revérifiée, inventaire |
+| **SS7**  | SR4 × OV5    | ER5        |    3    | Cache offline, compte de secours, console hors-bande     |
+
+Les mesures citées ici sont de haut niveau. Leur déclinaison technique, avec
+scores de vraisemblance et de gravité par chemin d'attaque, est l'objet des
+**39 fiches de l'atelier 4** ([enrôlement](01-enrollment.md),
+[connexion SSH](02-ssh-connection.md)), et leur ordonnancement celui du
+[plan de traitement](07-plan-de-traitement.md).
+
+---
+
+Atelier précédent : [Atelier 2 — sources de risque](05-atelier2-sources-de-risque.md) ·
+Atelier suivant : Atelier 4 — [enrôlement](01-enrollment.md) et
+[connexion SSH](02-ssh-connection.md)

--- a/doc/security/07-plan-de-traitement.md
+++ b/doc/security/07-plan-de-traitement.md
@@ -1,0 +1,102 @@
+# Atelier 5 — Plan de traitement du risque
+
+> **Méthode :** EBIOS Risk Manager (ANSSI, 2018), atelier 5. Ce document est le
+> plan de traitement : une mesure par ligne, avec le risque qu'elle réduit, sa
+> nature, sa priorité, son porteur, son échéance et son état. Il remplace la
+> liste de « pistes » en texte libre de [99-risk-reduce.md](99-risk-reduce.md),
+> qui reste le lieu de l'**argumentaire** technique de chaque mesure.
+>
+> **Ce document n'est pas complet tant que les colonnes _Porteur_ et _Échéance_
+> portent la mention `À COMPLÉTER`.** Ces valeurs relèvent d'une décision
+> projet, pas d'une analyse ; elles sont laissées vides plutôt qu'inventées.
+
+## 5.1 Convention
+
+| Colonne      | Valeurs                                                                                                                    |
+| ------------ | -------------------------------------------------------------------------------------------------------------------------- |
+| **Priorité** | **P0** = requis avant mise en production · **P1** = requis dans le cycle courant · **P2** = amélioration planifiée         |
+| **Nature**   | **Produit** = code ou paquet Open Bastion · **Déploiement** = configuration à la pose · **Exploitation** = geste récurrent |
+| **Porteur**  | Rôle responsable de la réalisation. `À COMPLÉTER` = à nommer par le projet                                                 |
+| **Échéance** | Date cible. `À COMPLÉTER` = à fixer par le projet                                                                          |
+| **État**     | **Livré** (avec la référence de PR ou d'issue) · **Ouvert** · **Écarté** (avec le motif)                                   |
+
+Une mesure `Livré` reste dans le plan : elle documente que le risque associé est
+traité, et par quoi. C'est ce qui manquait au backlog précédent, où deux mesures
+déjà livrées étaient encore proposées comme travaux futurs (voir #215).
+
+## 5.2 Mesures requises avant mise en production (P0)
+
+Ce sont les **conditions d'emploi** : sans elles, les scores résiduels de
+l'atelier 4 ne sont pas atteints. Elles sont reprises, avec leur preuve de mise
+en œuvre attendue, en [08-dossier-homologation.md](08-dossier-homologation.md).
+
+| Id       | Mesure                                                                                            | Risques  | Nature       | Priorité | Porteur             | Échéance      | État                                     |
+| -------- | ------------------------------------------------------------------------------------------------- | -------- | ------------ | :------: | ------------------- | ------------- | ---------------------------------------- |
+| **MT01** | `locationRules` sur `^/device` restreignant l'approbation d'enrôlement à un groupe d'approbateurs | R0, R7   | Déploiement  |    P0    | Administrateur LLNG | `À COMPLÉTER` | **Livré** (doc + démos, #195)            |
+| **MT02** | `locationRules` sur `^/ssh/(admin\|certs\|revoke)` restreignant l'administration ssh-ca           | R-S4     | Déploiement  |    P0    | Administrateur LLNG | `À COMPLÉTER` | **Livré** (doc + démos, #195)            |
+| **MT03** | `allowed_bastions` renseigné sur chaque backend avec les device-ids réellement attendus           | R-S23    | Déploiement  |    P0    | Équipe Open Bastion | `À COMPLÉTER` | **Livré** (invite + alerte, #182)        |
+| **MT04** | `RequirePKCE = 1` sur le client OIDC d'enrôlement                                                 | R13      | Déploiement  |    P0    | Administrateur LLNG | `À COMPLÉTER` | **Ouvert** — à vérifier sur cible        |
+| **MT05** | Compte de service de secours + accès console hors-bande documenté et testé                        | R-S17    | Déploiement  |    P0    | Équipe exploitation | `À COMPLÉTER` | **Ouvert**                               |
+| **MT06** | KRL déployée sur tous les serveurs, rafraîchie ≤ 30 min, avec alerte de fraîcheur                 | R-S15    | Exploitation |    P0    | Équipe exploitation | `À COMPLÉTER` | Partiel — cron livré, alerte **ouverte** |
+| **MT07** | Clé privée de la CA SSH protégée : accès Manager LLNG restreint et tracé                          | R5, R-S4 | Exploitation |    P0    | Administrateur LLNG | `À COMPLÉTER` | **Ouvert**                               |
+
+## 5.3 Mesures du cycle courant (P1)
+
+| Id       | Mesure                                                                                              | Risques      | Nature       | Priorité | Porteur             | Échéance      | État                                                  |
+| -------- | --------------------------------------------------------------------------------------------------- | ------------ | ------------ | :------: | ------------------- | ------------- | ----------------------------------------------------- |
+| **MT10** | Enregistrement de session écrit par un puits root, inaccessible à l'utilisateur enregistré          | R-S18, R-S19 | Produit      |    P1    | Équipe Open Bastion | —             | **Livré** (#157, `ob-record-sink`)                    |
+| **MT11** | Enregistrement fail-closed : la session est refusée si le puits est injoignable                     | R-S18        | Produit      |    P1    | Équipe Open Bastion | —             | **Livré** — actif par défaut                          |
+| **MT12** | Confinement de session (`KillUserProcesses`, `at`/`cron` en allow-list, refus du `linger`)          | R-S19, R-S20 | Déploiement  |    P1    | Équipe exploitation | `À COMPLÉTER` | **Livré** en opt-in (`--enable-hardening`, #112)      |
+| **MT13** | Trace auditd de niveau syscall (`execve`, watches, `connect`)                                       | R-S21        | Déploiement  |    P1    | Équipe exploitation | `À COMPLÉTER` | **Livré** en opt-in (`--enable-audit-trace`, #113)    |
+| **MT14** | Export des journaux auditd et des enregistrements vers un collecteur distant (WORM ou SIEM)         | R-S18, R-S21 | Exploitation |    P1    | Équipe exploitation | `À COMPLÉTER` | **Ouvert** — recommandation prioritaire               |
+| **MT15** | Liaison de l'empreinte de clé SSH à la session SSO, exigible (`fingerprint_required`)               | R-S3, R-S15  | Produit      |    P1    | Équipe Open Bastion | —             | **Livré** (#192)                                      |
+| **MT16** | Token LLNG frais à chaque `sudo` (`timestamp_timeout=0` cadré sur le groupe SSO)                    | R-S16        | Déploiement  |    P1    | Équipe exploitation | `À COMPLÉTER` | **Livré** en opt-in (`--enable-sudo-fresh-otp`, #178) |
+| **MT17** | Vérification de `target=` par `ob-ssh-principals` contre le FQDN local                              | R-S22        | Produit      |    P1    | Équipe Open Bastion | `À COMPLÉTER` | **Ouvert**                                            |
+| **MT18** | Mode strict de vouching : l'absence d'`allowed_bastions` refuse au lieu du mode hérité              | R-S23        | Produit      |    P1    | Équipe Open Bastion | `À COMPLÉTER` | **Ouvert**                                            |
+| **MT19** | Alerte sur échec de `ob-heartbeat.service` et sur l'âge du token serveur                            | R-S17, R10   | Exploitation |    P1    | Équipe exploitation | `À COMPLÉTER` | **Ouvert**                                            |
+| **MT20** | Rotation et inventaire des clés de comptes de service ; `sudo_allowed` accordé au strict nécessaire | R-S24, R-SA1 | Exploitation |    P1    | Équipe exploitation | `À COMPLÉTER` | **Ouvert**                                            |
+| **MT21** | `AllowTcpForwarding no` sur le bastion, ou comptes de service non déclarés sur le bastion           | R-S25        | Déploiement  |    P1    | Équipe exploitation | `À COMPLÉTER` | **Ouvert**                                            |
+| **MT22** | Test de recouvrement annuel : simulation de panne LLNG, validation console + compte de secours      | R-S17        | Exploitation |    P1    | Équipe exploitation | `À COMPLÉTER` | **Ouvert**                                            |
+
+## 5.4 Améliorations planifiées (P2)
+
+| Id       | Mesure                                                                                             | Risques               | Nature      | Priorité | Porteur             | Échéance      | État                             |
+| -------- | -------------------------------------------------------------------------------------------------- | --------------------- | ----------- | :------: | ------------------- | ------------- | -------------------------------- |
+| **MT30** | `client_id` distincts par zone de sécurité (isolation des credentials d'enrôlement)                | R0, R4, R7, R11, R-S6 | Déploiement |    P2    | Administrateur LLNG | `À COMPLÉTER` | **Ouvert** — arbitrage documenté |
+| **MT31** | Réduction de `pamAccessBastionVoucherTtl` sous 12 h                                                | R-S6                  | Déploiement |    P2    | Administrateur LLNG | `À COMPLÉTER` | **Ouvert**                       |
+| **MT32** | Réduction de `pamAccessBastionCertTtl` (120 s → 30–60 s) sur les zones sensibles                   | R-S9                  | Déploiement |    P2    | Administrateur LLNG | `À COMPLÉTER` | **Ouvert**                       |
+| **MT33** | Signature cryptographique des enregistrements à la clôture (clé hors bastion)                      | R-S18                 | Produit     |    P2    | Équipe Open Bastion | `À COMPLÉTER` | **Ouvert**                       |
+| **MT34** | Détection d'un enregistreur tué en cours de session (`killed_prematurely`)                         | R-S19                 | Produit     |    P2    | Équipe Open Bastion | `À COMPLÉTER` | **Ouvert** — reliquat de MT10    |
+| **MT35** | Webhook de révocation LLNG → fermeture des sessions ouvertes                                       | R-S8                  | Produit     |    P2    | Équipe Open Bastion | `À COMPLÉTER` | **Ouvert**                       |
+| **MT36** | Notification de rotation de CA vers les backends (`TrustedUserCAKeys`) et monitoring de divergence | R-S10                 | Produit     |    P2    | Équipe Open Bastion | `À COMPLÉTER` | **Ouvert**                       |
+| **MT37** | Purge des crontabs pré-existants à l'activation du durcissement                                    | R-S20                 | Produit     |    P2    | Équipe Open Bastion | `À COMPLÉTER` | **Ouvert**                       |
+| **MT38** | Épinglage de certificat TLS rendu obligatoire vers le portail                                      | R5                    | Déploiement |    P2    | Équipe exploitation | `À COMPLÉTER` | **Ouvert**                       |
+| **MT39** | Second facteur exigé pour l'obtention du token `sudo`                                              | R-S16                 | Déploiement |    P2    | Administrateur LLNG | `À COMPLÉTER` | **Ouvert**                       |
+
+## 5.5 Mesures écartées
+
+Une mesure écartée reste tracée : elle a été examinée, et le motif du refus fait
+partie de l'analyse.
+
+| Mesure envisagée                                                           | Risques | Motif de l'écart                                                                                                                                   |
+| -------------------------------------------------------------------------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Profil MAC (AppArmor/SELinux) interdisant `setsid` aux shells utilisateurs | R-S19   | Coût de rédaction et de maintenance par distribution jugé supérieur au gain, `KillUserProcesses` couvrant le canal principal                       |
+| `KillUserProcesses=yes` imposé par le postinst                             | R-S19   | Modification système globale silencieuse, contraire à la politique Debian. Réexaminable sous forme d'un paquet `open-bastion-strict` dédié         |
+| Épinglage de `target=` côté LLNG via `source-address`                      | R-S22   | Techniquement impossible : `source-address` épingle l'origine, pas la destination. Le contrôle doit être porté par `ob-ssh-principals` (voir MT17) |
+| Traitement du risque « administrateur du portail LLNG » (SR7)              | tous    | Hors de portée du produit : c'est l'autorité dont dépend le modèle. Traité comme **hypothèse de confiance** en [08](08-dossier-homologation.md)    |
+
+## 5.6 Suivi
+
+| Question                                          | Réponse                                                                                                      |
+| ------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| Qui tient ce plan à jour ?                        | `À COMPLÉTER`                                                                                                |
+| À quelle fréquence est-il revu ?                  | `À COMPLÉTER` (recommandation : à chaque version mineure, et après tout incident)                            |
+| Comment une mesure livrée est-elle vérifiée ?     | Par la référence de PR portée en colonne État, et par les tests cités dans la fiche de risque correspondante |
+| Comment une nouvelle fiche entre-t-elle au plan ? | `tests/ebios_matrix_check.py` échoue si une fiche n'est rattachée à aucun événement redouté (atelier 1)      |
+
+---
+
+Atelier précédent : Atelier 4 — [enrôlement](01-enrollment.md) et
+[connexion SSH](02-ssh-connection.md) · Argumentaire technique des mesures :
+[99-risk-reduce.md](99-risk-reduce.md) · Décisions :
+[08-dossier-homologation.md](08-dossier-homologation.md)

--- a/doc/security/08-dossier-homologation.md
+++ b/doc/security/08-dossier-homologation.md
@@ -1,0 +1,172 @@
+# Dossier d'homologation — périmètre, conditions d'emploi, acceptation
+
+> **Ce document est le seul de l'étude qui engage.** Les ateliers analysent ; ce
+> document décide : ce qui est homologué, sous quelles conditions vérifiables, et
+> quels risques résiduels sont acceptés, par qui.
+>
+> **Il n'est pas signé tant que les champs `À COMPLÉTER` subsistent.** Ces
+> valeurs — noms, dates, décisions d'acceptation — relèvent de l'autorité
+> d'homologation et ne sont pas déduites de l'analyse.
+
+## Identification du dossier
+
+| Champ                        | Valeur                                                                       |
+| ---------------------------- | ---------------------------------------------------------------------------- |
+| **Objet**                    | Open Bastion — accès SSH d'administration gouverné par LemonLDAP::NG         |
+| **Version du dossier**       | 1.0 (première émission)                                                      |
+| **Version du produit visée** | `À COMPLÉTER` (version d'Open Bastion et des quatre plugins LLNG homologuée) |
+| **Méthode**                  | EBIOS Risk Manager (ANSSI, 2018), ateliers 1 à 5                             |
+| **Rédacteur**                | Équipe Open Bastion                                                          |
+| **Date d'émission**          | `À COMPLÉTER`                                                                |
+| **Autorité d'homologation**  | `À COMPLÉTER` (nom et fonction)                                              |
+| **Date de décision**         | `À COMPLÉTER`                                                                |
+| **Durée de validité**        | `À COMPLÉTER` (recommandation : 3 ans, ou toute évolution du périmètre)      |
+
+### Composition du dossier
+
+| Pièce                                                                              | Contenu                                                        |
+| ---------------------------------------------------------------------------------- | -------------------------------------------------------------- |
+| [00-architecture.md](00-architecture.md)                                           | Cible de sécurité, architecture, mécanismes                    |
+| [04-atelier1-cadrage-socle.md](04-atelier1-cadrage-socle.md)                       | Périmètre, valeurs métier, biens supports, échelles, ER, socle |
+| [05-atelier2-sources-de-risque.md](05-atelier2-sources-de-risque.md)               | Sources de risque, objectifs visés, couples retenus            |
+| [06-atelier3-scenarios-strategiques.md](06-atelier3-scenarios-strategiques.md)     | Écosystème, scénarios stratégiques                             |
+| [01-enrollment.md](01-enrollment.md), [02-ssh-connection.md](02-ssh-connection.md) | Scénarios opérationnels : 39 fiches de risque                  |
+| [07-plan-de-traitement.md](07-plan-de-traitement.md)                               | Plan de traitement                                             |
+| [99-risk-reduce.md](99-risk-reduce.md)                                             | Matrice résiduelle consolidée et argumentaire des mesures      |
+| [03-offboarding.md](03-offboarding.md)                                             | Procédure opérationnelle de révocation                         |
+| **Ce document**                                                                    | Périmètre d'homologation, conditions d'emploi, acceptation     |
+
+## 1. Périmètre d'homologation
+
+### 1.1 Ce qui est homologué
+
+Le périmètre est celui de l'[atelier 1, §1.1](04-atelier1-cadrage-socle.md#11-objet-et-périmètre-de-létude),
+et il **inclut le portail LemonLDAP::NG et sa chaîne de quatre plugins**
+(`pam-access`, `ssh-ca`, `oidc-device-authorization`,
+`oidc-device-organization`).
+
+Cette inclusion est une décision, et elle a un motif : le portail autorise chaque
+session et chaque `sudo`, signe les certificats et détient la clé de CA. Une
+homologation qui s'arrêterait au bord du serveur porterait sur la moitié des
+décisions de sécurité et laisserait l'autre moitié hors de tout engagement.
+
+Conséquence directe : les constats de sécurité portant sur les plugins font
+partie de l'étude et doivent y être intégrés, y compris lorsqu'ils invalident une
+revendication de remédiation côté serveur.
+
+### 1.2 Ce qui n'est pas homologué
+
+| Hors périmètre                                            | Attendu de l'exploitant                                               |
+| --------------------------------------------------------- | --------------------------------------------------------------------- |
+| Système d'exploitation hôte et son durcissement           | Socle durci (CIS / ANSSI-BP-028), mises à jour de sécurité appliquées |
+| `sshd` (OpenSSH amont)                                    | Version supportée, correctifs de sécurité appliqués                   |
+| Réseau et sa segmentation                                 | Backends joignables uniquement depuis le bastion                      |
+| Annuaire LDAP/AD derrière LLNG                            | Cycle de vie des comptes maîtrisé, désactivation effective au départ  |
+| Socle LLNG cœur (portail, sessions, Manager) hors plugins | Version supportée, accès Manager restreint et tracé                   |
+| Postes de travail des administrateurs                     | Durcissement et protection du matériel d'authentification             |
+| **Les modes PAM A à D**                                   | Non couverts : l'étude porte sur la cible Mode E seule                |
+
+### 1.3 Hypothèses de confiance
+
+Ces hypothèses ne sont pas des mesures : ce sont des postulats sans lesquels
+l'analyse ne tient pas. Elles sont énoncées pour être contestables.
+
+| Id     | Hypothèse                                                                                                   | Si elle tombe                                                            |
+| ------ | ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
+| **H1** | L'administrateur du portail LLNG (SR7) est digne de confiance ; son accès au Manager est restreint et tracé | Le modèle entier tombe : il peut signer un certificat pour n'importe qui |
+| **H2** | Root sur le bastion n'est pas dans le modèle de menace de la traçabilité                                    | Les enregistrements de session ne sont plus opposables                   |
+| **H3** | La chaîne de distribution APT et sa signature GPG ne sont pas compromises                                   | Un paquet malveillant s'installe avec les droits root                    |
+| **H4** | L'annuaire amont reflète fidèlement les habilitations en vigueur                                            | La révocation LLNG ne coupe plus l'accès en pratique                     |
+
+## 2. Conditions d'emploi
+
+Les scores résiduels de l'atelier 4 **supposent** ces conditions. Le produit ne
+les impose pas toutes : elles doivent être vérifiées sur la cible, et la preuve
+conservée dans le dossier.
+
+| Id       | Condition                                                                            | Risques concernés | Vérification sur cible                                                                                    | Statut cible  |
+| -------- | ------------------------------------------------------------------------------------ | ----------------- | --------------------------------------------------------------------------------------------------------- | ------------- |
+| **CE01** | `locationRules` sur `^/device` restreignant l'approbation d'enrôlement               | R0, R7            | Manager LLNG → vhost portail → règle présente ; test négatif avec un compte non approbateur               | `À COMPLÉTER` |
+| **CE02** | `locationRules` sur `^/ssh/(admin\|certs\|revoke)`                                   | R-S4              | Idem ; vérifier que `/ssh/revoked` (KRL publique) reste accessible                                        | `À COMPLÉTER` |
+| **CE03** | `pamAccessServerGroups` renseigné, ou mode hérité explicitement accepté              | R4, R7, R11       | Manager LLNG ; sinon consigner l'acceptation du mode hérité                                               | `À COMPLÉTER` |
+| **CE04** | `RequirePKCE = 1` sur le client OIDC d'enrôlement                                    | R13               | Manager LLNG → RP → option PKCE                                                                           | `À COMPLÉTER` |
+| **CE05** | CrowdSec **et un bouncer** effectivement déployés                                    | R2, R-S12         | Le plugin n'émet qu'une alerte : sans bouncer, aucun blocage. Vérifier la chaîne de bout en bout          | `À COMPLÉTER` |
+| **CE06** | `allowed_bastions` renseigné sur chaque backend                                      | R-S23             | `cat /etc/open-bastion/allowed_bastions` non vide sur chaque backend ; alerte `authpriv` absente des logs | `À COMPLÉTER` |
+| **CE07** | Durcissement de confinement activé (`--enable-hardening`)                            | R-S19, R-S20      | Sans lui, R-S19 revient à (P=3, I=3) et R-S20 à (P=2, I=3)                                                | `À COMPLÉTER` |
+| **CE08** | Trace auditd activée (`--enable-audit-trace`)                                        | R-S21             | Sans elle, R-S21 revient à (P=2, I=3)                                                                     | `À COMPLÉTER` |
+| **CE09** | `fingerprint_required = true` sur les hôtes en mode certificat                       | R-S3, R-S15       | Sans lui, la liaison d'empreinte disparaît silencieusement si le spool manque                             | `À COMPLÉTER` |
+| **CE10** | Enregistrement de session actif et fail-closed (défaut, non désactivé)               | R-S18             | Absence de `--disable-session-recorder` ; `ob-record.socket` actif                                        | `À COMPLÉTER` |
+| **CE11** | KRL déployée et rafraîchie ≤ 30 min, avec alerte de fraîcheur                        | R-S15             | `RevokedKeys` dans `sshd_config` ; âge du fichier surveillé                                               | `À COMPLÉTER` |
+| **CE12** | Compte de service de secours **et** accès console hors-bande, testés                 | R-S17             | Test de recouvrement daté (MT22)                                                                          | `À COMPLÉTER` |
+| **CE13** | Clé privée de la CA SSH : accès au Manager LLNG restreint et tracé                   | R5, R-S4          | La clé est en clair dans la configuration LLNG : c'est l'accès au Manager qui la protège                  | `À COMPLÉTER` |
+| **CE14** | Journaux auditd et enregistrements exportés vers un collecteur distant               | R-S18, R-S21      | Sans export, root du bastion peut effacer la trace après coup (voir H2)                                   | `À COMPLÉTER` |
+| **CE15** | `client_secret_mode: prompt` ou secret sous `ansible-vault` ; bundles non versionnés | R0, R3            | Aucun `ob_client_secret` en clair dans un dépôt ou une sauvegarde                                         | `À COMPLÉTER` |
+
+**CE13 mérite d'être lu deux fois.** La clé privée de la CA SSH est stockée en
+clair dans la configuration LLNG. Ce n'est pas un défaut caché : c'est un choix
+d'architecture, dont la conséquence est que **l'accès en lecture à la
+configuration LLNG équivaut à la possession de la CA**. Le risque R-S4
+(compromission de la CA, gravité 4) repose donc entièrement sur la protection de
+cet accès.
+
+## 3. Acceptation des risques résiduels
+
+Trois risques sont en **zone orange** (score 6) après traitement et requièrent
+une acceptation formelle. Les cinq risques en zone jaune sont listés pour
+information ; les 31 risques en zone verte relèvent de la surveillance ordinaire.
+
+### 3.1 Zone orange — acceptation requise
+
+| Risque    | Libellé                                     | Résiduel | Justification du maintien                                                                                                            | Décision      | Approbateur   | Date          |
+| --------- | ------------------------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------ | ------------- | ------------- | ------------- |
+| **R1**    | Interception du `user_code` en transmission | P=2, I=3 | Le canal de transmission du `user_code` à l'opérateur est hors du produit ; l'approbation humaine sur `/device` reste requise (CE01) | `À COMPLÉTER` | `À COMPLÉTER` | `À COMPLÉTER` |
+| **R-S6**  | Compromission du bastion                    | P=2, I=3 | Réductible à I=2 par des `client_id` distincts par zone (MT30) — arbitrage entre isolation et nombre de RP à gérer                   | `À COMPLÉTER` | `À COMPLÉTER` | `À COMPLÉTER` |
+| **R-SA1** | Vol de clé de compte de service             | P=2, I=3 | Une clé de service n'est pas gouvernée par LLNG : sa révocation est un geste d'exploitation sur chaque serveur (MT20)                | `À COMPLÉTER` | `À COMPLÉTER` | `À COMPLÉTER` |
+
+### 3.2 Zone jaune — pour information
+
+| Risque    | Libellé                                        | Résiduel |
+| --------- | ---------------------------------------------- | -------- |
+| **R4**    | Vol du fichier token après enrôlement          | P=1, I=4 |
+| **R5**    | Usurpation du serveur LLNG                     | P=1, I=4 |
+| **R-S4**  | Compromission de la CA SSH                     | P=1, I=4 |
+| **R-SA2** | Compromission du fichier de comptes de service | P=1, I=4 |
+| **R-S8**  | Session persistante après révocation           | P=2, I=2 |
+
+R4, R5, R-S4 et R-SA2 partagent une propriété : leur vraisemblance est
+très faible mais leur gravité maximale. Ce sont les points où le modèle
+concentre sa confiance — la CA, le portail, les credentials d'enrôlement, les
+comptes de service. Aucune mesure produit ne les ramène en gravité 3 ; ce sont
+les conditions d'emploi CE13, CE15 et l'hypothèse H1 qui les tiennent.
+
+### 3.3 Décision d'homologation
+
+> **Décision :** `À COMPLÉTER` — homologation accordée / accordée sous réserve /
+> refusée.
+>
+> **Réserves éventuelles :** `À COMPLÉTER`
+>
+> **Autorité d'homologation :** `À COMPLÉTER` (nom, fonction, signature)
+>
+> **Date :** `À COMPLÉTER`
+>
+> **Prochaine revue :** `À COMPLÉTER`
+
+## 4. Conditions de maintien
+
+L'homologation cesse d'être valide si l'une de ces conditions n'est plus tenue :
+
+1. Une condition d'emploi de la section 2 n'est plus vérifiée sur la cible.
+2. Le périmètre change : ajout d'un composant, changement de mode PAM, portail
+   LLNG remplacé ou plugins retirés.
+3. Une nouvelle fiche de risque atteint la zone orange ou rouge sans acceptation.
+4. Un incident de sécurité met en défaut une hypothèse de confiance (§1.3).
+5. La durée de validité est atteinte.
+
+---
+
+Analyse : [Atelier 1](04-atelier1-cadrage-socle.md) ·
+[Atelier 2](05-atelier2-sources-de-risque.md) ·
+[Atelier 3](06-atelier3-scenarios-strategiques.md) · Atelier 4
+([enrôlement](01-enrollment.md), [SSH](02-ssh-connection.md)) ·
+[Plan de traitement](07-plan-de-traitement.md)

--- a/doc/security/99-risk-reduce.md
+++ b/doc/security/99-risk-reduce.md
@@ -1,5 +1,13 @@
 # Pistes d'Amélioration - Mode E (Sécurité Maximale)
 
+> **Ce document porte l'argumentaire technique des mesures, pas le plan.** Le
+> plan de traitement — une mesure par ligne, avec porteur, priorité, échéance et
+> état — est en [07-plan-de-traitement.md](07-plan-de-traitement.md), et les
+> décisions (périmètre, conditions d'emploi, acceptation des résiduels) en
+> [08-dossier-homologation.md](08-dossier-homologation.md). Les sections
+> « Pistes » ci-dessous expliquent **pourquoi** une mesure réduit un risque et ce
+> qu'elle coûte ; le plan dit **qui** la porte et **quand**.
+
 ## Matrice des Risques Résiduels (Mode E)
 
 | Impact ↓ / Probabilité → | 1 - Très improbable                                                                    | 2 - Peu probable | 3 - Probable | 4 - Très probable |
@@ -22,11 +30,16 @@
 > identifiant y figure sans fiche. R-S1 et R-S2 sont éliminés par la cible Mode E
 > et n'ont donc pas de fiche.
 
-**Zones de risque** (score = P × I) **:**
+**Zones de risque** — définition unique en
+[atelier 1, §1.5.1](04-atelier1-cadrage-socle.md#151-zones-de-risque)
+(score = Vraisemblance × Gravité) **:**
 
-- Score ≥ 6 : Zone rouge → aucun risque dans cette zone en Mode E avec PR1 + PR2 activées
-- Score 4-5 : Zone jaune → R4, R5, R-S4, R-SA2 (P=1, I=4) ; R-S6 et R-SA1 (P=2, I=3) ; R-S8 (P=2, I=2)
-- Score ≤ 3 : Zone verte → tous les autres, y compris R6 et R-S3 (P=2, I=1 = score 2)
+- **Rouge** (score ≥ 9) : aucun risque, en Mode E avec PR1 + PR2 activées
+- **Orange** (score 6–8) : R1, R-S6, R-SA1 (P=2, I=3 = 6) — les trois seuls à
+  requérir une acceptation formelle, portée par
+  [08-dossier-homologation.md](08-dossier-homologation.md)
+- **Jaune** (score 4–5) : R4, R5, R-S4, R-SA2 (P=1, I=4) et R-S8 (P=2, I=2)
+- **Verte** (score ≤ 3) : les 31 autres, dont R6 et R-S3 (P=2, I=1 = 2)
 
 **Risques éliminés ou ramenés en zone verte par le Mode E (avec PR1 et PR2 activées) :**
 

--- a/doc/security/99-risk-reduce.md
+++ b/doc/security/99-risk-reduce.md
@@ -2,22 +2,31 @@
 
 ## Matrice des Risques Résiduels (Mode E)
 
-| Impact ↓ / Probabilité → | 1 - Très improbable                                                | 2 - Peu probable | 3 - Probable | 4 - Très probable |
-| ------------------------ | ------------------------------------------------------------------ | ---------------- | ------------ | ----------------- |
-| **4 - Critique**         | R-S4, R-SA2                                                        | R-SA1            |              |                   |
-| **3 - Important**        | R5, R-S5, R-S11, R-S23, R-S24                                      | R-S6             |              |                   |
-| **2 - Limité**           | R-S7, R-S9, R-S10, R-S12, R-S16, R-S17, R-S20, R-S21, R-S22, R-S25 | R6, R-S8         |              |                   |
-| **1 - Négligeable**      | R0, R13, R-S14, R-S15, R-S19                                       | R-S3, R-S18      |              |                   |
+| Impact ↓ / Probabilité → | 1 - Très improbable                                                                    | 2 - Peu probable | 3 - Probable | 4 - Très probable |
+| ------------------------ | -------------------------------------------------------------------------------------- | ---------------- | ------------ | ----------------- |
+| **4 - Critique**         | R4, R5, R-S4, R-SA2                                                                    |                  |              |                   |
+| **3 - Important**        | R2, R3, R7, R8, R11, R12, R-S5, R-S11, R-S23, R-S24                                    | R1, R-S6, R-SA1  |              |                   |
+| **2 - Limité**           | R0, R9, R10, R-S7, R-S9, R-S12, R-S13, R-S14, R-S16, R-S17, R-S20, R-S21, R-S22, R-S25 | R-S8             |              |                   |
+| **1 - Négligeable**      | R13, R-S10, R-S15, R-S18, R-S19                                                        | R6, R-S3         |              |                   |
 
-> **Note :** R-S3 et R-S15 ont été descendus d'un cran sur l'axe Impact grâce au **binding fingerprint SSH** introduit dans le plugin PamAccess ≥ 0.1.16. La vérification est effectuée côté LLNG à la fois sur `/pam/authorize` (à chaque ouverture de session SSH, phase PAM `account`) et sur `/pam/verify` (à chaque utilisation d'un token PAM pour sudo ou ré-authentification) : tant que l'empreinte de la clef SSH n'est pas présente, active et non révoquée dans la session persistante LLNG, ni la session SSH ni l'escalade sudo ne sont autorisées, indépendamment de la fraîcheur de la KRL locale. Voir [02-ssh-connection.md](02-ssh-connection.md) pour les détails.
+> **Note :** R-S3 et R-S15 sont descendus de I=3 à I=1 grâce au **binding fingerprint SSH** introduit dans le plugin PamAccess ≥ 0.1.16. La vérification est effectuée côté LLNG à la fois sur `/pam/authorize` (à chaque ouverture de session SSH, phase PAM `account`) et sur `/pam/verify` (à chaque utilisation d'un token PAM pour sudo ou ré-authentification) : tant que l'empreinte de la clef SSH n'est pas présente, active et non révoquée dans la session persistante LLNG, ni la session SSH ni l'escalade sudo ne sont autorisées, indépendamment de la fraîcheur de la KRL locale. Voir [02-ssh-connection.md](02-ssh-connection.md) pour les détails.
 
 > **Note (R-S18, R-S19, R-S20, R-S21) :** Les scores résiduels indiqués ci-dessus pour R-S19, R-S20 et R-S21 supposent l'activation **simultanée** du hardening (PR1 #112, `--enable-hardening`) et de la trace auditd (PR2 #113, `--enable-audit-trace`). En l'absence d'activation, R-S19 reste à (P=3, I=3), R-S20 et R-S21 restent à (P=2, I=3) — tous trois en zone jaune. Voir [doc/hardening.md](../hardening.md) et [doc/audit.md](../audit.md) (documentations techniques en anglais) pour les détails opérationnels.
 
-**Zones de risque :**
+> **Comment lire cette matrice.** Elle consolide les **39 fiches de risque** des
+> deux études (R0–R13 pour l'enrôlement, R-S3–R-S25 et R-SA1/R-SA2 pour la
+> connexion SSH et les comptes de service) et reprend, case par case, le score
+> résiduel **écrit dans chaque fiche** — aucune case n'est une évaluation
+> autonome. `tests/ebios_matrix_check.py` le vérifie mécaniquement et échoue si
+> une case s'écarte de sa fiche, si un risque analysé manque, ou si un
+> identifiant y figure sans fiche. R-S1 et R-S2 sont éliminés par la cible Mode E
+> et n'ont donc pas de fiche.
 
-- Score ≥ 6 : Zone rouge (aucun risque dans cette zone en Mode E avec PR1 + PR2 activées)
-- Score 4-5 : Zone jaune → R-S4, R-SA2 (P=1, I=4), R-SA1 (P=2, I=4/3), R6, R-S8 (P=2, I=2), R-S6 (P=2, I=3)
-- Score ≤ 3 : Zone verte → Tous les autres risques (incluant R-S18 à P=2, I=1 = score 2)
+**Zones de risque** (score = P × I) **:**
+
+- Score ≥ 6 : Zone rouge → aucun risque dans cette zone en Mode E avec PR1 + PR2 activées
+- Score 4-5 : Zone jaune → R4, R5, R-S4, R-SA2 (P=1, I=4) ; R-S6 et R-SA1 (P=2, I=3) ; R-S8 (P=2, I=2)
+- Score ≤ 3 : Zone verte → tous les autres, y compris R6 et R-S3 (P=2, I=1 = score 2)
 
 **Risques éliminés ou ramenés en zone verte par le Mode E (avec PR1 et PR2 activées) :**
 
@@ -44,7 +53,7 @@ Pistes pour réduire la probabilité à quasi-zéro :
 2. mTLS : Le serveur PAM présente aussi un certificat client
 3. DANE (DNSSEC + TLSA) : Validation du certificat via DNS signé
 
-### R6 _(P=2, I=2)_ - Expiration device_code
+### R6 _(P=2, I=1)_ - Expiration device_code
 
 Pistes pour réduire P à 1 :
 
@@ -88,7 +97,13 @@ Pistes pour réduire P à 1 :
 Pistes pour réduire I à 2 :
 
 1. **Segmentation par zone (credentials d'enrôlement)** : par défaut un `client_id` = un **projet** (toutes ses machines partagent l'allowlist, et les groupes PAM séparent les _politiques_ à l'intérieur du projet — pas les _credentials_). Pour réduire le rayon d'impact d'un bastion compromis, **découper en plusieurs `client_id`** (un par zone de sécurité), chacun avec un `allowed_bastions` distinct par backend → un bastion compromis ne peut voucher que pour les backends de sa zone. C'est un arbitrage : plus d'isolation des credentials, mais autant de RP OIDC à gérer.
-2. **Session recording** : Enregistrement de toutes les sessions transitant par le bastion
+2. ~~**Session recording**~~ — **LIVRÉ et actif par défaut.** L'enregistrement de
+   toutes les sessions transitant par le bastion n'est pas une piste : il est
+   activé par défaut (`ob-bastion-setup` : « Session recording is a core bastion
+   guarantee and is ON by default »), le désactiver demande un
+   `--disable-session-recorder` explicite, et il est **fail-closed** — si le
+   puits est injoignable, `ob-session-recorder` refuse la session
+   (« Session recording is required but unavailable; access refused »).
 3. **Réduire `pamAccessBastionVoucherTtl`** (défaut 43200 s = 12 h) : borne la durée pendant laquelle un bastion compromis peut continuer à obtenir des certificats pour les utilisateurs récemment vouchés sans nouvelle connexion de leur part. Compromis ergonomie (les admins doivent se reconnecter plus souvent) vs exposition.
 
 ### R-S8 _(P=2, I=2)_ - Session persistante après révocation
@@ -156,7 +171,7 @@ Le timer `ob-heartbeat` rafraîchit l'access_token (TTL 3600 s) toutes les 5 min
 
 ## Pistes d'Amélioration - Spécifiques au Mode E
 
-### R-S15 _(P=1, I=2)_ - KRL non à jour
+### R-S15 _(P=1, I=1)_ - KRL non à jour
 
 Pistes pour réduire P à quasi-zéro :
 
@@ -250,6 +265,7 @@ Avant remédiation, ce risque est en **zone rouge** (P=2, I=4). La remédiation 
 > **Contrepartie en cas de panne LLNG :** le module ne sert jamais d'entrée périmée (elle est supprimée à la lecture) et un échec transitoire renvoie `NSS_STATUS_UNAVAIL` sans repli sur le cache. Le tampon de résolution vaut donc exactement `cache_ttl` (défaut **300 s**, `/etc/open-bastion/nss_openbastion.conf`), là où le cache persistant de `nscd` couvrait plusieurs dizaines de minutes. Augmenter `cache_ttl` (jusqu'à 86400 s) sur les hôtes exposés à ce risque.
 
 > **Trois limites à connaître en régime nominal**, détaillées dans le guide d'administration :
+>
 > 1. **Seul root remplit le cache** (le jeton serveur LLNG est `0600 root:root`) : une entrée qui expire sans qu'un processus root ne résolve l'utilisateur n'est pas renouvelée. Dans une session SSH inactive : `ls -l` en uid numériques, `whoami`/`id` en échec, `ssh`/`scp` sortant refusé (« You don't exist, go away! »). Toute résolution root (nouvelle session, `su`, `sudo`, `cron`) répare immédiatement ; l'authentification et l'autorisation ne sont pas affectées.
 > 2. **Les résultats négatifs ne sont cachés qu'en mémoire, par processus** : le cache fichier n'est peuplé que sur succès, volontairement, car il est alimenté depuis un chemin non authentifié (`sshd` résout le nom avant l'authentification) et l'y autoriser donnerait à un attaquant distant un moyen de remplir `/var/cache/nss_llng` d'inodes. Chaque tentative SSH avec un nom inexistant coûte donc une requête HTTPS `/pam/userinfo`. `nscd` ne couvrait ce cas que partiellement (cache négatif keyé par nom, 20 s). Borner côté connexions (`MaxStartups`, `fail2ban`/CrowdSec).
 > 3. **SELinux `enforcing` (Rocky/RHEL) non validé** : le cache est écrit depuis le domaine du processus appelant (`sshd_t`, `sudo_t`, `crond_t`). Si la politique par défaut le refuse, l'écriture échoue en silence et le cache partagé n'est jamais peuplé — vérifier par `ausearch -m avc` avant déploiement.
@@ -271,7 +287,16 @@ Cette section couvre les nouveaux risques R-S19, R-S20, R-S21 introduits par l'a
 
 Pistes pour aller plus loin :
 
-1. **Démon collecteur de session privilégié** : remplacer le pty recording local par un démon `ob-session-collector` qui reçoit le flux pty via socket Unix (`SO_PEERCRED`) et écrit dans des fichiers root-owned. Détecte la fermeture brutale du recorder via RST socket et marque la session comme `killed_prematurely` côté serveur. Architecture déjà décrite dans le brainstorm initial mais non retenue à ce stade pour éviter d'introduire un nouveau service permanent.
+1. ~~**Démon collecteur de session privilégié**~~ — **LIVRÉ (PR #157)**, voir
+   [R-S18](#r-s18-p1-i1---effacement-des-enregistrements-de-session). Cette piste
+   était listée « non retenue pour éviter d'introduire un nouveau service
+   permanent » : les deux objections sont caduques. Le puits `ob-record-sink` est
+   **activé par socket** (`systemd/ob-record.socket`), donc pas un service
+   permanent, et il écrit des fichiers **root-owned** (`src/ob-record-sink.c`,
+   `openat(..., O_NOFOLLOW, 0640)` dans une arborescence `root:ob-sessions 0750`),
+   l'utilisateur étant dérivé de `SO_PEERCRED`. Reste à faire de cette piste :
+   la détection de fermeture brutale du recorder (`killed_prematurely` côté
+   serveur), qui n'est pas implémentée.
 2. **Mandatory Access Control** : profil AppArmor / SELinux qui interdit `setsid` aux shells utilisateurs (rompre le canal d'évasion à la racine). Coût opérationnel élevé (rédaction et maintenance du profil par distribution) mais blocage fort.
 3. **`KillUserProcesses=yes` rendu obligatoire** : retirer l'opt-in et l'imposer en postinst. Abandonné à cause de la philosophie Debian (pas de modification système globale silencieuse). Pourrait être réintroduit comme paquet `open-bastion-strict` dédié, qui imposerait le hardening sans demande de confirmation.
 
@@ -301,6 +326,11 @@ des dérogations volontaires au contrôle centralisé : utiles pour l'automatisa
 
 ### R-S24 _(P=1, I=3)_ - Sudo de compte de service hors token SSO
 
+> **Fiche de risque :** l'analyse complète de R-S24 (vecteurs, facteurs
+> atténuants, remédiation, score résiduel) est en section 6 de
+> [02-ssh-connection.md](02-ssh-connection.md) ; la section ci-dessous n'est
+> que le volet « pistes » du plan de traitement.
+
 Le droit sudo d'un compte de service provient **uniquement** de
 `service-accounts.conf` (`sudo_allowed` / `sudo_nopasswd`) : `pam_openbastion`
 l'accorde localement et renvoie un succès **sans aucun appel LLNG**, **y compris
@@ -315,12 +345,17 @@ Pistes :
    restreintes à des commandes précises plutôt qu'un sudo total.
 2. **Inventaire et rotation** : traiter chaque clé de service comme un secret de
    longue durée (coffre-fort, rotation périodique, révocation à la sortie d'un
-   prestataire/outil). Recoupe le compte de secours de [R-S17](#r-s17-_p1-i2_---verrouillage-total-lockout).
+   prestataire/outil). Recoupe le compte de secours de [R-S17](#r-s17-p1-i2---verrouillage-total-lockout).
 3. **Audit dédié** : journaliser/alerter sur l'usage sudo des comptes de service
    (auditd `-k` distinct), puisqu'il n'apparaît pas dans les logs d'autorisation
    LLNG.
 
 ### R-S25 _(P=1, I=2)_ - Hop de compte de service via ProxyJump non enregistré
+
+> **Fiche de risque :** l'analyse complète de R-S25 (vecteurs, facteurs
+> atténuants, remédiation, score résiduel) est en section 6 de
+> [02-ssh-connection.md](02-ssh-connection.md) ; la section ci-dessous n'est
+> que le volet « pistes » du plan de traitement.
 
 Un compte de service ne peut pas utiliser `ob-ssh` (pas de voucher SSO), mais un
 `ssh -J bastion compte@backend` natif fonctionne s'il est configuré des deux

--- a/doc/security/README.md
+++ b/doc/security/README.md
@@ -1,0 +1,52 @@
+# Étude de sécurité Open Bastion — EBIOS Risk Manager
+
+Cette étude suit la méthode **EBIOS Risk Manager** (ANSSI, 2018). Elle porte sur
+la cible de sécurité maximale d'Open Bastion (Mode E) et **inclut le portail
+LemonLDAP::NG et ses quatre plugins** dans son périmètre.
+
+Les documents sont en français ; les documentations techniques auxquelles ils
+renvoient (`doc/hardening.md`, `doc/audit.md`, `doc/pam-modes.md`) sont en
+anglais.
+
+## Plan de lecture
+
+| Atelier                         | Document                                                                                      | Contenu                                                                             |
+| ------------------------------- | --------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
+| —                               | [00-architecture.md](00-architecture.md)                                                      | Cible de sécurité, architecture, mécanismes de défense                              |
+| **1** — Cadrage et socle        | [04-atelier1-cadrage-socle.md](04-atelier1-cadrage-socle.md)                                  | Périmètre, valeurs métier, biens supports, **échelles**, événements redoutés, socle |
+| **2** — Sources de risque       | [05-atelier2-sources-de-risque.md](05-atelier2-sources-de-risque.md)                          | Sources de risque, objectifs visés, couples SR/OV retenus                           |
+| **3** — Scénarios stratégiques  | [06-atelier3-scenarios-strategiques.md](06-atelier3-scenarios-strategiques.md)                | Écosystème, niveaux de menace, sept scénarios stratégiques                          |
+| **4** — Scénarios opérationnels | [01-enrollment.md](01-enrollment.md) · [02-ssh-connection.md](02-ssh-connection.md)           | **39 fiches de risque** avec scores initiaux et résiduels, matrices                 |
+| **5** — Traitement              | [07-plan-de-traitement.md](07-plan-de-traitement.md) · [99-risk-reduce.md](99-risk-reduce.md) | Plan de traitement daté et porté ; matrice résiduelle consolidée et argumentaire    |
+| Décision                        | [08-dossier-homologation.md](08-dossier-homologation.md)                                      | Périmètre d'homologation, **conditions d'emploi**, acceptation des résiduels        |
+| Opérationnel                    | [03-offboarding.md](03-offboarding.md)                                                        | Procédure de révocation des accès administrateurs                                   |
+
+## Deux lectures utiles selon le besoin
+
+- **« Puis-je déployer ce produit ? »** → lire les **conditions d'emploi** en
+  [08-dossier-homologation.md, §2](08-dossier-homologation.md#2-conditions-demploi).
+  Ce sont les quinze hypothèses que les scores résiduels supposent vérifiées, et
+  que le produit n'impose pas toutes.
+- **« Quel est le risque résiduel ? »** → lire la matrice consolidée en tête de
+  [99-risk-reduce.md](99-risk-reduce.md), puis les trois risques en zone orange
+  en [08, §3.1](08-dossier-homologation.md#31-zone-orange-acceptation-requise).
+
+## Cohérence vérifiée mécaniquement
+
+Une matrice de risque n'est pas une affirmation autonome : chaque case doit
+découler du couple (Vraisemblance, Gravité) écrit dans la fiche correspondante.
+`tests/ebios_matrix_check.py` — exécuté en CI par
+`tests/test_ob_ebios_matrices.sh` — le vérifie et échoue si :
+
+- une case de matrice contredit sa fiche ;
+- un risque analysé manque à une matrice, ou y figure sans fiche ;
+- un score répété dans un titre de section de `99-risk-reduce.md` contredit sa fiche ;
+- une fiche n'est rattachée à aucun événement redouté de l'atelier 1 ;
+- une liste de zone de risque ne découle pas des scores.
+
+## État du dossier
+
+Le dossier d'homologation porte des champs `À COMPLÉTER` : version du produit
+visée, porteurs, échéances, décisions d'acceptation et signature. Ces valeurs
+relèvent de l'autorité d'homologation et ne sont pas déduites de l'analyse. Tant
+qu'ils subsistent, **le dossier est complet en tant qu'analyse, mais non signé.**

--- a/tests/ebios_matrix_check.py
+++ b/tests/ebios_matrix_check.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+"""
+Check that every EBIOS risk matrix in doc/security/ agrees with the risk sheets
+it summarises (#213, #214).
+
+Why this exists: the matrices were maintained by hand, next to the sheets they
+summarise, and drifted from them in at least thirteen places -- a risk shown one
+column to the left, a residual impact that no sheet states, a consolidated table
+missing eleven analysed risks and carrying two that had no sheet at all. An
+evaluator reads the matrix, not the sheets, so a matrix that disagrees with its
+own study is worse than no matrix.
+
+The rule enforced here is simple: a matrix cell is not a claim of its own. Every
+placement must be derivable from the (Probabilite, Impact) written in the
+corresponding sheet, and every analysed risk must appear exactly once.
+
+Run:  python3 tests/ebios_matrix_check.py
+"""
+
+import re
+import sys
+from pathlib import Path
+
+DOC = Path(__file__).resolve().parent.parent / "doc" / "security"
+
+ENROLLMENT = DOC / "01-enrollment.md"
+SSH = DOC / "02-ssh-connection.md"
+CONSOLIDATED = DOC / "99-risk-reduce.md"
+
+RISK_ID = r"R-?S?A?\d+"
+HEADING = re.compile(rf"^#{{3,4}}\s+({RISK_ID})\s*[-–—]\s", re.M)
+ANY_HEADING = re.compile(r"^#{1,6}\s", re.M)
+
+# A score table row: "| **Probabilite** | 1 (because ...) |"
+PROB_ROW = re.compile(r"^\|\s*\*\*Probabilit[ée]\*\*\s*\|\s*([0-9])", re.M)
+IMPACT_ROW = re.compile(r"^\|\s*\*\*Impact\*\*\s*\|\s*([0-9])", re.M)
+
+
+def sheets(path):
+    """Return {risk_id: {"initial": (P, I), "residual": (P, I), "level": n, "line": n}}.
+
+    A sheet runs from its own heading to the next heading of the same or a
+    higher level: stopping only at the next *risk* heading would make the last
+    sheet in a file swallow the matrices that follow it.
+    """
+    lines = path.read_text(encoding="utf-8").split("\n")
+
+    # Heading levels per line, with fenced code blocks blanked out: a shell
+    # comment inside a ``` block ("# FORTEMENT RECOMMANDE ...") is not a
+    # Markdown heading, and treating it as one truncates the sheet before its
+    # residual-score table.
+    level_of = [0] * len(lines)
+    fenced = False
+    for i, line in enumerate(lines):
+        if line.lstrip().startswith("```"):
+            fenced = not fenced
+            continue
+        if fenced:
+            continue
+        h = re.match(r"^(#{1,6})\s", line)
+        if h:
+            level_of[i] = len(h.group(1))
+
+    starts = []
+    for i, line in enumerate(lines):
+        if not 3 <= level_of[i] <= 4:
+            continue
+        m = re.match(rf"^#+\s+({RISK_ID})\s*[-\u2013\u2014]\s", line)
+        if m:
+            starts.append((i, level_of[i], m.group(1)))
+
+    found = {}
+    for n, (i, level, rid) in enumerate(starts):
+        end = len(lines)
+        for j in range(i + 1, len(lines)):
+            if level_of[j] and level_of[j] <= level:
+                end = j
+                break
+        body = "\n".join(lines[i:end])
+        probs = PROB_ROW.findall(body)
+        impacts = IMPACT_ROW.findall(body)
+        if len(probs) < 2 or len(impacts) < 2:
+            continue  # not a scored sheet (or an unscored backlog heading)
+        found[rid] = {
+            "initial": (int(probs[0]), int(impacts[0])),
+            "residual": (int(probs[-1]), int(impacts[-1])),
+            "level": level,
+            "line": i + 1,
+        }
+    return found
+
+
+def matrix(path, after_heading):
+    """Parse the 4x4 matrix that follows `after_heading`.
+
+    Returns {risk_id: (P, I)} and the line the matrix starts on.
+    """
+    text = path.read_text(encoding="utf-8")
+    start = text.index(after_heading) + len(after_heading)
+    table = text[start:]
+    placed = {}
+    line0 = text[:start].count("\n") + 1
+    for row in table.split("\n"):
+        row = row.strip()
+        if not row.startswith("|"):
+            if placed:
+                break  # table finished
+            continue
+        m = re.match(r"^\|\s*\*\*([0-9])\s*-", row)
+        if not m:
+            continue
+        impact = int(m.group(1))
+        cells = [c.strip() for c in row.strip("|").split("|")][1:]
+        for col, cell in enumerate(cells, start=1):
+            for rid in re.findall(rf"\b{RISK_ID}\b", cell):
+                placed[rid] = (col, impact)
+    return placed, line0
+
+
+def compare(label, expected, placed, kind, errors):
+    """`expected` is {rid: (P, I)}; `placed` is what the matrix says."""
+    for rid, want in sorted(expected.items()):
+        got = placed.get(rid)
+        if got is None:
+            errors.append(f"{label}: {rid} is analysed ({kind} P={want[0]}, I={want[1]}) "
+                          f"but absent from the matrix")
+        elif got != want:
+            errors.append(f"{label}: {rid} placed at P={got[0]}, I={got[1]} "
+                          f"but its sheet says P={want[0]}, I={want[1]}")
+    for rid in sorted(placed):
+        if rid not in expected:
+            errors.append(f"{label}: {rid} appears in the matrix but has no scored sheet")
+
+
+def main():
+    errors = []
+
+    enrol = sheets(ENROLLMENT)
+    ssh = sheets(SSH)
+
+    if len(enrol) < 14:
+        errors.append(f"01-enrollment.md: only {len(enrol)} scored sheets parsed, expected 14")
+    if len(ssh) < 23:
+        errors.append(f"02-ssh-connection.md: only {len(ssh)} scored sheets parsed, expected 23+")
+
+    checks = [
+        ("01-enrollment avant", ENROLLMENT, "## 3. Matrice des Risques\n\n### Avant remédiation\n",
+         {k: v["initial"] for k, v in enrol.items()}, "initial"),
+        ("01-enrollment après", ENROLLMENT, "### Après remédiation\n",
+         {k: v["residual"] for k, v in enrol.items()}, "residual"),
+        ("02-ssh avant", SSH, "## 4. Matrice des Risques\n\n### Avant remédiation\n",
+         {k: v["initial"] for k, v in ssh.items()}, "initial"),
+        ("02-ssh après", SSH, "### Après remédiation complète\n",
+         {k: v["residual"] for k, v in ssh.items()}, "residual"),
+    ]
+
+    for label, path, heading, expected, kind in checks:
+        try:
+            placed, _ = matrix(path, heading)
+        except ValueError:
+            errors.append(f"{label}: matrix heading not found ({heading.strip()!r})")
+            continue
+        compare(label, expected, placed, kind, errors)
+
+    # The consolidated matrix must cover EVERY analysed risk from both studies.
+    all_residual = {}
+    all_residual.update({k: v["residual"] for k, v in enrol.items()})
+    all_residual.update({k: v["residual"] for k, v in ssh.items()})
+    try:
+        placed, _ = matrix(CONSOLIDATED, "## Matrice des Risques Résiduels (Mode E)\n")
+    except ValueError:
+        placed = None
+        errors.append("99-risk-reduce.md: consolidated matrix heading not found")
+    if placed is not None:
+        compare("99-risk-reduce consolidée", all_residual, placed, "residual", errors)
+
+    # 99-risk-reduce.md repeats each score in its own section headings
+    # ("### R5 _(P=1, I=4)_ - ..."). Those must agree with the sheets too: the
+    # file used to state three different values for R-S18 on three lines.
+    text = CONSOLIDATED.read_text(encoding="utf-8")
+    for m in re.finditer(rf"^#{{2,4}}\s+({RISK_ID})\s+_\(P=([0-9]+)[^)]*?I=([0-9]+)", text, re.M):
+        rid, p, i = m.group(1), int(m.group(2)), int(m.group(3))
+        want = all_residual.get(rid)
+        if want is None:
+            errors.append(f"99-risk-reduce heading: {rid} has no scored sheet")
+        elif (p, i) != want:
+            line = text[:m.start()].count("\n") + 1
+            errors.append(f"99-risk-reduce heading (line {line}): {rid} says P={p}, I={i} "
+                          f"but its sheet says P={want[0]}, I={want[1]}")
+
+    if errors:
+        print(f"{len(errors)} matrix/sheet disagreement(s):\n")
+        for e in errors:
+            print(f"  - {e}")
+        return 1
+
+    total = len(all_residual)
+    print(f"OK: {total} risk sheets, every matrix cell derivable from its sheet")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/ebios_matrix_check.py
+++ b/tests/ebios_matrix_check.py
@@ -26,6 +26,7 @@ DOC = Path(__file__).resolve().parent.parent / "doc" / "security"
 ENROLLMENT = DOC / "01-enrollment.md"
 SSH = DOC / "02-ssh-connection.md"
 CONSOLIDATED = DOC / "99-risk-reduce.md"
+WORKSHOP1 = DOC / "04-atelier1-cadrage-socle.md"
 
 RISK_ID = r"R-?S?A?\d+"
 HEADING = re.compile(rf"^#{{3,4}}\s+({RISK_ID})\s*[-–—]\s", re.M)
@@ -187,6 +188,54 @@ def main():
             line = text[:m.start()].count("\n") + 1
             errors.append(f"99-risk-reduce heading (line {line}): {rid} says P={p}, I={i} "
                           f"but its sheet says P={want[0]}, I={want[1]}")
+
+    # Atelier 1 attaches every risk sheet to exactly one feared event. That table
+    # is the bridge between the workshops and the sheets: if a sheet is added and
+    # not attached, the study silently stops covering it.
+    if WORKSHOP1.exists():
+        w1 = WORKSHOP1.read_text(encoding="utf-8")
+        attached = {}
+        for m in re.finditer(r"^\|\s*(ER[0-9]+)\s*\|([^|]*)\|", w1, re.M):
+            er = m.group(1)
+            for rid in re.findall(rf"\b{RISK_ID}\b", m.group(2)):
+                if rid in attached:
+                    errors.append(f"04-atelier1: {rid} is attached to both "
+                                  f"{attached[rid]} and {er}")
+                attached[rid] = er
+        if not attached:
+            errors.append("04-atelier1: no feared-event/risk-sheet mapping found")
+        else:
+            for rid in sorted(all_residual):
+                if rid not in attached:
+                    errors.append(f"04-atelier1: {rid} has a risk sheet but is attached "
+                                  f"to no feared event")
+            for rid in sorted(attached):
+                if rid not in all_residual:
+                    errors.append(f"04-atelier1: {rid} is attached to {attached[rid]} "
+                                  f"but has no risk sheet")
+
+    # The zone listing in 99-risk-reduce.md must follow from the same scores.
+    # It used to list R-S6 and R-SA1 as "jaune" while stating score = P x I,
+    # which puts them at 6.
+    zones = {"rouge": (9, 99), "orange": (6, 8), "jaune": (4, 5), "verte": (0, 3)}
+    computed = {z: set() for z in zones}
+    for rid, (p, i) in all_residual.items():
+        score = p * i
+        for z, (lo, hi) in zones.items():
+            if lo <= score <= hi:
+                computed[z].add(rid)
+    text = CONSOLIDATED.read_text(encoding="utf-8")
+    for z in ("rouge", "orange", "jaune"):
+        m = re.search(rf"^- \*\*{z.capitalize()}\*\* \(score[^)]*\)\s*:(.*)$", text, re.M)
+        if not m:
+            errors.append(f"99-risk-reduce: no '{z}' zone listing found")
+            continue
+        listed = set(re.findall(rf"\b{RISK_ID}\b", m.group(1)))
+        if listed != computed[z]:
+            missing = sorted(computed[z] - listed)
+            extra = sorted(listed - computed[z])
+            errors.append(f"99-risk-reduce zone {z}: "
+                          f"missing {missing or '-'}, unexpected {extra or '-'}")
 
     if errors:
         print(f"{len(errors)} matrix/sheet disagreement(s):\n")

--- a/tests/test_ob_ebios_matrices.sh
+++ b/tests/test_ob_ebios_matrices.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+#
+# Every EBIOS risk matrix in doc/security/ must agree with the risk sheets it
+# summarises (#213, #214).
+#
+# The matrices were maintained by hand next to the sheets and drifted from them
+# in at least thirteen places: a risk shown one column to the left, a residual
+# impact no sheet states, a consolidated table missing eleven analysed risks and
+# carrying two identifiers that had no sheet at all. An evaluator reads the
+# matrix, not the sheets, so a matrix that contradicts its own study is worse
+# than no matrix.
+#
+# The check is mechanical: a matrix cell is not a claim of its own, it must be
+# derivable from the (Probabilite, Impact) written in the corresponding sheet.
+# See tests/ebios_matrix_check.py.
+#
+
+set -uo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+
+if ! command -v python3 >/dev/null 2>&1; then
+    echo "  SKIP: python3 not available"
+    exit 0
+fi
+
+echo "=== EBIOS matrices vs risk sheets (#213, #214) ==="
+if python3 "$ROOT_DIR/tests/ebios_matrix_check.py"; then
+    echo ""
+    echo "Tests run: 1, passed: 1, failed: 0"
+    exit 0
+else
+    echo ""
+    echo "Tests run: 1, passed: 0, failed: 1"
+    exit 1
+fi


### PR DESCRIPTION
Closes #212, #216, #217.

> **Stacked on #239** (`docs/ebios-matrix-consistency`), which this work depends on — the matrices must agree with the sheets before the workshops can point at them. Merge #239 first; the base then switches to `main` on its own.

## The gap

`doc/security/` is presented as an EBIOS RM study and contains **only workshop 4**. The word "EBIOS" appears nowhere inside it. No essential assets, no risk sources, no strategic scenarios — and no explicit severity or likelihood scales, so the matrices were using scales that were never written down anywhere.

There was also no treatment plan (25 free-text *pistes* with no owner, priority, due date or status) and **no decision artefact at all**: no perimeter of homologation, no conditions of use, no residual-risk acceptance.

## What ships

| Document | Content |
| --- | --- |
| `04-atelier1-cadrage-socle.md` | Perimeter, business values, supporting assets, the **severity and likelihood scales** the matrices were already using implicitly, the risk-zone definition, seven feared events, security baseline with its gaps |
| `05-atelier2-sources-de-risque.md` | Seven risk sources, six target objectives, the SR/OV relevance grid, and why the discarded pairs were discarded |
| `06-atelier3-scenarios-strategiques.md` | Ecosystem mapping with threat levels, seven strategic scenarios |
| `07-plan-de-traitement.md` | **29 measures** with risk, nature, priority, owner, due date and state — plus four measures explicitly discarded, with their reason |
| `08-dossier-homologation.md` | Dossier front matter, homologation perimeter, four trust assumptions, **fifteen conditions of use** with how to verify each on target, residual-risk acceptance table |
| `README.md` | Maps each document to its workshop, with two entry points: "can I deploy this?" and "what is the residual risk?" |

Each strategic scenario states what the architecture opposes **and what it does not** — SS2 says plainly that the recording lives on the bastion and root there is a trust assumption, not a protection.

## Three decisions, flagged as decisions

1. **The LLNG portal and its four plugins are inside the homologation perimeter** (your call in this session). The portal authorizes every session and every `sudo`, signs the certificates and holds the CA key; stopping at the edge of the server would homologate half the security decisions. This also makes #218 in scope by construction.
2. **The LLNG portal administrator (SR7) is not a risk the product reduces.** It is written as a trust assumption (H1), not dressed up as something the architecture defends against.
3. **Owner names, dates, product version and acceptance decisions are `À COMPLÉTER`.** They belong to the homologation authority. The dossier states it is complete as an analysis but **not signed** while they remain — rather than inventing names and dates that would make it look approved.

## Two things the audit did not ask for, found on the way

- **The risk-zone definition contradicted itself.** `01-enrollment.md` used thresholds on (P, I); `99-risk-reduce.md` used a score — and listed R-S6 and R-SA1 as "jaune" while stating score = P × I, which puts them at 6. There is now one definition in workshop 1, and R1 turns out to belong in the orange zone too, which no listing had.
- **Delivered measures now stay in the plan** with their PR reference. Deleting them is what let two shipped measures keep being listed as future work (#215).

## Enforcement

`tests/ebios_matrix_check.py` gains two rules: every risk sheet must be attached to exactly one feared event in workshop 1, and every risk-zone listing must follow from the scores.

```
$ bash tests/test_ob_ebios_matrices.sh
OK: 39 risk sheets, every matrix cell derivable from its sheet
```

Verified by regression: detaching R-S9 from ER4 fails with `R-S9 has a risk sheet but is attached to no feared event`. All intra-document links and anchors check out.

https://claude.ai/code/session_011q88Fs4nFuUs7JMvmgbBTN