### PR TITLE
test(offline-cache): the flake is a one-second TTL boundary in the test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -523,6 +523,43 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   of children actually started, so a fork failure no longer prints a second,
   false layer of failure on top of the one already reported.
 
+- **The `test_offline_cache` flake is a one-second TTL boundary in the test
+  itself, and it is now out of reach (#244).** `test_expiration` stored an entry
+  with `ttl = 1` and asserted that an immediate `verify()` succeeds. `store()`
+  writes `expires_at = now + ttl` (`src/offline_cache.c:618`, taken after the
+  Argon2id hash) and `verify()` expires on `now >= expires_at`
+  (`src/offline_cache.c:1180`, taken after the read and decrypt), both at
+  one-second granularity — so the assertion fails whenever a wall-clock second
+  boundary falls between those two `time()` calls. The window between them holds
+  the AES-GCM encrypt, the write and an **`fsync()`**, which is why it depends on
+  the filesystem: measured by interposing `time()`, 0.09 ms with the cache on
+  tmpfs and 1.7 ms on ext4 — 0.01% against 0.2% per run, ~19x, and higher again
+  on a CI runner with a contended disk. The RPM job runs the cache on the
+  container's disk-backed `/tmp`, which is where the flake was seen.
+
+  #244 recorded this candidate as ruled out, on 60 local runs with no failure.
+  That test had no power: at the tmpfs rate those 60 runs were expected to
+  produce 0.005 failures, so observing none says nothing. Forcing a boundary
+  into the window makes the outcome deterministic — 5/5 `Entry expired` at
+  `ttl = 1`, 0/5 at `ttl = 2`.
+
+  The test now uses `ttl = 2` with `sleep(3)`: the immediate verify would need a
+  full second to elapse inside the window to lose the race, and expiry is still
+  guaranteed. The assertions are unchanged; only their margin is. `test_cleanup`
+  keeps `ttl = 1` and says why — it asserts nothing before the entry expires, so
+  it sits on the safe side of the same boundary. No production code changes:
+  one-second granularity on an entry whose real TTL is hours is not a defect.
+
+  Two of the issue's other candidates are closed by construction rather than
+  argued about. The test directory was `/tmp/test_offline_cache_<pid>` with
+  `EEXIST` accepted, so a directory left behind by a run that died before
+  cleanup — a killed CI job — was silently reused with its entries in place, and
+  in a container PIDs restart low and repeat; it is now `mkdtemp()`. The two
+  `mkdir()` calls for per-test subdirectories, and the `offline_cache_store()`
+  calls in `test_cleanup`, `test_stats` and `test_invalidate_all`, ignored their
+  return values, so a failure there surfaced several assertions later as
+  something else; each is now checked and named.
+
 - **`ob-builder` artefacts that carry the client secret are no longer
   world-readable, and no longer commit themselves (#203).** With
   `client_secret_mode: embedded` the OIDC client secret is written in clear text

--- a/tests/test_offline_cache.c
+++ b/tests/test_offline_cache.c
@@ -52,12 +52,20 @@ static int has_machine_id(void)
 
 static char test_dir[256];
 
-/* Create test directory */
+/*
+ * Create test directory.
+ *
+ * mkdtemp, not "/tmp/test_offline_cache_<pid>": that name is reproducible, and
+ * mkdir's EEXIST was accepted, so a directory left behind by an earlier run
+ * that died before cleanup_test_dir() -- a killed CI job, a crash -- would be
+ * silently reused with its entries in place. In a container PIDs restart low
+ * and repeat, which makes the collision likely rather than theoretical (#244).
+ */
 static int setup_test_dir(void)
 {
-    snprintf(test_dir, sizeof(test_dir), "/tmp/test_offline_cache_%d", getpid());
-    if (mkdir(test_dir, 0700) != 0 && errno != EEXIST) {
-        perror("mkdir");
+    snprintf(test_dir, sizeof(test_dir), "/tmp/test_offline_cache_XXXXXX");
+    if (mkdtemp(test_dir) == NULL) {
+        perror("mkdtemp");
         return -1;
     }
     return 0;
@@ -225,8 +233,24 @@ static int test_expiration(void)
     offline_cache_t *cache = offline_cache_init(test_dir, NULL);
     ASSERT(cache != NULL);
 
-    /* Store with 1 second TTL */
-    int ret = offline_cache_store(cache, "expiring_user", "pass", 1,
+    /*
+     * 2 seconds, not 1. store() writes expires_at = now + ttl and verify()
+     * expires on now >= expires_at, both at one-second granularity, so with
+     * ttl = 1 the immediate verify below fails whenever a wall-clock second
+     * boundary happens to fall between store()'s time() (offline_cache.c:618,
+     * taken after the Argon2id hash) and verify()'s (offline_cache.c:1180,
+     * taken after the read and decrypt). That window is short but real: it
+     * contains the AES-GCM encrypt, the write and an fsync(), measured at
+     * 0.09 ms with the cache on tmpfs and 1.7 ms on ext4, i.e. a 0.01% to
+     * 0.2% chance per run -- and higher on a CI runner with a contended
+     * disk, which is where the flake of #244 was seen.
+     *
+     * With ttl = 2 the immediate verify would need a full second to elapse
+     * inside that window, so it cannot lose the race, and sleep(3) still
+     * guarantees expiry. The assertions are unchanged; only their timing
+     * margin is.
+     */
+    int ret = offline_cache_store(cache, "expiring_user", "pass", 2,
                                   NULL, NULL, NULL);
     ASSERT(ret == OFFLINE_CACHE_OK);
 
@@ -235,7 +259,7 @@ static int test_expiration(void)
     ASSERT(ret == OFFLINE_CACHE_OK);
 
     /* Wait for expiration */
-    sleep(2);
+    sleep(3);
 
     /* Verify after expiration should fail */
     ret = offline_cache_verify(cache, "expiring_user", "pass", NULL);
@@ -339,17 +363,25 @@ static int test_cleanup(void)
 {
     if (!has_machine_id()) return 2;
 
-    /* Create fresh test directory for this test to avoid interference */
+    /* Create fresh test directory for this test to avoid interference.
+     * test_dir is already unique (mkdtemp), so a fixed name is enough. */
     char fresh_dir[256];
-    snprintf(fresh_dir, sizeof(fresh_dir), "%s/cleanup_%d", test_dir, getpid());
-    mkdir(fresh_dir, 0700);
+    snprintf(fresh_dir, sizeof(fresh_dir), "%s/cleanup", test_dir);
+    if (mkdir(fresh_dir, 0700) != 0 && errno != EEXIST) {
+        printf("(mkdir %s: %s) ", fresh_dir, strerror(errno));
+        return 0;
+    }
 
     offline_cache_t *cache = offline_cache_init(fresh_dir, NULL);
     ASSERT(cache != NULL);
 
-    /* Store some entries */
-    offline_cache_store(cache, "cleanup_user1", "pass", 1, NULL, NULL, NULL);  /* Expires in 1s */
-    offline_cache_store(cache, "cleanup_user2", "pass", 3600, NULL, NULL, NULL);  /* Active */
+    /* Store some entries. ttl = 1 is safe here, unlike in test_expiration:
+     * nothing is asserted about user1 before it expires, and the assertions
+     * below are all on the expired side of the boundary. */
+    int r1 = offline_cache_store(cache, "cleanup_user1", "pass", 1, NULL, NULL, NULL);
+    ASSERT(r1 == OFFLINE_CACHE_OK);
+    int r2 = offline_cache_store(cache, "cleanup_user2", "pass", 3600, NULL, NULL, NULL);
+    ASSERT(r2 == OFFLINE_CACHE_OK);
 
     /* Wait for first to expire */
     sleep(2);
@@ -374,9 +406,9 @@ static int test_stats(void)
     ASSERT(cache != NULL);
 
     /* Store some entries */
-    offline_cache_store(cache, "stats_user1", "pass", 3600, NULL, NULL, NULL);
-    offline_cache_store(cache, "stats_user2", "pass", 3600, NULL, NULL, NULL);
-    offline_cache_store(cache, "stats_user3", "pass", 3600, NULL, NULL, NULL);
+    ASSERT(offline_cache_store(cache, "stats_user1", "pass", 3600, NULL, NULL, NULL) == OFFLINE_CACHE_OK);
+    ASSERT(offline_cache_store(cache, "stats_user2", "pass", 3600, NULL, NULL, NULL) == OFFLINE_CACHE_OK);
+    ASSERT(offline_cache_store(cache, "stats_user3", "pass", 3600, NULL, NULL, NULL) == OFFLINE_CACHE_OK);
 
     int total = 0, active = 0, locked = 0;
     int ret = offline_cache_stats(cache, &total, &active, &locked);
@@ -396,15 +428,20 @@ static int test_invalidate_all(void)
 
     /* Create fresh test directory for this test */
     char fresh_dir[256];
-    snprintf(fresh_dir, sizeof(fresh_dir), "%s/fresh_%d", test_dir, getpid());
-    mkdir(fresh_dir, 0700);
+    snprintf(fresh_dir, sizeof(fresh_dir), "%s/fresh", test_dir);
+    if (mkdir(fresh_dir, 0700) != 0 && errno != EEXIST) {
+        printf("(mkdir %s: %s) ", fresh_dir, strerror(errno));
+        return 0;
+    }
 
     offline_cache_t *cache = offline_cache_init(fresh_dir, NULL);
     ASSERT(cache != NULL);
 
     /* Store some entries */
-    offline_cache_store(cache, "all_user1", "pass", 3600, NULL, NULL, NULL);
-    offline_cache_store(cache, "all_user2", "pass", 3600, NULL, NULL, NULL);
+    int r1 = offline_cache_store(cache, "all_user1", "pass", 3600, NULL, NULL, NULL);
+    ASSERT(r1 == OFFLINE_CACHE_OK);
+    int r2 = offline_cache_store(cache, "all_user2", "pass", 3600, NULL, NULL, NULL);
+    ASSERT(r2 == OFFLINE_CACHE_OK);
 
     /* Verify entries exist */
     ASSERT(offline_cache_has_entry(cache, "all_user1"));


### PR DESCRIPTION
Closes the diagnosis part of #244, and removes the mechanism.

## What the flake is

`test_expiration` stored an entry with `ttl = 1` and asserted that an **immediate** `verify()` succeeds:

- `store()` writes `expires_at = now + ttl` — `src/offline_cache.c:618`, `now` taken *after* the Argon2id hash;
- `verify()` expires on `now >= expires_at` — `src/offline_cache.c:1180`, `now` taken *after* the read and decrypt.

Both at one-second granularity. So the assertion fails whenever a wall-clock second boundary falls between those two `time()` calls.

What sits in that window is the AES-GCM encrypt, the write and an **`fsync()`** — which makes its size a property of the filesystem, not of the CPU. Measured by interposing `time()` and reading the two call sites directly:

| cache on | window | P(failure) per run |
| --- | --- | --- |
| tmpfs | 0.09 ms | 0.009 % |
| ext4 | 1.68 ms | 0.17 % |

~19×, and higher again on a CI runner with a contended disk. The RPM job runs the cache on the container's disk-backed `/tmp` — which is where the flake was seen, and not where the local investigation ran.

## The "ruled out" in #244 was under-powered

The issue records this candidate as investigated and ruled out, on *"0 failures of the immediate verify in 60 runs"*. Those runs were on tmpfs, where the rate is 0.009 % — they were expected to produce **0.005 failures**. Observing none is consistent with the mechanism being exactly what it is. 60 runs could only have excluded a rate above ~5 %.

Forcing a second boundary into the window instead of waiting for one makes the outcome deterministic:

```
ttl=1: 5/5 EXPIRED
ttl=2: 0/5 EXPIRED
```

I cannot prove this *was* the observed failure — the log that would name the sub-test is gone, which is the whole point of #244. What I can say is that it is a demonstrated failure mode of that sub-test, at a rate consistent with "once, then green on a re-run", and it is now impossible.

## The change

- `test_expiration` uses `ttl = 2` with `sleep(3)`. The immediate verify would need a full second to elapse inside the window to lose the race; expiry after the sleep is still guaranteed. The assertions are unchanged, only their margin.
- `test_cleanup` keeps `ttl = 1` and now says why: it asserts nothing before the entry expires, so it sits on the safe side of the same boundary. That comment is there so the lesson is not copied in the wrong direction.
- **No production change.** One-second granularity on an entry whose real TTL is hours is not a defect.

Two of the issue's remaining candidates are closed by construction rather than argued about:

- The test directory was `/tmp/test_offline_cache_<pid>` with `EEXIST` accepted — a directory left by a run that died before `cleanup_test_dir()` (a killed CI job) was silently reused with its entries in place, and in a container PIDs restart low and repeat. Now `mkdtemp()`.
- The two per-test `mkdir()` calls, and the `offline_cache_store()` calls in `test_cleanup`, `test_stats` and `test_invalidate_all`, ignored their return values, so a failure there surfaced several assertions later as something else. Each is now checked and named — the remaining half of #244's item 2.

## Verified

- `test_offline_cache` 17/17, full `ctest` 21/21 on `INSTALL_DESKTOP=ON`.
- No `/tmp/test_offline_cache_*` left behind after the run.
- The before/after is the deterministic probe above, not "it passed once".

https://claude.ai/code/session_011q88Fs4nFuUs7JMvmgbBTN