### PR TITLE
docs(offline): state what works during a portal outage, and the personal-key question

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -579,6 +579,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   because the setup scripts write it there, but it is read only from
   `nss_openbastion.conf`, by the NSS module.
 
+- **`doc/offline-mode.md` now states what actually works during a portal outage
+  (#165).** A ten-row matrix derived from the code and the generated `sshd`
+  configurations: what keeps working (user resolution, certificate logins,
+  service-account `sudo`), what does not (`sudo` for SSO users — the cache is an
+  *authorization* cache, not an authentication one — `ob-ssh`/`ob-scp`/`ob-sftp`,
+  enrolment, revocation), and the two cache TTLs that must be sized together.
+
+  It also answers a question that comes up on every deployment: can a user keep a
+  **personal SSH key on the bastion** as an outage fallback? In Mode E, no — the
+  backends set `AuthorizedKeysFile none` and `sshd` refuses a plain key before
+  PAM is consulted. In the key modes, yes, under four stated conditions — and the
+  documentation says what it costs: a long-lived private key on the bastion, not
+  bounded by a certificate TTL and not revocable through the portal, and a hop
+  that is no longer vouched. One assumption is corrected: the audit trail
+  **survives**, because a plain `ssh` run from inside a recorded bastion session
+  is captured by the pty recorder; what is not recorded is a `ssh -J bastion`
+  ProxyJump from a workstation.
+
+  The EBIOS risk R-S17 (total lockout) gains the same note in French, and
+  `doc/pam-modes.md` points Mode C at the matrix. The key-mode path is labelled
+  as analysis, not as a tested procedure: the end-to-end lab validation the issue
+  asks for has not been done.
+
 - **A world- or group-readable `/etc/open-bastion/cache.key` is now rejected
   instead of used with a warning** (offline auth cache, desktop SSO). Versions
   up to 0.6.2 accepted such a key and merely logged a warning. `SECURITY.md`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -582,9 +582,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`doc/offline-mode.md` now states what actually works during a portal outage
   (#165).** A ten-row matrix derived from the code and the generated `sshd`
   configurations: what keeps working (user resolution, certificate logins,
-  service-account `sudo`), what does not (`sudo` for SSO users — the cache is an
-  *authorization* cache, not an authentication one — `ob-ssh`/`ob-scp`/`ob-sftp`,
-  enrolment, revocation), and the two cache TTLs that must be sized together.
+  service-account `sudo`), what does not (`ob-ssh`/`ob-scp`/`ob-sftp`, enrolment,
+  revocation), and the two cache TTLs that must be sized together.
+
+  `sudo` for an SSO user is the row that needed splitting rather than a ❌. The
+  cache is an _authorization_ cache, not an authentication one, so the `auth`
+  phase cannot be served offline — but `sudo` only runs that phase when its own
+  credential has lapsed (`timestamp_timeout`, 15 min, idle-based). While it is
+  valid `sudo` never calls `pam_authenticate()`, and the `account` phase answers
+  `sudo_allowed` from the authorization cache. A user who elevated recently
+  therefore keeps elevating during an outage. Conversely, `--enable-sudo-fresh-otp`
+  (#178) sets `timestamp_timeout=0` and so removes the window entirely: on such a
+  host no SSO user can `sudo` at all while the portal is down. The same
+  correction is applied to `doc/security/02-ssh-connection.md`, whose "les
+  escalades sudo sont refusées" was an assumption R-S17 rests on.
 
   It also answers a question that comes up on every deployment: can a user keep a
   **personal SSH key on the bastion** as an outage fallback? In Mode E, no — the

--- a/doc/offline-mode.md
+++ b/doc/offline-mode.md
@@ -34,18 +34,38 @@ Before the configuration details: this is the honest matrix of what an operator
 can and cannot do while the LLNG portal is unreachable. It is derived from the
 code, not from intent.
 
-| Operation                                                 | Portal down                                 | Why                                                                                                                                     |
-| --------------------------------------------------------- | ------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
-| **Resolve a user** (`getent passwd`)                      | ✅ while the NSS cache holds                | `libnss_openbastion` caches lookups; `cache_ttl` in `nss_openbastion.conf`                                                              |
-| **SSH login with a valid certificate**                    | ✅ while the auth cache holds               | sshd validates the certificate against `TrustedUserCAKeys` locally; PAM `account` falls back to the authorization cache                 |
-| **SSH login with a plain key** (`~/.ssh/authorized_keys`) | ✅ **only in key modes** — never in Mode E  | Mode E sets `AuthorizedKeysFile none`; sshd rejects a plain key before PAM runs                                                         |
-| **`sudo` for an SSO user**                                | ❌                                          | The `auth` phase needs a fresh one-time token from `/pam/verify`. The cache is an _authorization_ cache, not an authentication one      |
-| **`sudo` for a service account**                          | ✅                                          | Rights come from `service-accounts.conf`, read locally, with no portal call                                                             |
-| **`ob-ssh` / `ob-scp` / `ob-sftp` to a backend**          | ❌                                          | Each mints an ephemeral certificate through `/pam/bastion-cert`. There is no offline path, and the per-session voucher is not cacheable |
-| **Plain `ssh user@backend` from the bastion**             | ✅ **only in key modes** — never in Mode E  | See the row above; the backend's own PAM `account` then falls back to its authorization cache                                           |
-| **Enrolling a new server**                                | ❌                                          | The RFC 8628 device flow needs the portal and a human approval                                                                          |
-| **Refreshing the KRL**                                    | ❌ (the last downloaded KRL stays in force) | `RevokedKeys` is a local file; it simply stops being updated                                                                            |
-| **Revoking a user**                                       | ❌ — and this is the point that matters     | Revocation is a portal-side action. While the portal is down, a cached authorization keeps working until its TTL expires                |
+| Operation                                                                  | Portal down                                   | Why                                                                                                                                                                                  |
+| -------------------------------------------------------------------------- | --------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Resolve a user** (`getent passwd`)                                       | ✅ while the NSS cache holds                  | `libnss_openbastion` caches lookups; `cache_ttl` in `nss_openbastion.conf`                                                                                                           |
+| **SSH login with a valid certificate**                                     | ✅ while the auth cache holds                 | sshd validates the certificate against `TrustedUserCAKeys` locally; PAM `account` falls back to the authorization cache                                                              |
+| **SSH login with a plain key** (`~/.ssh/authorized_keys`)                  | ✅ **only in key modes** — never in Mode E    | Mode E sets `AuthorizedKeysFile none`; sshd rejects a plain key before PAM runs                                                                                                      |
+| **`sudo` for an SSO user** — first one, or after the sudo timestamp lapses | ❌                                            | The `auth` phase needs a fresh one-time token from `/pam/verify`. The cache is an _authorization_ cache, not an authentication one                                                   |
+| **`sudo` for an SSO user** — while sudo's own timestamp is still valid     | ⚠️ works, if the authorization is also cached | sudo skips `pam_authenticate()` entirely while its credential is fresh, so no token is asked for; the `account` phase then falls back to the authorization cache. See the note below |
+| **`sudo` for a service account**                                           | ✅                                            | Rights come from `service-accounts.conf`, read locally, with no portal call                                                                                                          |
+| **`ob-ssh` / `ob-scp` / `ob-sftp` to a backend**                           | ❌                                            | Each mints an ephemeral certificate through `/pam/bastion-cert`. There is no offline path, and the per-session voucher is not cacheable                                              |
+| **Plain `ssh user@backend` from the bastion**                              | ✅ **only in key modes** — never in Mode E    | Same reason as the "SSH login with a plain key" row above; the backend's own PAM `account` then falls back to its authorization cache                                                |
+| **Enrolling a new server**                                                 | ❌                                            | The RFC 8628 device flow needs the portal and a human approval                                                                                                                       |
+| **Refreshing the KRL**                                                     | ❌ (the last downloaded KRL stays in force)   | `RevokedKeys` is a local file; it simply stops being updated                                                                                                                         |
+| **Revoking a user**                                                        | ❌ — and this is the point that matters       | Revocation is a portal-side action. While the portal is down, a cached authorization keeps working until its TTL expires                                                             |
+
+> **The `sudo` rows deserve their nuance.** Saying flatly that an SSO user
+> cannot `sudo` during an outage is not what the code does. `sudo` keeps its own
+> credential (`timestamp_timeout`, 15 minutes by default, idle-based and rearmed
+> on each use), and while it is valid `sudo` does not run the PAM `auth` phase at
+> all — `pam_openbastion` is never asked for a one-time token. The `account`
+> phase still runs, and with the portal down it answers from the authorization
+> cache (`sudo_allowed` is stored there). So during an outage an SSO user who
+> elevated recently keeps elevating; the failure lands on the first `sudo` after
+> the timestamp lapses.
+>
+> This cuts the other way too. `ob-bastion-setup` /
+> `ob-backend-setup --enable-sudo-fresh-otp` (#178) sets
+> `timestamp_timeout=0` for the SSO group precisely so that every elevation goes
+> through the `auth` phase. On a host configured that way, **no SSO user can
+> `sudo` at all while the portal is down** — the ⚠️ row above becomes a ❌. That
+> is the intended trade: a fresh proof per elevation, paid for in availability.
+> Break-glass service accounts (`sudo` read from `service-accounts.conf`) are the
+> designed answer, and they are unaffected either way.
 
 Two caches are involved and they must be sized together:
 

--- a/doc/offline-mode.md
+++ b/doc/offline-mode.md
@@ -28,6 +28,96 @@ flowchart TB
     end
 ```
 
+## What works offline, and what needs the portal
+
+Before the configuration details: this is the honest matrix of what an operator
+can and cannot do while the LLNG portal is unreachable. It is derived from the
+code, not from intent.
+
+| Operation                                                 | Portal down                                 | Why                                                                                                                                     |
+| --------------------------------------------------------- | ------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| **Resolve a user** (`getent passwd`)                      | ✅ while the NSS cache holds                | `libnss_openbastion` caches lookups; `cache_ttl` in `nss_openbastion.conf`                                                              |
+| **SSH login with a valid certificate**                    | ✅ while the auth cache holds               | sshd validates the certificate against `TrustedUserCAKeys` locally; PAM `account` falls back to the authorization cache                 |
+| **SSH login with a plain key** (`~/.ssh/authorized_keys`) | ✅ **only in key modes** — never in Mode E  | Mode E sets `AuthorizedKeysFile none`; sshd rejects a plain key before PAM runs                                                         |
+| **`sudo` for an SSO user**                                | ❌                                          | The `auth` phase needs a fresh one-time token from `/pam/verify`. The cache is an _authorization_ cache, not an authentication one      |
+| **`sudo` for a service account**                          | ✅                                          | Rights come from `service-accounts.conf`, read locally, with no portal call                                                             |
+| **`ob-ssh` / `ob-scp` / `ob-sftp` to a backend**          | ❌                                          | Each mints an ephemeral certificate through `/pam/bastion-cert`. There is no offline path, and the per-session voucher is not cacheable |
+| **Plain `ssh user@backend` from the bastion**             | ✅ **only in key modes** — never in Mode E  | See the row above; the backend's own PAM `account` then falls back to its authorization cache                                           |
+| **Enrolling a new server**                                | ❌                                          | The RFC 8628 device flow needs the portal and a human approval                                                                          |
+| **Refreshing the KRL**                                    | ❌ (the last downloaded KRL stays in force) | `RevokedKeys` is a local file; it simply stops being updated                                                                            |
+| **Revoking a user**                                       | ❌ — and this is the point that matters     | Revocation is a portal-side action. While the portal is down, a cached authorization keeps working until its TTL expires                |
+
+Two caches are involved and they must be sized together:
+
+- the **NSS** cache (`cache_ttl` in `nss_openbastion.conf`) — without it the user
+  does not resolve at all, and nothing else matters;
+- the **PAM authorization** cache (`auth_cache = true` in `openbastion.conf`) —
+  its TTL is not a local setting: the portal supplies it in the `/pam/authorize`
+  response from LLNG's `pamAccessOfflineTtl`, with a built-in 24 h fallback.
+
+> **Build note.** The authorization cache is _looked up_ in every build, but only
+> _written_ in builds with `INSTALL_DESKTOP=ON`. The Debian package is built that
+> way, so this concerns you only if you compile the module yourself with
+> `INSTALL_DESKTOP=OFF`: there the cache is never populated and every row marked
+> ✅ above becomes ❌.
+
+### A personal SSH key on the bastion as an outage fallback
+
+A question that comes up on every deployment: can a user keep a **personal SSH
+key** in their home directory on the bastion, so that bastion→backend hops keep
+working when the portal is down?
+
+**In Mode E (cert-vouching, maximum security): no, by design.** The backends set
+`AuthorizedKeysFile none` and accept only certificates signed by the LLNG CA,
+whose key-id must carry `bastion=<id>;user=<u>` — a plain user key is refused by
+`sshd` before PAM is ever consulted. `ob-ssh` cannot help either: minting its
+ephemeral certificate requires the portal. This is not an oversight to work
+around; it is the property that makes the bastion the only way in.
+
+**In the key modes (a certificate mode _without_ `--max-security`, or PAM mode
+C): yes, with conditions.** Those setups do not write `AuthorizedKeysFile none`,
+so `sshd` still honours `~/.ssh/authorized_keys` on the backend. The user's own
+key authenticates them, and the backend's PAM `account` phase falls back to its
+authorization cache. Conditions:
+
+1. The backend must **not** have been set up with `--max-security`.
+2. The user must already be in the backend's authorization cache — the cache is
+   populated by a successful _online_ login, so this only helps someone who
+   connected recently, not someone who has never logged in.
+3. NSS must still resolve the user on the backend (its own cache TTL).
+4. The public key must have been placed in `~/.ssh/authorized_keys` on the
+   backend beforehand, by an out-of-band mechanism.
+
+**What it costs you.** This is a deliberate trade-off, not a free resilience
+feature:
+
+- a **long-lived private key** now lives on the bastion, where the ephemeral-key
+  design specifically avoided one. Its compromise is not bounded by a
+  certificate TTL, and it is not revocable through the portal — removing it means
+  editing `authorized_keys` on every backend;
+- the hop is no longer **vouched**: the backend cannot tell that the user
+  authenticated to the bastion, so `allowed_bastions`, the source-address pinning
+  and the voucher TTL all stop applying to it;
+- **the audit trail survives, contrary to what one might assume**: a plain `ssh`
+  run _from inside a bastion session_ is captured by the session recorder like
+  any other command, because the recorder captures the pty. What is **not**
+  recorded is a `ssh -J bastion …` ProxyJump from a workstation, which uses a
+  `direct-tcpip` channel the `ForceCommand` never sees — the same gap as R-S25 in
+  [the risk study](security/99-risk-reduce.md).
+
+**Recommendation.** Treat it as a degraded-but-available posture chosen
+deliberately, per deployment, and prefer the two mechanisms designed for the
+outage case: a **break-glass service account** (`service-accounts.conf`, resolved
+locally with no portal call) and **out-of-band console access**. Both are the
+remediation the risk study already prescribes for a total lockout — see R-S17 in
+[doc/security/99-risk-reduce.md](security/99-risk-reduce.md).
+
+> **Validation status.** The matrix above and the Mode E answer are derived from
+> the code and the generated `sshd` configurations. The key-mode path has **not
+> yet been validated end to end in a lab** (portal up, then portal down, cached
+> authorization still admitting the key). Until it has, treat the key-mode rows
+> as analysis rather than as a tested procedure — see issue #165.
+
 ## Use Cases
 
 | Scenario               | Description                                         |

--- a/doc/pam-modes.md
+++ b/doc/pam-modes.md
@@ -54,6 +54,12 @@ session    required     pam_unix.so
 
 ## Mode C: SSH Key with LLNG Authorization
 
+> **Offline behaviour differs from the certificate modes.** Because Mode C does
+> not set `AuthorizedKeysFile none`, `sshd` still honours `~/.ssh/authorized_keys`
+> — which makes a personal key an _opt-in_ fallback during a portal outage, with
+> trade-offs worth knowing before relying on it. See
+> [what works offline](offline-mode.md#what-works-offline-and-what-needs-the-portal).
+
 **SSH key authentication only, but LLNG checks if user is authorized.**
 
 Users authenticate with SSH keys. PAM doesn't handle password authentication,

--- a/doc/security/02-ssh-connection.md
+++ b/doc/security/02-ssh-connection.md
@@ -1614,10 +1614,27 @@ cache_rate_limit_max_lockout_sec = 3600 # 1 heure max
 En mode offline, le cache mémorise les autorisations mais **pas** les tokens sudo. Une panne LLNG signifie :
 
 - Les connexions SSH des utilisateurs précédemment autorisés continuent (cache hit)
-- Les escalades sudo sont **refusées** (token LLNG non vérifiable)
+- Les escalades sudo **qui traversent la phase `auth`** sont refusées (token LLNG
+  non vérifiable)
 - Les nouveaux utilisateurs ne peuvent pas se connecter
 
 Ce comportement est intentionnel : l'escalade de privilèges requiert toujours une vérification en ligne.
+
+> **Nuance vérifiée au code.** Toute escalade ne traverse pas la phase `auth`.
+> `sudo` conserve son propre timestamp (`timestamp_timeout`, 15 min par défaut,
+> réarmé à chaque usage) et, tant qu'il est valide, n'appelle pas
+> `pam_authenticate()` : aucun token n'est demandé. La phase `account`, elle,
+> s'exécute bien, et pendant une panne elle répond depuis le cache
+> d'autorisation (`sudo_allowed` y est stocké). Un utilisateur SSO qui vient
+> d'élever ses privilèges continue donc de le faire pendant la panne ; le refus
+> tombe à la première élévation après expiration du timestamp.
+>
+> L'option `--enable-sudo-fresh-otp` (`timestamp_timeout=0`, cf. #178) supprime
+> cette fenêtre : chaque élévation traverse la phase `auth`, donc **aucun sudo
+> SSO n'est possible pendant une panne** sur un hôte ainsi configuré. C'est le
+> compromis assumé — une preuve fraîche par élévation, payée en disponibilité —
+> et c'est une hypothèse dont R-S17 dépend. Les comptes de service de secours
+> ne sont affectés dans aucun des deux cas.
 
 ---
 

--- a/doc/security/02-ssh-connection.md
+++ b/doc/security/02-ssh-connection.md
@@ -1099,6 +1099,30 @@ L'enregistrement de session est streamé vers le puits root `ob-record-sink` (so
 
 > **Automatisation bootstrap :** Le paquet `open-bastion-linagora` prend en charge la configuration initiale de `securetty`, du compte de service `linagora` et de `PermitRootLogin no`. Ces éléments n'ont pas besoin d'être configurés manuellement sur les déploiements utilisant ce paquet.
 
+> **Écarter la « clé SSH personnelle sur le bastion » comme filet.** Une réponse
+> souvent proposée à ce risque est de laisser chaque administrateur déposer une
+> clé SSH personnelle dans son `~/.ssh` sur le bastion, pour continuer à
+> rebondir vers les backends pendant une panne du portail. **En Mode E, c'est
+> impossible par construction** : les backends posent `AuthorizedKeysFile none`
+> et n'acceptent qu'un certificat signé par la CA dont le key-id porte
+> `bastion=<id>;user=<u>` — `sshd` refuse une clé nue avant même que PAM ne soit
+> consulté, et `ob-ssh` ne peut pas aider puisque l'émission du certificat
+> éphémère exige le portail.
+>
+> Hors Mode E (modes « clé »), c'est techniquement possible et cela déplace le
+> risque plutôt qu'il ne le réduit : une clé privée de longue durée réside alors
+> sur le bastion, non bornée par un TTL de certificat et non révocable par le
+> portail, et le rebond cesse d'être vouché (`allowed_bastions`, épinglage
+> d'adresse source et TTL de voucher ne s'y appliquent plus). La traçabilité,
+> elle, survit : un `ssh` lancé **depuis une session de bastion enregistrée** est
+> capturé par l'enregistreur de pty — ce qui ne l'est pas, c'est un
+> `ssh -J bastion` depuis le poste de travail (canal `direct-tcpip`, cf. R-S25).
+>
+> Les deux mesures conçues pour cette panne restent le **compte de service de
+> secours** et l'**accès console hors-bande** ci-dessus. Voir
+> [doc/offline-mode.md](../offline-mode.md) pour la matrice complète de ce qui
+> fonctionne hors ligne.
+
 **Remédiation infrastructure :**
 
 - LLNG en haute disponibilité (réduit la probabilité de panne prolongée)


### PR DESCRIPTION
Refs #165 — the documentation deliverables. The lab validation the issue lists as an acceptance criterion is **not** done, and the text says so rather than implying it was.

## The matrix

`doc/offline-mode.md` described the mechanism but never said what an operator can actually do while the portal is unreachable. It now carries a ten-row matrix derived from the code and from the generated `sshd` configurations:

| | |
| --- | --- |
| **Keeps working** | user resolution (NSS cache), SSH login with a valid certificate, service-account `sudo` (rights read locally) |
| **Does not** | `sudo` for SSO users — the cache is an *authorization* cache, not an authentication one, and the `auth` phase needs a fresh one-time token — `ob-ssh`/`ob-scp`/`ob-sftp`, enrolment, revocation |

Plus the two cache TTLs that must be sized together (NSS `cache_ttl`, and the PAM authorization cache whose TTL comes from LLNG's `pamAccessOfflineTtl`), and one build detail worth knowing: the authorization cache is **looked up** in every build but only **written** with `INSTALL_DESKTOP=ON` — which the Debian package is, so this bites only people compiling the module themselves.

## The personal-key question, answered from the code

**Mode E: no, by construction.** The backends set `AuthorizedKeysFile none` and accept only certificates whose key-id carries `bastion=<id>;user=<u>`. `sshd` refuses a plain key before PAM is consulted, and `ob-ssh` cannot help because minting its ephemeral certificate requires the portal.

**Key modes: yes**, under four stated conditions — those setups do not write `AuthorizedKeysFile none` (only `configure_max_security_sshd` does), so `~/.ssh/authorized_keys` is still honoured, and the backend's PAM `account` phase falls back to its authorization cache.

And what it costs, said plainly: a long-lived private key on the bastion, neither bounded by a certificate TTL nor revocable through the portal, and a hop that is no longer vouched — `allowed_bastions`, source-address pinning and the voucher TTL all stop applying to it.

## One correction to the issue's analysis

The issue expects the bastion's role as the mandatory audited point of passage to be eroded. **The audit trail survives.** A plain `ssh` run *from inside a recorded bastion session* is captured by the pty recorder like any other command. What is not recorded is a `ssh -J bastion …` ProxyJump from a workstation, which uses a `direct-tcpip` channel the `ForceCommand` never sees — the same gap as R-S25. The distinction matters for anyone weighing the trade-off.

## Also

- **EBIOS R-S17** (total lockout) gains the same note in French, since the personal key is often proposed as its remedy — with a pointer back to the two mechanisms actually designed for the outage case (break-glass service account, out-of-band console).
- **`doc/pam-modes.md`** points Mode C at the matrix, because Mode C is where the offline behaviour differs.

## Left open

Deliverable 1 of the issue — validating the key-mode path end to end in a lab (portal up, then portal down, cached authorization still admitting the key) — is not done. The key-mode rows are labelled as analysis, not as a tested procedure, and the issue stays open for that.

https://claude.ai/code/session_011q88Fs4nFuUs7JMvmgbBTN