### PR TITLE
docs(changelog): the offline matrix has eleven rows, not ten

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -624,7 +624,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `nss_openbastion.conf`, by the NSS module.
 
 - **`doc/offline-mode.md` now states what actually works during a portal outage
-  (#165).** A ten-row matrix derived from the code and the generated `sshd`
+  (#165).** An eleven-row matrix derived from the code and the generated `sshd`
   configurations: what keeps working (user resolution, certificate logins,
   service-account `sudo`), what does not (`ob-ssh`/`ob-scp`/`ob-sftp`, enrolment,
   revocation), and the two cache TTLs that must be sized together.


### PR DESCRIPTION
The `[Unreleased]` entry for #165 says the offline matrix is a **ten-row** matrix. It was, when #165 shipped it. #242 split the `sudo` for an SSO user row into two — the very next paragraph of the same entry describes that split — so the table now has eleven data rows (`doc/offline-mode.md:39-49`).

One word. The count is now what the file actually contains.

https://claude.ai/code/session_011q88Fs4nFuUs7JMvmgbBTN