### PR TITLE
feat(pam): sign every /pam/ call, so pamAccessRequestSigningMode=required becomes deployable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,71 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- **Every caller of a `/pam/` endpoint now signs its request, so
+  `pamAccessRequestSigningMode = required` is deployable (#247).** The portal
+  verifies `X-Signature-256` in `_checkCaller`, ahead of any caller identity,
+  which covers all six endpoints. Two were signed: `/pam/verify` and
+  `/pam/authorize`. The other four now are — `/pam/heartbeat` in the PAM module
+  and in `ob-heartbeat`, `/pam/bastion-cert` in `ob-cert-daemon`, `/pam/whoami`
+  in `ob-bastion-id`, `/pam/userinfo` in `ob-session-monitor`, plus the
+  post-enrolment `/pam/authorize` check in `ob-enroll`. `/pam/heartbeat` was the
+  dangerous one: it is how every enrolled host renews its access token, so
+  turning `required` on used to break nothing at the moment of the change and
+  take the whole fleet down hours later, together, as the tokens still in hand
+  expired.
+
+  Two call sites were missing from the issue's own inventory and are signed
+  here as well: `ob-enroll` verifies the enrolment through `/pam/authorize`, and
+  `/pam/userinfo` — recorded as having no caller — is called by
+  `ob-session-monitor`, whose loop terminates sessions for users the portal no
+  longer knows. `tests/test_ob_request_signing.sh` now walks the tree for
+  anything that builds a `/pam/` URL and fails if it is not in the signed
+  inventory, so a new caller cannot creep back in unsigned.
+
+- **The shell callers sign through `ob-sign-request`, not through
+  `openssl dgst -hmac` (#247).** OpenSSL takes the HMAC key as a command-line
+  argument and offers no form that reads it from a file or the environment.
+  `/proc/<pid>/cmdline` is world-readable, and `ob-heartbeat` runs from a timer
+  every few minutes, forever, on a host whose purpose is to give other people a
+  shell: signing that way would have published the fleet-wide signing secret to
+  anyone who polls, and a secret an attacker can read is a signature an attacker
+  can forge. The new helper reads the secret from the root-only configuration
+  file, takes the body on stdin — `ob-heartbeat`'s body carries the host's
+  `refresh_token`, which would otherwise have been an argument too — and prints
+  only the MAC and its inputs. `scripts/ob-sign-lib.sh` is the shared shell
+  interface; `man ob-sign-request` carries the rationale.
+
+- **`request_signing_secret` is no longer truncated at a `#` (#247).**
+  `config.c` exempts opaque secrets from inline-comment stripping, on the
+  grounds that `#` is an ordinary character in a generated secret. The other
+  three readers in the tree did not: `ob-cert-daemon`'s `load_ini` cut the line
+  at the first `#` anywhere, and the `awk`/`sed` readers in `ob-heartbeat` and
+  `ob-bastion-id` cut at any `#` in the value. A secret containing one would
+  have produced a valid-looking signature over the wrong key — reported by the
+  portal as `bad_signature`, which looks like a portal problem and is not. There
+  is now one reader for this key outside `config.c` (`ob_sign_load_secret`), and
+  `tests/test_ob_sign.c` pins its rule.
+
 ### Changed
+
+- **Request signing has one implementation and a test that pins it to the
+  portal's (#247).** The nonce and HMAC generators move out of `ob_client.c`
+  into `src/ob_sign.c`, shared by the PAM module, `ob-cert-daemon` and
+  `ob-sign-request`. `tests/test_ob_sign.c` checks the wire format against
+  digests produced by `Digest::SHA`'s `hmac_sha256_hex` — the function
+  `PamAccess.pm` itself calls — rather than recomputing them with OpenSSL, which
+  would only have proved the file agrees with itself. It covers the trailing
+  separator a bodyless request signs (`/pam/whoami` is one), and that the
+  timestamp, nonce, method and path are each inside the MAC. Signing had no
+  coverage at all before.
+
+  A signing failure now fails the request instead of falling back to an unsigned
+  one: the portal reads a partially signed request as malformed in every mode,
+  and an operator who configured a secret asked for the call to be signed. The
+  exception is `ob-session-monitor`, where "we could not ask" must not become
+  "the user is gone" — its loop terminates sessions.
 
 - **`ob-bastion-id` now asks `POST /pam/whoami`, not the removed
   `/pam/bastion-token` (#246).** Upstream `lemonldap-ng-plugins` 0.6.0 removes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,11 +22,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   take the whole fleet down hours later, together, as the tokens still in hand
   expired.
 
-  Two call sites were missing from the issue's own inventory and are signed
-  here as well: `ob-enroll` verifies the enrolment through `/pam/authorize`, and
-  `/pam/userinfo` — recorded as having no caller — is called by
-  `ob-session-monitor`, whose loop terminates sessions for users the portal no
-  longer knows. `tests/test_ob_request_signing.sh` now walks the tree for
+  Three call sites were missing from the issue's own inventory and are signed
+  here as well: the `ob-heartbeat` timer, which is the shell half of
+  `/pam/heartbeat` and the one that runs forever; `ob-enroll`, which verifies
+  the enrolment through `/pam/authorize`; and `/pam/userinfo` — recorded as
+  having no caller — which is called by `ob-session-monitor`, whose loop
+  terminates sessions for users the portal no longer knows. `tests/test_ob_request_signing.sh` now walks the tree for
   anything that builds a `/pam/` URL and fails if it is not in the signed
   inventory, so a new caller cannot creep back in unsigned.
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,7 @@ endif()
 set(PAM_MODULE_SOURCES
     src/pam_openbastion.c
     src/ob_client.c
+    src/ob_sign.c
     src/config.c
     src/audit_log.c
     src/rate_limiter.c
@@ -196,6 +197,13 @@ install(FILES ${CMAKE_SOURCE_DIR}/scripts/ob-cert-lib.sh
     DESTINATION lib/open-bastion
 )
 
+# Shared request-signing library, sourced by every shell caller of a /pam/
+# endpoint (ob-heartbeat, ob-bastion-id, ob-enroll, ob-session-monitor). Same
+# fixed path as ob-cert-lib.sh, which the scripts look up.
+install(FILES ${CMAKE_SOURCE_DIR}/scripts/ob-sign-lib.sh
+    DESTINATION lib/open-bastion
+)
+
 # Bastion-to-backend SSH / SCP / SFTP connectors (cert vouching).
 install(PROGRAMS ${CMAKE_SOURCE_DIR}/scripts/ob-ssh
     DESTINATION ${CMAKE_INSTALL_BINDIR}
@@ -222,11 +230,17 @@ install(FILES ${CMAKE_SOURCE_DIR}/scripts/ssh-proxy.conf.example
 # socket-activated) holds the server token and derives the certificate's user
 # from the connection's SO_PEERCRED; ob-cert-request is the unprivileged client
 # that ob-ssh / ob-scp / ob-sftp invoke — no sudo, no setuid.
-add_executable(ob-cert-daemon src/ob-cert-daemon.c src/ob_cert_proto.c)
+add_executable(ob-cert-daemon
+    src/ob-cert-daemon.c
+    src/ob_cert_proto.c
+    src/ob_sign.c
+    src/str_utils.c
+)
 target_include_directories(ob-cert-daemon PRIVATE
     ${CMAKE_SOURCE_DIR}/include
     ${CURL_INCLUDE_DIRS}
     ${JSON_C_INCLUDE_DIRS}
+    ${OPENSSL_INCLUDE_DIRS}
 )
 target_compile_options(ob-cert-daemon PRIVATE
     -Wall -Wextra -Werror
@@ -238,6 +252,7 @@ target_compile_options(ob-cert-daemon PRIVATE
 target_link_libraries(ob-cert-daemon
     ${CURL_LIBRARIES}
     ${JSON_C_LIBRARIES}
+    ${OPENSSL_LIBRARIES}
 )
 target_link_options(ob-cert-daemon PRIVATE
     -Wl,-z,relro
@@ -265,6 +280,39 @@ target_link_options(ob-cert-request PRIVATE
 )
 install(TARGETS ob-cert-request
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+)
+
+# Request signing for the shell callers of /pam/* (ob-heartbeat, ob-bastion-id).
+# Root-only: it reads request_signing_secret out of openbastion.conf, which is
+# why the secret never has to appear in an `openssl dgst -hmac` command line
+# where /proc/<pid>/cmdline would publish it. See src/ob-sign-request.c.
+add_executable(ob-sign-request
+    src/ob-sign-request.c
+    src/ob_sign.c
+    src/str_utils.c
+)
+target_include_directories(ob-sign-request PRIVATE
+    ${CMAKE_SOURCE_DIR}/include
+    ${OPENSSL_INCLUDE_DIRS}
+)
+target_compile_options(ob-sign-request PRIVATE
+    -Wall -Wextra -Werror
+    -D_GNU_SOURCE
+    -fstack-protector-strong
+    -Wformat -Wformat-security
+    $<$<CONFIG:Release>:-flto>
+)
+target_link_libraries(ob-sign-request
+    ${OPENSSL_LIBRARIES}
+)
+target_link_options(ob-sign-request PRIVATE
+    -Wl,-z,relro
+    -Wl,-z,now
+    -Wl,-z,noexecstack
+    $<$<CONFIG:Release>:-flto>
+)
+install(TARGETS ob-sign-request
+    RUNTIME DESTINATION ${CMAKE_INSTALL_SBINDIR}
 )
 
 # Tamper-evident session recording: socket-activated root sink + unprivileged
@@ -387,6 +435,7 @@ install(FILES
     ${CMAKE_SOURCE_DIR}/man/ob-session-prune.8
     ${CMAKE_SOURCE_DIR}/man/ob-cert-daemon.8
     ${CMAKE_SOURCE_DIR}/man/ob-record-sink.8
+    ${CMAKE_SOURCE_DIR}/man/ob-sign-request.8
     DESTINATION ${CMAKE_INSTALL_MANDIR}/man8
 )
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -66,6 +66,22 @@ signature, defeating the replay window.
 
 This provides defense-in-depth against request tampering, even if TLS is somehow compromised.
 
+Every caller signs: the PAM module (`/pam/verify`, `/pam/authorize`,
+`/pam/heartbeat`), `ob-cert-daemon` (`/pam/bastion-cert`), and the shell
+callers `ob-heartbeat`, `ob-bastion-id`, `ob-enroll` and `ob-session-monitor`.
+The portal refuses an unsigned call on any of them once
+`pamAccessRequestSigningMode` is `required`, so leaving one out is a fleet-wide
+outage waiting on a token to expire, not a missing hardening measure.
+
+The shell callers sign through `ob-sign-request`, never through
+`openssl dgst -sha256 -hmac "$secret"`. OpenSSL takes the HMAC key on the
+command line and offers no form that reads it from a file or the environment;
+`/proc/<pid>/cmdline` is world-readable, so on a bastion that one-liner would
+hand the fleet-wide signing secret to every user with a shell, every few
+minutes, forever. `ob-sign-request` reads the secret from the root-only
+configuration file and takes the body on stdin — which matters too, since
+`ob-heartbeat` signs a body carrying the host's `refresh_token`.
+
 ## Server Authentication
 
 The PAM module authenticates to the LLNG server using:

--- a/UPGRADE-NOTES.md
+++ b/UPGRADE-NOTES.md
@@ -65,19 +65,40 @@ the mechanism and the file layout are in
 security rationale in
 [doc/security/02-ssh-connection.md](doc/security/02-ssh-connection.md).
 
-### 3. Do not set `pamAccessRequestSigningMode = required`
+### 3. `pamAccessRequestSigningMode = required` — deployable, in this order
 
-Plugin 0.6.0 verifies `X-Signature-256` / `X-Timestamp` / `X-Nonce`. The wire
-format matches what this client already produces, so **`optional` is safe to
-deploy today** — it refuses a _bad_ signature on the two endpoints that consume
-credentials.
+Plugin 0.6.0 verifies `X-Signature-256` / `X-Timestamp` / `X-Nonce` on all six
+`/pam/*` endpoints, in `_checkCaller`, before it looks at any caller identity.
+Every caller on this side now signs — the PAM module
+(`/pam/verify`, `/pam/authorize`, `/pam/heartbeat`), `ob-cert-daemon`
+(`/pam/bastion-cert`), `ob-heartbeat`, `ob-bastion-id` (`/pam/whoami`),
+`ob-enroll` and `ob-session-monitor` (`/pam/userinfo`). Before
+[#247](https://github.com/linagora/open-bastion/issues/247) only the first two
+were signed, and `required` would have taken the fleet down.
 
-`required` is not deployable: the gate covers all six `/pam/*` endpoints and
-the client signs two of them (`/pam/verify`, `/pam/authorize`).
-`/pam/heartbeat` is unsigned and is how every enrolled host renews its access
-token, so `required` breaks nothing at the moment you flip it and takes the
-whole fleet down hours later, together, when the tokens still in hand expire.
-Tracked in [#247](https://github.com/linagora/open-bastion/issues/247).
+There is one portal-wide `pamAccessRequestSigningSecret`, and it is the
+`request_signing_secret` every host already has in `openbastion.conf`: the
+signature proves fleet membership, it does not identify a caller. So the
+rollout is about **which hosts hold the secret**, and the order is not
+negotiable:
+
+1. Upgrade the hosts to a release carrying #247. A host that has not been
+   upgraded still signs nothing on four of the six endpoints.
+2. Set `pamAccessRequestSigningMode = optional` on the portal. This already
+   refuses a _bad_ signature; it only waives the requirement to sign.
+3. Roll `request_signing_secret` out to every host.
+4. Confirm every host signs — a host that is silently unsigned is invisible
+   until step 5, and then it is not.
+5. Only then set `required`.
+
+Doing it in any other order is how this breaks badly rather than visibly.
+`/pam/heartbeat` is how every enrolled host renews its access token: switching
+to `required` while one host is unsigned breaks nothing at the moment you flip
+it, and takes that host down hours later, when the access token it still holds
+expires. On a whole fleet, together.
+
+The signature is defence in depth on top of TLS, not a substitute for it. Do
+not relax `verify_ssl` because of it.
 
 ### 4. Check your PAM scope spelling
 

--- a/config/openbastion.conf.example
+++ b/config/openbastion.conf.example
@@ -86,6 +86,28 @@ verify_ssl = true
 # ca_cert = /etc/ssl/certs/my-ca.pem
 
 # ==============================================================================
+# Request signing (optional, defence in depth on top of TLS)
+# ==============================================================================
+
+# Shared HMAC-SHA256 secret for the X-Signature-256 header. It must match the
+# portal's pamAccessRequestSigningSecret -- there is one value for the whole
+# fleet: the signature proves fleet membership, it does not identify a caller.
+#
+# Every /pam/ call this host makes is signed when this is set: the PAM module,
+# ob-cert-daemon, ob-heartbeat, ob-bastion-id, ob-enroll and ob-session-monitor.
+# The portal's pamAccessRequestSigningMode decides what it does with them:
+# off (ignore), optional (a signature must verify, but may be absent) or
+# required (mandatory). Roll this secret out to EVERY host and confirm they all
+# sign before switching the portal to `required`: /pam/heartbeat is how a host
+# renews its access token, so an unsigned host does not fail at the moment of
+# the change, it fails hours later when its current token expires. See
+# UPGRADE-NOTES.md.
+#
+# The value is taken literally, '#' included. Generate one with, for example,
+# `openssl rand -hex 32`.
+# request_signing_secret =
+
+# ==============================================================================
 # Authorization Cache Settings (offline mode)
 # ==============================================================================
 

--- a/debian/open-bastion.install
+++ b/debian/open-bastion.install
@@ -21,12 +21,14 @@ usr/sbin/ob-bastion-setup
 usr/sbin/ob-standalone-setup
 usr/sbin/ob-backend-setup
 usr/sbin/ob-cert-daemon
+usr/sbin/ob-sign-request
 usr/sbin/ob-record-sink
 usr/sbin/ob-cache-admin
 usr/sbin/ob-session-prune
 
 # Shared cert-vouching library (sourced by ob-ssh / ob-scp / ob-sftp)
 usr/lib/open-bastion/ob-cert-lib.sh
+usr/lib/open-bastion/ob-sign-lib.sh
 
 # User scripts
 usr/bin/ob-ssh-cert
@@ -54,6 +56,7 @@ usr/share/man/man8/ob-session-recorder.8
 usr/share/man/man8/ob-session-prune.8
 usr/share/man/man8/ob-cert-daemon.8
 usr/share/man/man8/ob-record-sink.8
+usr/share/man/man8/ob-sign-request.8
 
 # Audit trace templates (deployed by `ob-bastion-setup --enable-audit-trace`)
 usr/share/open-bastion/audit/rules.d/open-bastion.rules

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -95,7 +95,33 @@ rate_limit_max_lockout = 3600
 # notify_enabled = true
 # notify_url = https://alerts.example.com/webhook
 # notify_secret = your-hmac-secret
+
+# Request signing (optional); must match the portal's
+# pamAccessRequestSigningSecret. One value for the whole fleet.
+# request_signing_secret = 0123456789abcdef...
 ```
+
+### Request signing
+
+`request_signing_secret` turns on the `X-Signature-256` / `X-Timestamp` /
+`X-Nonce` headers on every `/pam/` call this host makes — the PAM module,
+`ob-cert-daemon`, `ob-heartbeat`, `ob-bastion-id`, `ob-enroll` and
+`ob-session-monitor`. It is defence in depth on top of TLS, not a substitute
+for it.
+
+The secret is fleet-wide and must equal the portal's
+`pamAccessRequestSigningSecret`: the signature proves that the caller is part of
+the fleet, it does not identify which host is calling. The portal's
+`pamAccessRequestSigningMode` decides what happens to an unsigned call — `off`,
+`optional` (a signature that is present must verify) or `required`.
+
+Do not switch the portal to `required` before every host holds the secret and
+has been seen signing. `/pam/heartbeat` is how a host renews its access token,
+so an unsigned host does not fail when you flip the switch: it fails hours
+later, when the token it is still holding expires. The full order is in
+[UPGRADE-NOTES.md](../UPGRADE-NOTES.md).
+
+The value is taken literally, `#` included (see the comment rules above).
 
 For detailed documentation on specific features:
 

--- a/doc/security/00-architecture.md
+++ b/doc/security/00-architecture.md
@@ -101,6 +101,23 @@ valide, ce qui annulerait la protection anti-rejeu.
 
 Cela fournit une défense en profondeur contre la falsification de requêtes, même si TLS est d'une façon ou d'une autre compromis.
 
+Tous les appelants signent : le module PAM (`/pam/verify`, `/pam/authorize`,
+`/pam/heartbeat`), `ob-cert-daemon` (`/pam/bastion-cert`), et les appelants
+shell `ob-heartbeat`, `ob-bastion-id`, `ob-enroll` et `ob-session-monitor`. Dès
+que `pamAccessRequestSigningMode` vaut `required`, le portail refuse tout appel
+non signé sur chacun d'eux : en oublier un n'est pas un durcissement manquant,
+c'est une panne de flotte en attente de l'expiration d'un token.
+
+Les appelants shell signent via `ob-sign-request`, jamais via
+`openssl dgst -sha256 -hmac "$secret"`. OpenSSL prend la clé HMAC sur la ligne
+de commande et n'offre aucune forme qui la lise depuis un fichier ou
+l'environnement ; `/proc/<pid>/cmdline` est lisible par tous, donc sur un
+bastion ce one-liner livrerait le secret de signature de toute la flotte à
+chaque utilisateur ayant un shell, toutes les quelques minutes, indéfiniment.
+`ob-sign-request` lit le secret dans le fichier de configuration réservé à root
+et prend le corps sur stdin — ce qui compte aussi, puisque `ob-heartbeat` signe
+un corps contenant le `refresh_token` de l'hôte.
+
 ## Authentification du Serveur
 
 Le module PAM s'authentifie auprès du serveur LLNG en utilisant :

--- a/include/ob_sign.h
+++ b/include/ob_sign.h
@@ -1,0 +1,85 @@
+/*
+ * ob_sign.h - Request signing for the LLNG /pam/<endpoint> endpoints
+ *
+ * Copyright (C) 2025 Linagora
+ * License: AGPL-3.0
+ *
+ * One wire format, one implementation. The portal (LLNG pam-access,
+ * _checkRequestSignature) verifies every /pam/<endpoint> call the same way, so every
+ * caller on this side has to produce the bytes the same way:
+ *
+ *     message = <timestamp>.<nonce>.<method>.<path>.<body>
+ *     HMAC-SHA256, key = the raw bytes of request_signing_secret
+ *
+ *     X-Timestamp      unix seconds, decimal
+ *     X-Nonce          <unix_ms>-<uuid-v4>
+ *     X-Signature-256  sha256=<64 lowercase hex>
+ *
+ * The four '.' separators are always present: a bodyless request signs the
+ * empty string, so the message still ends with a trailing '.'. <path> carries
+ * no scheme, host or query string, and <body> is the raw bytes as sent.
+ *
+ * This header exists because the fleet has four callers of /pam/<endpoint> -- the PAM
+ * module, ob-cert-daemon, and the two shell scripts through ob-sign-request --
+ * and pamAccessRequestSigningMode=required refuses any of them that gets it
+ * wrong (#247).
+ */
+
+#ifndef OB_SIGN_H
+#define OB_SIGN_H
+
+#include <stddef.h>
+
+/* Sizes a caller must provide. Both include the terminating NUL. */
+#define OB_SIGN_NONCE_SIZE     80   /* <unix_ms>-<uuid-v4>, generously */
+#define OB_SIGN_SIGNATURE_SIZE 65   /* 64 hex characters */
+
+/*
+ * Generate a nonce: "<timestamp_ms>-<uuid v4>", from OpenSSL's CSPRNG.
+ *
+ * The nonce is the portal's replay key, and it is covered by the signature
+ * (see ob_sign_compute) so it cannot be swapped for a fresh value on a
+ * replayed request. `size` must be at least OB_SIGN_NONCE_SIZE; on a smaller
+ * buffer the nonce is set empty, which ob_sign_compute then refuses.
+ */
+void ob_sign_generate_nonce(char *nonce, size_t size);
+
+/*
+ * HMAC-SHA256 over <timestamp>.<nonce>.<method>.<path>.<body>, hex-encoded.
+ *
+ * `body` may be NULL, which signs the empty string. `sig_size` must be at
+ * least OB_SIGN_SIGNATURE_SIZE. On any failure `signature` is set empty --
+ * callers must treat an empty signature as "do not send", never as "send
+ * unsigned", since the portal reads a partially signed request as malformed.
+ */
+void ob_sign_compute(const char *secret,
+                     long timestamp,
+                     const char *nonce,
+                     const char *method,
+                     const char *path,
+                     const char *body,
+                     char *signature,
+                     size_t sig_size);
+
+/*
+ * Read request_signing_secret out of an openbastion.conf-style file.
+ *
+ * Returns 0 and sets *secret (caller frees) when the key is present and
+ * non-empty, 1 when the file parsed but has no secret in it -- signing is
+ * optional, so that is not an error -- and -1 when the file cannot be read or
+ * is not adequately protected.
+ *
+ * Protection means: a regular file, not a symlink, unreadable by group and
+ * other, owned by root or by the effective uid. The euid clause is what makes
+ * this testable without root; in production every caller runs as root, where
+ * it says exactly "owned by root" (see check_file_permissions_fd in config.c,
+ * which is the same policy for the PAM module's own load).
+ *
+ * The value is taken the way config.c takes an opaque secret: everything after
+ * the first '=', trimmed, minus at most one layer of matching quotes, and no
+ * inline-comment stripping -- '#' is an ordinary character in a generated
+ * secret (see key_holds_opaque_secret in config.c).
+ */
+int ob_sign_load_secret(const char *conf_path, char **secret);
+
+#endif /* OB_SIGN_H */

--- a/man/ob-sign-request.8
+++ b/man/ob-sign-request.8
@@ -1,0 +1,132 @@
+.TH OB-SIGN-REQUEST 8 "September 2026" "open-bastion" "System Administration"
+.SH NAME
+ob-sign-request \- compute the request-signing headers for a /pam/ portal call
+.SH SYNOPSIS
+.B ob-sign-request
+.BI \-\-method " METHOD"
+.BI \-\-path " PATH"
+.RB [ \-\-config
+.IR FILE ]
+.PP
+The request body is read from standard input. The headers are written to
+standard output, one per line.
+.SH DESCRIPTION
+LemonLDAP::NG's
+.B pam-access
+plugin verifies a signature on every
+.I /pam/
+endpoint it serves, and its
+.B pamAccessRequestSigningMode
+=
+.B required
+refuses any call that carries none.
+.B ob-sign-request
+is how the shell callers on this side sign:
+.BR ob-heartbeat (8),
+.BR ob-bastion-id (1),
+.BR ob-enroll (8)
+and
+.BR ob-session-monitor .
+They reach it through
+.IR /usr/lib/open-bastion/ob-sign-lib.sh ,
+not directly.
+.PP
+It reads
+.B request_signing_secret
+from
+.IR /etc/open-bastion/openbastion.conf ,
+computes
+.PP
+.RS
+HMAC\-SHA256(\fIsecret\fR, "\fItimestamp\fR.\fInonce\fR.\fIMETHOD\fR.\fIPATH\fR.\fIbody\fR")
+.RE
+.PP
+and prints
+.BR X-Timestamp ,
+.B X-Nonce
+and
+.BR X-Signature-256 .
+The C clients (the PAM module and
+.BR ob-cert-daemon (8))
+compute the same bytes in-process; this program exists only because the shell
+callers cannot.
+.SH WHY NOT OPENSSL
+.B openssl dgst -sha256 -hmac
+takes the HMAC key as a command-line argument, and OpenSSL offers no form that
+reads it from a file or the environment.
+.I /proc/<pid>/cmdline
+is world-readable, so on a bastion \(em a host whose purpose is to give other
+people a shell \(em signing that way would publish the fleet-wide signing
+secret to any user who polls, every time
+.BR ob-heartbeat (8)
+runs. A secret an attacker can read is a signature an attacker can forge.
+.PP
+Here the secret is read from a root-only file and never leaves the process, and
+the body arrives on standard input \(em which matters as well:
+.BR ob-heartbeat (8)
+signs a body containing this host's
+.BR refresh_token .
+What reaches standard output is the MAC and its inputs, which are about to go
+over the wire anyway.
+.SH OPTIONS
+.TP
+.BI \-\-method " METHOD"
+The HTTP method, uppercase. The portal signs
+.BR uc(method) ,
+so anything else is refused rather than signed into a mismatch.
+.TP
+.BI \-\-path " PATH"
+The absolute request path, with no scheme, host or query string \(em the portal
+strips the query before hashing, so a path containing one is refused.
+.TP
+.BI \-\-config " FILE"
+The configuration file to read the secret from. Defaults to
+.IR /etc/open-bastion/openbastion.conf .
+It must be a regular file, unreadable by group and other, and owned by root.
+.SH EXIT STATUS
+.TP
+.B 0
+The three headers were printed.
+.TP
+.B 3
+No
+.B request_signing_secret
+is configured. Nothing is printed, and the caller should send the request
+unsigned: the portal's
+.B off
+and
+.B optional
+modes accept it. This is the state to be in while the secret is rolled out.
+.TP
+.B 1
+Anything else, with a diagnostic on standard error.
+.SH FILES
+.TP
+.I /etc/open-bastion/openbastion.conf
+Read for
+.BR request_signing_secret .
+The value is taken literally: a
+.RB \(oq # \(cq
+in it is part of the secret, not the start of a comment.
+.SH SECURITY
+The signature is defence in depth on top of TLS, not a substitute for it. Do
+not relax
+.B verify_ssl
+because of it.
+.PP
+Turning the portal to
+.B required
+before every host holds the secret takes the fleet down \(em not at the moment
+of the change, but hours later, as access tokens expire and
+.I /pam/heartbeat
+stops renewing them. The order is:
+.BR optional ,
+roll the secret out, confirm every host signs, then
+.BR required .
+.SH SEE ALSO
+.BR ob-heartbeat (8),
+.BR ob-bastion-id (1),
+.BR ob-enroll (8),
+.BR ob-cert-daemon (8)
+.SH AUTHOR
+Linagora

--- a/rpm/open-bastion.spec
+++ b/rpm/open-bastion.spec
@@ -97,6 +97,7 @@ mkdir -p %{buildroot}/var/cache/nss_llng/byname
 %{_sbindir}/ob-standalone-setup
 %{_sbindir}/ob-backend-setup
 %{_sbindir}/ob-cert-daemon
+%{_sbindir}/ob-sign-request
 %{_sbindir}/ob-record-sink
 %{_sbindir}/ob-cache-admin
 %{_sbindir}/ob-session-prune
@@ -109,6 +110,7 @@ mkdir -p %{buildroot}/var/cache/nss_llng/byname
 %{_bindir}/ob-bastion-id
 %dir %{_prefix}/lib/open-bastion
 %{_prefix}/lib/open-bastion/ob-cert-lib.sh
+%{_prefix}/lib/open-bastion/ob-sign-lib.sh
 # 0711 = traversable but NOT listable. Entries under these directories are 0644
 # so an unprivileged getpwnam()/getpwuid() can read its own record (an NSS
 # module runs inside the calling process), but no local account can readdir()
@@ -147,6 +149,7 @@ mkdir -p %{buildroot}/var/cache/nss_llng/byname
 %{_mandir}/man8/ob-session-prune.8*
 %{_mandir}/man8/ob-cert-daemon.8*
 %{_mandir}/man8/ob-record-sink.8*
+%{_mandir}/man8/ob-sign-request.8*
 %{_mandir}/man1/ob-ssh.1*
 %{_mandir}/man1/ob-scp.1*
 %{_mandir}/man1/ob-sftp.1*

--- a/scripts/ob-bastion-id
+++ b/scripts/ob-bastion-id
@@ -127,6 +127,22 @@ base64url_decode() {
     printf '%s' "$s" | base64 -d 2>/dev/null
 }
 
+# Request signing for the /pam/ calls below (#247). The HMAC is computed by
+# ob-sign-request so the signing secret never reaches a command line; the
+# rationale and the interface are in scripts/ob-sign-lib.sh.
+_OB_SIGN_LIB="${OB_SIGN_LIB:-/usr/lib/open-bastion/ob-sign-lib.sh}"
+if [ ! -r "$_OB_SIGN_LIB" ]; then
+    _OB_SIGN_LIB="$(dirname "$(readlink -f "$0")")/ob-sign-lib.sh"
+fi
+if [ -r "$_OB_SIGN_LIB" ]; then
+    # shellcheck source=scripts/ob-sign-lib.sh
+    . "$_OB_SIGN_LIB"
+else
+    SIGN_HEADERS=()
+    ob_sign_request() { SIGN_HEADERS=(); OB_SIGN_ERROR=""; \
+        OB_SIGN_NOTE="ob-sign-lib.sh not found; sending $2 unsigned"; return 0; }
+fi
+
 # POST a JSON body to a /pam/* endpoint. Sets HTTP_STATUS and BODY; returns
 # non-zero only when the request never got an answer at all (DNS, TLS, timeout).
 #
@@ -138,10 +154,19 @@ base64url_decode() {
 # on, so the status has to survive.
 pam_post() {
     local path="$1" payload="$2" response
+    OB_SIGN_CONFIG="$CONFIG_FILE"
+    if ! ob_sign_request POST "$path" "$payload"; then
+        log_error "$OB_SIGN_ERROR"
+        return 1
+    fi
+    if [ -n "${OB_SIGN_NOTE:-}" ]; then
+        log_info "$OB_SIGN_NOTE"
+    fi
     response=$(curl "${CURL_OPTS[@]}" \
         -X POST \
         -H "Authorization: Bearer $SERVER_TOKEN" \
         -H "Content-Type: application/json" \
+        "${SIGN_HEADERS[@]}" \
         -w '\n__HTTP_STATUS__:%{http_code}' \
         -d "$payload" \
         "${PORTAL_URL}${path}" 2>&1) || {

--- a/scripts/ob-bastion-id
+++ b/scripts/ob-bastion-id
@@ -139,6 +139,8 @@ if [ -r "$_OB_SIGN_LIB" ]; then
     . "$_OB_SIGN_LIB"
 else
     SIGN_HEADERS=()
+    # OB_SIGN_NOTE is read by the call sites below, not here.
+    # shellcheck disable=SC2034
     ob_sign_request() { SIGN_HEADERS=(); OB_SIGN_ERROR=""; \
         OB_SIGN_NOTE="ob-sign-lib.sh not found; sending $2 unsigned"; return 0; }
 fi
@@ -154,6 +156,8 @@ fi
 # on, so the status has to survive.
 pam_post() {
     local path="$1" payload="$2" response
+    # Read by ob-sign-lib.sh, which shellcheck cannot follow across the `.`.
+    # shellcheck disable=SC2034
     OB_SIGN_CONFIG="$CONFIG_FILE"
     if ! ob_sign_request POST "$path" "$payload"; then
         log_error "$OB_SIGN_ERROR"

--- a/scripts/ob-enroll
+++ b/scripts/ob-enroll
@@ -24,6 +24,22 @@ SCOPE="pam:server offline_access"
 POLL_INTERVAL=5
 TIMEOUT=300
 
+# Request signing for the /pam/ call below (#247). The HMAC is computed by
+# ob-sign-request so the signing secret never reaches a command line; the
+# rationale and the interface are in scripts/ob-sign-lib.sh.
+_OB_SIGN_LIB="${OB_SIGN_LIB:-/usr/lib/open-bastion/ob-sign-lib.sh}"
+if [ ! -r "$_OB_SIGN_LIB" ]; then
+    _OB_SIGN_LIB="$(dirname "$(readlink -f "$0")")/ob-sign-lib.sh"
+fi
+if [ -r "$_OB_SIGN_LIB" ]; then
+    # shellcheck source=scripts/ob-sign-lib.sh
+    . "$_OB_SIGN_LIB"
+else
+    SIGN_HEADERS=()
+    ob_sign_request() { SIGN_HEADERS=(); OB_SIGN_ERROR=""; \
+        OB_SIGN_NOTE="ob-sign-lib.sh not found; sending $2 unsigned"; return 0; }
+fi
+
 # Colors for output (disabled if not a terminal)
 if [ -t 1 ]; then
     RED='\033[0;31m'
@@ -659,12 +675,23 @@ verify_enrollment() {
         --arg server_group "$SERVER_GROUP" \
         '{user: $user, host: $host, server_group: $server_group}')
 
-    # Try to call /pam/authorize to verify the token works
+    # Try to call /pam/authorize to verify the token works.
+    #
+    # Signed like every other /pam/ call (#247). This one is easy to forget --
+    # it is a post-enrolment sanity check, not part of the running system --
+    # and forgetting it would make every enrolment report "could not verify"
+    # the day the portal is switched to pamAccessRequestSigningMode=required.
     build_curl_opts
+    OB_SIGN_CONFIG="$CONFIG_FILE"
+    if ! ob_sign_request POST /pam/authorize "$json_payload"; then
+        log_warn "$OB_SIGN_ERROR"
+        return 0
+    fi
     response=$(curl "${CURL_OPTS[@]}" \
         -X POST "${PORTAL_URL}/pam/authorize" \
         -H "Authorization: Bearer ${ACCESS_TOKEN}" \
         -H "Content-Type: application/json" \
+        "${SIGN_HEADERS[@]}" \
         -d "$json_payload" 2>&1) || {
         log_warn "Could not verify enrollment (this may be normal)"
         return 0

--- a/scripts/ob-enroll
+++ b/scripts/ob-enroll
@@ -36,6 +36,8 @@ if [ -r "$_OB_SIGN_LIB" ]; then
     . "$_OB_SIGN_LIB"
 else
     SIGN_HEADERS=()
+    # OB_SIGN_NOTE is read by the call sites below, not here.
+    # shellcheck disable=SC2034
     ob_sign_request() { SIGN_HEADERS=(); OB_SIGN_ERROR=""; \
         OB_SIGN_NOTE="ob-sign-lib.sh not found; sending $2 unsigned"; return 0; }
 fi
@@ -682,6 +684,8 @@ verify_enrollment() {
     # and forgetting it would make every enrolment report "could not verify"
     # the day the portal is switched to pamAccessRequestSigningMode=required.
     build_curl_opts
+    # Read by ob-sign-lib.sh, which shellcheck cannot follow across the `.`.
+    # shellcheck disable=SC2034
     OB_SIGN_CONFIG="$CONFIG_FILE"
     if ! ob_sign_request POST /pam/authorize "$json_payload"; then
         log_warn "$OB_SIGN_ERROR"

--- a/scripts/ob-heartbeat
+++ b/scripts/ob-heartbeat
@@ -276,6 +276,8 @@ else
     # A broken install must not stop a bastion from renewing its token: send
     # the request unsigned, which a portal in `required` refuses visibly.
     SIGN_HEADERS=()
+    # OB_SIGN_NOTE is read by the call sites below, not here.
+    # shellcheck disable=SC2034
     ob_sign_request() { SIGN_HEADERS=(); OB_SIGN_ERROR=""; \
         OB_SIGN_NOTE="ob-sign-lib.sh not found; sending $2 unsigned"; return 0; }
 fi
@@ -347,6 +349,8 @@ send_heartbeat() {
 
     # Sign before sending, or do not send: an unsigned /pam/heartbeat is
     # exactly what made pamAccessRequestSigningMode=required undeployable.
+    # Read by ob-sign-lib.sh, which shellcheck cannot follow across the `.`.
+    # shellcheck disable=SC2034
     OB_SIGN_CONFIG="$CONFIG_FILE"
     if ! ob_sign_request POST /pam/heartbeat "$payload"; then
         log_error "$OB_SIGN_ERROR"

--- a/scripts/ob-heartbeat
+++ b/scripts/ob-heartbeat
@@ -262,6 +262,24 @@ build_curl_opts() {
     fi
 }
 
+# Request signing for the /pam/ call below (#247). The HMAC is computed by
+# ob-sign-request so the signing secret never reaches a command line; the
+# rationale and the interface are in scripts/ob-sign-lib.sh.
+_OB_SIGN_LIB="${OB_SIGN_LIB:-/usr/lib/open-bastion/ob-sign-lib.sh}"
+if [ ! -r "$_OB_SIGN_LIB" ]; then
+    _OB_SIGN_LIB="$(dirname "$(readlink -f "$0")")/ob-sign-lib.sh"
+fi
+if [ -r "$_OB_SIGN_LIB" ]; then
+    # shellcheck source=scripts/ob-sign-lib.sh
+    . "$_OB_SIGN_LIB"
+else
+    # A broken install must not stop a bastion from renewing its token: send
+    # the request unsigned, which a portal in `required` refuses visibly.
+    SIGN_HEADERS=()
+    ob_sign_request() { SIGN_HEADERS=(); OB_SIGN_ERROR=""; \
+        OB_SIGN_NOTE="ob-sign-lib.sh not found; sending $2 unsigned"; return 0; }
+fi
+
 # Persist a freshly minted access token into the JSON token file, keeping the
 # existing refresh_token / enrolled_at. Atomic replace, root-only perms.
 update_access_token() {
@@ -327,10 +345,21 @@ send_heartbeat() {
 
     build_curl_opts
 
+    # Sign before sending, or do not send: an unsigned /pam/heartbeat is
+    # exactly what made pamAccessRequestSigningMode=required undeployable.
+    OB_SIGN_CONFIG="$CONFIG_FILE"
+    if ! ob_sign_request POST /pam/heartbeat "$payload"; then
+        log_error "$OB_SIGN_ERROR"
+        exit 1
+    fi
+    if [ -n "${OB_SIGN_NOTE:-}" ]; then
+        log_debug "$OB_SIGN_NOTE"
+    fi
+
     local response
     local http_code
 
-    response=$(curl "${CURL_OPTS[@]}" -w "\n%{http_code}" \
+    response=$(curl "${CURL_OPTS[@]}" "${SIGN_HEADERS[@]}" -w "\n%{http_code}" \
         -X POST "${PORTAL_URL}/pam/heartbeat" \
         -H "Content-Type: application/json" \
         -d "$payload" 2>&1) || {

--- a/scripts/ob-session-monitor
+++ b/scripts/ob-session-monitor
@@ -11,6 +11,22 @@ set -euo pipefail
 
 # Configuration defaults
 CONFIG_FILE="${OB_CONFIG_FILE:-/etc/open-bastion/openbastion.conf}"
+
+# Request signing for the /pam/ call below (#247). The HMAC is computed by
+# ob-sign-request so the signing secret never reaches a command line; the
+# rationale and the interface are in scripts/ob-sign-lib.sh.
+_OB_SIGN_LIB="${OB_SIGN_LIB:-/usr/lib/open-bastion/ob-sign-lib.sh}"
+if [ ! -r "$_OB_SIGN_LIB" ]; then
+    _OB_SIGN_LIB="$(dirname "$(readlink -f "$0")")/ob-sign-lib.sh"
+fi
+if [ -r "$_OB_SIGN_LIB" ]; then
+    # shellcheck source=scripts/ob-sign-lib.sh
+    . "$_OB_SIGN_LIB"
+else
+    SIGN_HEADERS=()
+    ob_sign_request() { SIGN_HEADERS=(); OB_SIGN_ERROR=""; \
+        OB_SIGN_NOTE="ob-sign-lib.sh not found; sending $2 unsigned"; return 0; }
+fi
 MARKER_DIR="/run/open-bastion/offline_sessions"
 FORCE_ONLINE_FILE="/etc/open-bastion/force_online"
 FORCE_ONLINE_LOCK="/run/open-bastion/force_online.lock"
@@ -128,10 +144,24 @@ check_user_valid() {
     local payload
     payload=$(jq -n --arg u "$user" '{user: $u}')
 
+    # Signed like every other /pam/ call (#247). #247 recorded /pam/userinfo as
+    # having no caller; this is the caller. Left unsigned, session monitoring
+    # would start reporting every user as gone the day the portal is switched
+    # to pamAccessRequestSigningMode=required -- and this loop prunes sessions.
+    OB_SIGN_CONFIG="$CONFIG_FILE"
+    if ! ob_sign_request POST /pam/userinfo "$payload"; then
+        # "we could not ask" is not "the user is gone": a non-zero return here
+        # reaches the caller as an invalid user and terminates live sessions.
+        # A local signing misconfiguration must not do that.
+        log_warn "$OB_SIGN_ERROR -- treating $user as still valid"
+        return 0
+    fi
+
     local response
     response=$(curl -sf -m 10 \
         -H "Content-Type: application/json" \
         ${auth_header:+-H "$auth_header"} \
+        "${SIGN_HEADERS[@]}" \
         -d "$payload" \
         "${PORTAL_URL}/pam/userinfo" 2>/dev/null) || return 1
 

--- a/scripts/ob-session-monitor
+++ b/scripts/ob-session-monitor
@@ -24,6 +24,8 @@ if [ -r "$_OB_SIGN_LIB" ]; then
     . "$_OB_SIGN_LIB"
 else
     SIGN_HEADERS=()
+    # OB_SIGN_NOTE is read by the call sites below, not here.
+    # shellcheck disable=SC2034
     ob_sign_request() { SIGN_HEADERS=(); OB_SIGN_ERROR=""; \
         OB_SIGN_NOTE="ob-sign-lib.sh not found; sending $2 unsigned"; return 0; }
 fi
@@ -148,6 +150,8 @@ check_user_valid() {
     # having no caller; this is the caller. Left unsigned, session monitoring
     # would start reporting every user as gone the day the portal is switched
     # to pamAccessRequestSigningMode=required -- and this loop prunes sessions.
+    # Read by ob-sign-lib.sh, which shellcheck cannot follow across the `.`.
+    # shellcheck disable=SC2034
     OB_SIGN_CONFIG="$CONFIG_FILE"
     if ! ob_sign_request POST /pam/userinfo "$payload"; then
         # "we could not ask" is not "the user is gone": a non-zero return here

--- a/scripts/ob-sign-lib.sh
+++ b/scripts/ob-sign-lib.sh
@@ -34,6 +34,12 @@
 #
 # The caller sets OB_SIGN_CONFIG to the openbastion.conf to read; it defaults
 # to the standard path.
+#
+# SIGN_HEADERS, OB_SIGN_ERROR and OB_SIGN_NOTE are set here and read by the
+# sourcing script. CI runs shellcheck one file at a time, without -x, so it
+# cannot follow the `.` that pulls this file in: every assignment to them
+# looks dead from inside this file alone.
+# shellcheck disable=SC2034
 
 SIGN_HEADERS=()
 OB_SIGN_ERROR=""

--- a/scripts/ob-sign-lib.sh
+++ b/scripts/ob-sign-lib.sh
@@ -1,0 +1,77 @@
+# shellcheck shell=bash
+#
+# ob-sign-lib.sh - request signing for the shell callers of /pam/ endpoints
+#
+# Copyright (C) 2025 Linagora
+# License: AGPL-3.0
+#
+# Sourced by ob-heartbeat, ob-bastion-id, ob-enroll and ob-session-monitor.
+# The portal verifies X-Signature-256 on every /pam/ endpoint it serves, and
+# pamAccessRequestSigningMode=required refuses anything unsigned (#247).
+#
+# The HMAC is computed by ob-sign-request, never here. The obvious one-liner,
+#
+#     openssl dgst -sha256 -hmac "$secret"
+#
+# is not usable: openssl takes the key on the command line and offers no form
+# that reads it from a file or the environment, /proc/<pid>/cmdline is
+# world-readable, and these scripts run as root on a host whose whole purpose
+# is to give other people a shell -- ob-heartbeat every few minutes, forever.
+# It would publish the fleet-wide signing secret to anyone who polls, and a
+# secret an attacker can read is a signature an attacker can forge. Some of the
+# signed bodies also carry credentials of their own (ob-heartbeat's carries
+# this host's refresh_token), which is why the body goes to the helper on
+# stdin rather than in an argument.
+#
+# Interface:
+#
+#   ob_sign_request METHOD PATH BODY
+#       Sets SIGN_HEADERS to the curl arguments to add ("-H" "X-...": possibly
+#       none). Returns 0 when the request may be sent, non-zero when signing
+#       was configured and failed -- sending unsigned then would be a silent
+#       downgrade, and the portal refuses a partially signed request in every
+#       mode. On failure the reason is in OB_SIGN_ERROR.
+#
+# The caller sets OB_SIGN_CONFIG to the openbastion.conf to read; it defaults
+# to the standard path.
+
+SIGN_HEADERS=()
+OB_SIGN_ERROR=""
+OB_SIGN_NOTE=""
+
+ob_sign_request() {
+    local method="$1" path="$2" payload="$3"
+    local helper out line rc=0
+    local conf="${OB_SIGN_CONFIG:-/etc/open-bastion/openbastion.conf}"
+
+    SIGN_HEADERS=()
+    OB_SIGN_ERROR=""
+    OB_SIGN_NOTE=""
+
+    helper="${OB_SIGN_REQUEST:-}"
+    if [ -z "$helper" ]; then
+        helper=$(command -v ob-sign-request 2>/dev/null) \
+            || helper="/usr/sbin/ob-sign-request"
+    fi
+    if [ ! -x "$helper" ]; then
+        # Running from a source checkout, where the binary is in the build
+        # tree and not on PATH. Not a reason to stop: unsigned is what these
+        # scripts did before #247, and a portal in `required` refuses it
+        # visibly rather than silently.
+        OB_SIGN_NOTE="ob-sign-request not found; sending $path unsigned"
+        return 0
+    fi
+
+    out=$(printf '%s' "$payload" \
+        | "$helper" --method "$method" --path "$path" --config "$conf" 2>&1) || rc=$?
+    case "$rc" in
+        0) ;;
+        3) return 0 ;;   # no request_signing_secret configured: nothing to sign
+        *) OB_SIGN_ERROR="cannot sign $path: $out"; return 1 ;;
+    esac
+
+    while IFS= read -r line; do
+        [ -n "$line" ] && SIGN_HEADERS+=("-H" "$line")
+    done <<< "$out"
+    return 0
+}

--- a/src/ob-cert-daemon.c
+++ b/src/ob-cert-daemon.c
@@ -42,12 +42,14 @@
 #include <sys/socket.h>
 #include <sys/stat.h>
 #include <sys/time.h>
+#include <time.h>
 #include <unistd.h>
 
 #include <curl/curl.h>
 #include <json-c/json.h>
 
 #include "ob_cert_proto.h"
+#include "ob_sign.h"
 
 #define OB_CONFIG "/etc/open-bastion/openbastion.conf"
 #define PROXY_CONFIG "/etc/open-bastion/ssh-proxy.conf"
@@ -171,11 +173,15 @@ struct ob_cfg {
     char token_file[1024];
     int verify_ssl;
     long timeout;
+    char *signing_secret;   /* request_signing_secret, or NULL: see ob_sign.h */
 };
 
-/* openbastion.conf: ini-style "key = value". We only need portal_url/verify_ssl.
- * Root-only by construction (every installer writes it 0600 root) and read the
- * same way by the PAM module, so require the strict discipline here too. */
+/* openbastion.conf: ini-style "key = value". We need portal_url/verify_ssl, and
+ * the signing secret -- which is read by ob_sign_load_secret rather than here,
+ * because '#' is an ordinary character in a generated secret and the comment
+ * stripping below would silently truncate it (#247). Root-only by construction
+ * (every installer writes it 0600 root) and read the same way by the PAM
+ * module, so require the strict discipline here too. */
 static void load_ini(struct ob_cfg *cfg)
 {
     FILE *f = open_checked(OB_CONFIG, 1);
@@ -402,6 +408,20 @@ int main(void)
     snprintf(cfg.token_file, sizeof(cfg.token_file), "%s", DEFAULT_TOKEN_FILE);
     load_ini(&cfg);
     load_proxy(&cfg);
+    /*
+     * Optional: rc > 0 means this deployment does not sign, which is normal.
+     * rc < 0 means openbastion.conf could not be read at all -- and that is
+     * not necessarily fatal here, because portal_url may have come from
+     * ssh-proxy.conf instead. Say so in the journal rather than send an
+     * unsigned request silently: against a portal in
+     * pamAccessRequestSigningMode=required it would be refused, and the
+     * refusal would point at the portal instead of at this file.
+     */
+    if (ob_sign_load_secret(OB_CONFIG, &cfg.signing_secret) < 0) {
+        cfg.signing_secret = NULL;
+        fail("cannot read " OB_CONFIG " for request_signing_secret; "
+             "sending this request unsigned");
+    }
 
     /* strip a trailing slash from portal_url */
     size_t ul = strlen(cfg.portal_url);
@@ -447,6 +467,39 @@ int main(void)
     struct curl_slist *hdrs = NULL;
     hdrs = curl_slist_append(hdrs, "Content-Type: application/json");
     hdrs = curl_slist_append(hdrs, authhdr);
+
+    /* Sign the call when the deployment has a secret (#247). Signing is what
+     * makes pamAccessRequestSigningMode=required deployable; an unsigned
+     * /pam/bastion-cert under `required` means every ob-ssh hop stops working.
+     * Failing here rather than sending unsigned: the portal reads a partially
+     * signed request as malformed, and an operator who set the secret asked
+     * for this call to be signed. */
+    if (cfg.signing_secret) {
+        long sts = (long)time(NULL);
+        char snonce[OB_SIGN_NONCE_SIZE];
+        char ssig[OB_SIGN_SIGNATURE_SIZE];
+        ob_sign_generate_nonce(snonce, sizeof(snonce));
+        ob_sign_compute(cfg.signing_secret, sts, snonce, "POST",
+                        "/pam/bastion-cert", payload, ssig, sizeof(ssig));
+        if (!*snonce || !*ssig) {
+            fail("cannot sign the /pam/bastion-cert request");
+            curl_slist_free_all(hdrs);
+            curl_easy_cleanup(curl);
+            curl_global_cleanup();
+            memset(authhdr, 0, sizeof(authhdr));
+            memset(token, 0, strlen(token));
+            free(token);
+            json_object_put(body);
+            return 1;
+        }
+        char h[160];
+        snprintf(h, sizeof(h), "X-Timestamp: %ld", sts);
+        hdrs = curl_slist_append(hdrs, h);
+        snprintf(h, sizeof(h), "X-Nonce: %s", snonce);
+        hdrs = curl_slist_append(hdrs, h);
+        snprintf(h, sizeof(h), "X-Signature-256: sha256=%s", ssig);
+        hdrs = curl_slist_append(hdrs, h);
+    }
 
     curl_easy_setopt(curl, CURLOPT_URL, url);
     curl_easy_setopt(curl, CURLOPT_POST, 1L);

--- a/src/ob-sign-request.c
+++ b/src/ob-sign-request.c
@@ -1,0 +1,226 @@
+/*
+ * ob-sign-request - print the request-signing headers for a /pam/<endpoint> call
+ *
+ * Copyright (C) 2025 Linagora
+ * License: AGPL-3.0
+ *
+ * ob-heartbeat and ob-bastion-id are shell, and the portal's
+ * pamAccessRequestSigningMode=required covers the endpoints they call (#247).
+ * This is how they sign.
+ *
+ * Why a helper and not `openssl dgst -sha256 -hmac "$secret"`:
+ *
+ *   - openssl takes the HMAC key on the command line, and there is no form
+ *     that takes it from a file or the environment. argv is world-readable
+ *     through /proc/<pid>/cmdline, so every ob-heartbeat run -- every few
+ *     minutes, forever, on a host whose whole purpose is to give other people
+ *     a shell -- would publish the fleet-wide signing secret to anyone who
+ *     polls. A secret an attacker can read is a signature an attacker can
+ *     forge, which is the entire value of the mechanism.
+ *   - the body is signed too, and ob-heartbeat's body carries the host's
+ *     refresh_token. Passing it as an argument would leak that as well.
+ *
+ * So the secret never leaves this process (it is read here, from a file only
+ * root can read), the body arrives on stdin, and what goes to stdout is the
+ * MAC and its inputs -- which are safe to publish, and are about to be sent
+ * over the wire anyway.
+ *
+ * Usage:
+ *     ob-sign-request --method POST --path /pam/heartbeat [--config FILE] < body
+ *
+ * Exit status:
+ *     0  the three headers were printed, one per line
+ *     3  no request_signing_secret is configured: nothing to sign, and the
+ *        caller should send the request unsigned (the portal's 'off' and
+ *        'optional' modes accept it; 'required' will refuse it, which is the
+ *        deployment's own choice to make)
+ *     1  anything else, with a diagnostic on stderr
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <ctype.h>
+#include <time.h>
+#include <unistd.h>
+#include <errno.h>
+
+#include "ob_sign.h"
+
+#define DEFAULT_CONFIG "/etc/open-bastion/openbastion.conf"
+
+/* Bounded so a runaway producer on stdin cannot exhaust memory here. The
+ * largest real body is ob-heartbeat's session report, orders below this. */
+#define MAX_BODY (1024 * 1024)
+
+static void usage(FILE *out)
+{
+    fprintf(out,
+        "Usage: ob-sign-request --method METHOD --path /pam/... [--config FILE]\n"
+        "\n"
+        "Reads the request body on stdin and prints the X-Timestamp, X-Nonce\n"
+        "and X-Signature-256 headers for it, one per line.\n"
+        "Exit 3 means no request_signing_secret is configured.\n");
+}
+
+/*
+ * The portal signs uc($req->method) and the path with its query string
+ * removed. Refusing anything else here keeps a caller from producing a
+ * signature the portal can only compute differently -- which would fail as
+ * 'bad_signature', indistinguishable from a wrong secret.
+ */
+static int valid_method(const char *m)
+{
+    if (!m || !*m || strlen(m) > 16) return 0;
+    for (const char *p = m; *p; p++) {
+        if (*p < 'A' || *p > 'Z') return 0;
+    }
+    return 1;
+}
+
+static int valid_path(const char *p)
+{
+    if (!p || *p != '/' || strlen(p) > 512) return 0;
+    for (const char *q = p; *q; q++) {
+        if (*q == '?' || *q == '#') return 0;          /* not part of the signed path */
+        if (isspace((unsigned char)*q)) return 0;
+        if ((unsigned char)*q < 32 || (unsigned char)*q == 127) return 0;
+    }
+    return 1;
+}
+
+/* Read all of stdin. Returns NULL on error, sets *len on success. */
+static char *read_body(size_t *len)
+{
+    size_t cap = 8192, used = 0;
+    char *buf = malloc(cap);
+    if (!buf) return NULL;
+
+    for (;;) {
+        if (used == cap) {
+            if (cap >= MAX_BODY) {
+                fprintf(stderr, "ob-sign-request: body larger than %d bytes\n", MAX_BODY);
+                free(buf);
+                return NULL;
+            }
+            size_t ncap = cap * 2;
+            if (ncap > MAX_BODY) ncap = MAX_BODY;
+            char *nbuf = realloc(buf, ncap);
+            if (!nbuf) {
+                free(buf);
+                return NULL;
+            }
+            buf = nbuf;
+            cap = ncap;
+        }
+        size_t n = fread(buf + used, 1, cap - used, stdin);
+        used += n;
+        if (n == 0) {
+            if (ferror(stdin)) {
+                fprintf(stderr, "ob-sign-request: read error on stdin: %s\n",
+                        strerror(errno));
+                free(buf);
+                return NULL;
+            }
+            break;  /* EOF */
+        }
+    }
+
+    /*
+     * The body is signed as raw bytes, but it reaches us through a shell
+     * pipeline. A NUL would already have been lost on the way in, and would
+     * truncate the message here; say so instead of signing a prefix.
+     */
+    if (memchr(buf, '\0', used)) {
+        fprintf(stderr, "ob-sign-request: body contains a NUL byte\n");
+        free(buf);
+        return NULL;
+    }
+
+    /* The loop grows the buffer before every fread, so used < cap here and
+     * there is always room for the terminator. */
+    buf[used] = '\0';
+    *len = used;
+    return buf;
+}
+
+int main(int argc, char **argv)
+{
+    const char *method = NULL, *path = NULL, *conf = DEFAULT_CONFIG;
+
+    for (int i = 1; i < argc; i++) {
+        if (strcmp(argv[i], "--method") == 0 && i + 1 < argc) {
+            method = argv[++i];
+        } else if (strcmp(argv[i], "--path") == 0 && i + 1 < argc) {
+            path = argv[++i];
+        } else if (strcmp(argv[i], "--config") == 0 && i + 1 < argc) {
+            conf = argv[++i];
+        } else if (strcmp(argv[i], "-h") == 0 || strcmp(argv[i], "--help") == 0) {
+            usage(stdout);
+            return 0;
+        } else {
+            fprintf(stderr, "ob-sign-request: unexpected argument '%s'\n", argv[i]);
+            usage(stderr);
+            return 1;
+        }
+    }
+
+    if (!valid_method(method)) {
+        fprintf(stderr, "ob-sign-request: --method must be an uppercase HTTP method\n");
+        return 1;
+    }
+    if (!valid_path(path)) {
+        fprintf(stderr, "ob-sign-request: --path must be an absolute path with no "
+                        "query string\n");
+        return 1;
+    }
+
+    char *secret = NULL;
+    int rc = ob_sign_load_secret(conf, &secret);
+    if (rc < 0) {
+        fprintf(stderr, "ob-sign-request: cannot read the signing secret from %s "
+                        "(must be a regular file, owned by root, mode 0600)\n", conf);
+        return 1;
+    }
+    if (rc > 0) {
+        return 3;  /* nothing configured: the caller sends the request unsigned */
+    }
+
+    size_t body_len = 0;
+    char *body = read_body(&body_len);
+    if (!body) {
+        explicit_bzero(secret, strlen(secret));
+        free(secret);
+        return 1;
+    }
+
+    long timestamp = (long)time(NULL);
+
+    char nonce[OB_SIGN_NONCE_SIZE];
+    ob_sign_generate_nonce(nonce, sizeof(nonce));
+
+    char signature[OB_SIGN_SIGNATURE_SIZE];
+    ob_sign_compute(secret, timestamp, nonce, method, path, body,
+                    signature, sizeof(signature));
+
+    explicit_bzero(secret, strlen(secret));
+    free(secret);
+    explicit_bzero(body, body_len);
+    free(body);
+
+    if (!*nonce || !*signature) {
+        fprintf(stderr, "ob-sign-request: signing failed\n");
+        return 1;
+    }
+
+    printf("X-Timestamp: %ld\n", timestamp);
+    printf("X-Nonce: %s\n", nonce);
+    printf("X-Signature-256: sha256=%s\n", signature);
+
+    if (fflush(stdout) != 0) {
+        fprintf(stderr, "ob-sign-request: cannot write headers: %s\n", strerror(errno));
+        return 1;
+    }
+
+    return 0;
+}

--- a/src/ob_client.c
+++ b/src/ob_client.c
@@ -170,7 +170,17 @@ static int add_signing_headers(struct curl_slist **headers,
                                const char *path,
                                const char *body)
 {
-    if (!signing_secret) {
+    /*
+     * Empty counts as absent, exactly as ob_sign_load_secret() treats it.
+     * config_load() strdup's whatever follows the '=', so a degenerate
+     * `request_signing_secret =` reaches here as "" rather than NULL. HMAC
+     * with a zero-length key is well defined and worthless -- anyone can
+     * compute it -- so signing with it would ship a request that merely looks
+     * signed, and would disagree with the shell and daemon callers on the same
+     * host, which send that config unsigned. Unsigned is the honest answer: a
+     * portal in `required` refuses it visibly.
+     */
+    if (!signing_secret || !*signing_secret) {
         return 0;
     }
 

--- a/src/ob_client.c
+++ b/src/ob_client.c
@@ -13,20 +13,14 @@
 #include <pthread.h>
 #include <curl/curl.h>
 #include <json-c/json.h>
-#include <openssl/hmac.h>
-#include <openssl/evp.h>
-#include <openssl/rand.h>
-
 #include "ob_client.h"
+#include "ob_sign.h"
 #include "jwt_utils.h"
 #include "str_utils.h"
 
 /* TLS version constants for min_tls_version configuration */
 #define TLS_VERSION_1_2 12
 #define TLS_VERSION_1_3 13
-
-/* Stack buffer size for HMAC signature message building */
-#define SIGNATURE_STACK_BUFFER_SIZE 512
 
 /* Security: Maximum user groups to prevent DoS via memory exhaustion */
 #define MAX_USER_GROUPS 256
@@ -157,171 +151,76 @@ static char *strdup_or_null(const char *s)
 }
 
 /*
- * Generate HMAC-SHA256 signature for request signing.
- * Message format: timestamp.nonce.method.path.body
- * Output: hex-encoded signature string (65 bytes including null terminator)
- *
- * Security (#188): the nonce MUST be part of the signed message. It is sent
- * in its own X-Nonce header for the server's replay window; if it were left
- * out of the HMAC an attacker could replay a captured request with a fresh
- * nonce and the signature would still verify, defeating replay protection.
- */
-static void generate_request_signature(const char *secret,
-                                        long timestamp,
-                                        const char *nonce,
-                                        const char *method,
-                                        const char *path,
-                                        const char *body,
-                                        char *signature,
-                                        size_t sig_size)
-{
-    if (!secret || !nonce || !signature || sig_size < 65) {
-        if (signature && sig_size > 0) signature[0] = '\0';
-        return;
-    }
-
-    /* Build message: timestamp.nonce.method.path.body
-     * Use stack allocation for typical message sizes to avoid malloc overhead.
-     * Typical: timestamp(~10) + nonce(~55) + method(~4) + path(~50) + body(~200)
-     * < SIGNATURE_STACK_BUFFER_SIZE
-     */
-    char ts_str[32];
-    snprintf(ts_str, sizeof(ts_str), "%ld", timestamp);
-
-    size_t msg_len = strlen(ts_str) + 1 + strlen(nonce) + 1 + strlen(method) + 1 +
-                     strlen(path) + 1 + (body ? strlen(body) : 0);
-
-    /* Use stack buffer for small messages, heap for large ones */
-    char stack_message[SIGNATURE_STACK_BUFFER_SIZE];
-    char *message;
-    bool heap_allocated = false;
-
-    if (msg_len < sizeof(stack_message)) {
-        message = stack_message;
-    } else {
-        message = malloc(msg_len + 1);
-        if (!message) {
-            signature[0] = '\0';
-            return;
-        }
-        heap_allocated = true;
-    }
-
-    snprintf(message, msg_len + 1, "%s.%s.%s.%s.%s",
-             ts_str, nonce, method, path, body ? body : "");
-
-    /* Generate HMAC-SHA256 */
-    unsigned char hmac[EVP_MAX_MD_SIZE];
-    unsigned int hmac_len = 0;
-
-    unsigned char *result = HMAC(EVP_sha256(), secret, strlen(secret),
-                                  (unsigned char *)message, strlen(message),
-                                  hmac, &hmac_len);
-
-    /* Clear message buffer */
-    explicit_bzero(message, msg_len + 1);
-    if (heap_allocated) {
-        free(message);
-    }
-
-    /* Check HMAC result */
-    if (!result) {
-        signature[0] = '\0';
-        return;
-    }
-
-    /* Convert to hex string */
-    if (hmac_len * 2 + 1 <= sig_size) {
-        str_bytes_to_hex(hmac, hmac_len, signature);
-    }
-
-    /* Clear HMAC buffer */
-    explicit_bzero(hmac, sizeof(hmac));
-}
-
-/*
- * Generate a unique nonce for replay protection.
- * Format: timestamp_ms-uuid
- * Uses OpenSSL RAND_bytes for cryptographically secure random generation.
- */
-static void generate_nonce(char *nonce, size_t nonce_size)
-{
-    if (!nonce || nonce_size < 64) {
-        if (nonce && nonce_size > 0) nonce[0] = '\0';
-        return;
-    }
-
-    /* Get timestamp in milliseconds */
-    struct timespec ts;
-    clock_gettime(CLOCK_REALTIME, &ts);
-    long long timestamp_ms = (long long)ts.tv_sec * 1000 + ts.tv_nsec / 1000000;
-
-    /* Generate UUID v4 using OpenSSL RAND_bytes (CSPRNG) */
-    unsigned char uuid[16];
-    if (RAND_bytes(uuid, sizeof(uuid)) != 1) {
-        /* RAND_bytes failed - this is a critical error, but use timestamp as fallback */
-        snprintf(nonce, nonce_size, "%lld", timestamp_ms);
-        return;
-    }
-
-    /* Set version (4) and variant bits */
-    uuid[6] = (uuid[6] & 0x0F) | 0x40;
-    uuid[8] = (uuid[8] & 0x3F) | 0x80;
-
-    snprintf(nonce, nonce_size,
-             "%lld-%02x%02x%02x%02x-%02x%02x-%02x%02x-%02x%02x-%02x%02x%02x%02x%02x%02x",
-             timestamp_ms,
-             uuid[0], uuid[1], uuid[2], uuid[3],
-             uuid[4], uuid[5],
-             uuid[6], uuid[7],
-             uuid[8], uuid[9],
-             uuid[10], uuid[11], uuid[12], uuid[13], uuid[14], uuid[15]);
-}
-
-/*
  * Add request signing headers if signing_secret is configured.
  * Adds X-Timestamp, X-Nonce, and X-Signature-256 headers.
  *
  * The nonce provides replay protection - server should reject
  * requests with previously seen nonces within a time window. It is covered
- * by the signature (see generate_request_signature) so it cannot be swapped
+ * by the signature (see ob_sign_compute) so it cannot be swapped
  * for a fresh value on a replayed request.
+ *
+ * A secret that is configured but yields no signature is a hard failure, not
+ * a reason to fall back to an unsigned request: the portal reads a partially
+ * signed request as malformed and refuses it in every mode, and an operator
+ * who set the secret asked for the call to be signed.
  */
-static struct curl_slist *add_signing_headers(struct curl_slist *headers,
-                                               const char *signing_secret,
-                                               const char *method,
-                                               const char *path,
-                                               const char *body)
+static int add_signing_headers(struct curl_slist **headers,
+                               const char *signing_secret,
+                               const char *method,
+                               const char *path,
+                               const char *body)
 {
     if (!signing_secret) {
-        return headers;
+        return 0;
     }
 
     long timestamp = (long)time(NULL);
 
     /* Generate unique nonce */
-    char nonce[80];
-    generate_nonce(nonce, sizeof(nonce));
+    char nonce[OB_SIGN_NONCE_SIZE];
+    ob_sign_generate_nonce(nonce, sizeof(nonce));
 
     /* Generate signature over timestamp.nonce.method.path.body (#188) */
-    char signature[65];
-    generate_request_signature(signing_secret, timestamp, nonce, method, path, body,
-                               signature, sizeof(signature));
+    char signature[OB_SIGN_SIGNATURE_SIZE];
+    ob_sign_compute(signing_secret, timestamp, nonce, method, path, body,
+                    signature, sizeof(signature));
 
-    /* Add headers */
+    if (!*nonce || !*signature) {
+        syslog(LOG_ERR, "open-bastion: cannot sign %s %s "
+                        "(request_signing_secret is set but signing failed)",
+               method, path);
+        return -1;
+    }
+
     char ts_header[64];
     snprintf(ts_header, sizeof(ts_header), "X-Timestamp: %ld", timestamp);
-    headers = curl_slist_append(headers, ts_header);
 
     char nonce_header[128];
     snprintf(nonce_header, sizeof(nonce_header), "X-Nonce: %s", nonce);
-    headers = curl_slist_append(headers, nonce_header);
 
     char sig_header[128];
     snprintf(sig_header, sizeof(sig_header), "X-Signature-256: sha256=%s", signature);
-    headers = curl_slist_append(headers, sig_header);
 
-    return headers;
+    /*
+     * Append all three or none. curl_slist_append returns NULL on allocation
+     * failure and does NOT free the list it was given, so each step keeps the
+     * caller's list intact and reachable; a half-applied header set would go
+     * out as a partially signed request, which the portal refuses as
+     * malformed in every mode -- including 'off'.
+     */
+    struct curl_slist *tmp = curl_slist_append(*headers, ts_header);
+    if (!tmp) return -1;
+    *headers = tmp;
+
+    tmp = curl_slist_append(*headers, nonce_header);
+    if (!tmp) return -1;
+    *headers = tmp;
+
+    tmp = curl_slist_append(*headers, sig_header);
+    if (!tmp) return -1;
+    *headers = tmp;
+
+    return 0;
 }
 
 /*
@@ -541,10 +440,30 @@ int ob_client_refresh_via_heartbeat(ob_client_t *client,
     }
     const char *req_body = json_object_to_json_string(req_json);
 
-    /* /pam/heartbeat authenticates via the refresh_token in the body, like the
-     * shell ob-heartbeat — no Authorization header, no request signing. */
+    /*
+     * /pam/heartbeat authenticates via the refresh_token in the body, like the
+     * shell ob-heartbeat -- no Authorization header. It is signed all the same
+     * (#247): the portal checks the signature in _checkCaller, before it looks
+     * at any caller identity, so `required` covers this endpoint exactly like
+     * the five that do carry a Bearer token. There is one portal-wide
+     * pamAccessRequestSigningSecret, so the secret here is the same
+     * request_signing_secret as everywhere else -- the signature proves fleet
+     * membership, it does not name a caller.
+     *
+     * Leaving it unsigned is what makes `required` undeployable: every host
+     * renews its access token here, so flipping the switch breaks nothing
+     * visible and takes the whole fleet down hours later, at once.
+     */
     struct curl_slist *headers = NULL;
     headers = curl_slist_append(headers, "Content-Type: application/json");
+    if (add_signing_headers(&headers, client->signing_secret,
+                            "POST", "/pam/heartbeat", req_body) != 0) {
+        snprintf(client->error, sizeof(client->error),
+                 "Failed to sign the /pam/heartbeat request");
+        json_object_put(req_json);
+        curl_slist_free_all(headers);
+        return -1;
+    }
 
     response_buffer_t buf;
     init_buffer(&buf);
@@ -723,8 +642,15 @@ int ob_verify_token(ob_client_t *client,
     headers = curl_slist_append(headers, "Content-Type: application/json");
 
     /* Add request signing headers if configured */
-    headers = add_signing_headers(headers, client->signing_secret,
-                                   "POST", "/pam/verify", req_body);
+    if (add_signing_headers(&headers, client->signing_secret,
+                            "POST", "/pam/verify", req_body) != 0) {
+        snprintf(client->error, sizeof(client->error),
+                 "Failed to sign the /pam/verify request");
+        json_object_put(req_json);
+        curl_slist_free_all(headers);
+        explicit_bzero(auth_header, sizeof(auth_header));
+        return -1;
+    }
 
     response_buffer_t buf;
     init_buffer(&buf);
@@ -1134,8 +1060,15 @@ static int ob_authorize_user_internal(ob_client_t *client,
     headers = curl_slist_append(headers, "Content-Type: application/json");
 
     /* Add request signing headers if configured */
-    headers = add_signing_headers(headers, client->signing_secret,
-                                   "POST", "/pam/authorize", req_body);
+    if (add_signing_headers(&headers, client->signing_secret,
+                            "POST", "/pam/authorize", req_body) != 0) {
+        snprintf(client->error, sizeof(client->error),
+                 "Failed to sign the /pam/authorize request");
+        json_object_put(req_json);
+        curl_slist_free_all(headers);
+        explicit_bzero(auth_header, sizeof(auth_header));
+        return -1;
+    }
 
     response_buffer_t buf;
     init_buffer(&buf);

--- a/src/ob_sign.c
+++ b/src/ob_sign.c
@@ -83,7 +83,13 @@ void ob_sign_compute(const char *secret,
                      char *signature,
                      size_t sig_size)
 {
-    if (!secret || !nonce || !*nonce || !method || !path
+    /*
+     * `!*secret` as well as `!secret`: an empty key is not a secret. HMAC over
+     * a zero-length key is well defined and forgeable by anyone, so the single
+     * rule across this file is "empty counts as absent" -- the same answer
+     * ob_sign_load_secret() gives for `request_signing_secret =`.
+     */
+    if (!secret || !*secret || !nonce || !*nonce || !method || !path
         || !signature || sig_size < OB_SIGN_SIGNATURE_SIZE) {
         if (signature && sig_size > 0) signature[0] = '\0';
         return;

--- a/src/ob_sign.c
+++ b/src/ob_sign.c
@@ -1,0 +1,276 @@
+/*
+ * ob_sign.c - Request signing for the LLNG /pam/<endpoint> endpoints
+ *
+ * Copyright (C) 2025 Linagora
+ * License: AGPL-3.0
+ *
+ * The wire format and why this is shared code are documented in ob_sign.h.
+ * The two generators below were the PAM client's private helpers until #247
+ * needed them in ob-cert-daemon and in ob-sign-request as well.
+ */
+
+#include <stdio.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <string.h>
+#include <ctype.h>
+#include <time.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <errno.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+
+#include <openssl/hmac.h>
+#include <openssl/evp.h>
+#include <openssl/rand.h>
+
+#include "ob_sign.h"
+#include "str_utils.h"
+
+/* Stack buffer size for HMAC signature message building */
+#define SIGNATURE_STACK_BUFFER_SIZE 512
+
+/* Same line limit as config.c, so both readers agree on what fits. */
+#define OB_SIGN_CONF_LINE 1024
+
+void ob_sign_generate_nonce(char *nonce, size_t size)
+{
+    if (!nonce || size < OB_SIGN_NONCE_SIZE) {
+        if (nonce && size > 0) nonce[0] = '\0';
+        return;
+    }
+
+    /* Get timestamp in milliseconds */
+    struct timespec ts;
+    clock_gettime(CLOCK_REALTIME, &ts);
+    long long timestamp_ms = (long long)ts.tv_sec * 1000 + ts.tv_nsec / 1000000;
+
+    /* Generate UUID v4 using OpenSSL RAND_bytes (CSPRNG) */
+    unsigned char uuid[16];
+    if (RAND_bytes(uuid, sizeof(uuid)) != 1) {
+        /* RAND_bytes failed - this is a critical error, but use timestamp as fallback */
+        snprintf(nonce, size, "%lld", timestamp_ms);
+        return;
+    }
+
+    /* Set version (4) and variant bits */
+    uuid[6] = (uuid[6] & 0x0F) | 0x40;
+    uuid[8] = (uuid[8] & 0x3F) | 0x80;
+
+    snprintf(nonce, size,
+             "%lld-%02x%02x%02x%02x-%02x%02x-%02x%02x-%02x%02x-%02x%02x%02x%02x%02x%02x",
+             timestamp_ms,
+             uuid[0], uuid[1], uuid[2], uuid[3],
+             uuid[4], uuid[5],
+             uuid[6], uuid[7],
+             uuid[8], uuid[9],
+             uuid[10], uuid[11], uuid[12], uuid[13], uuid[14], uuid[15]);
+}
+
+/*
+ * Security (#188): the nonce MUST be part of the signed message. It is sent
+ * in its own X-Nonce header for the server's replay window; if it were left
+ * out of the HMAC an attacker could replay a captured request with a fresh
+ * nonce and the signature would still verify, defeating replay protection.
+ */
+void ob_sign_compute(const char *secret,
+                     long timestamp,
+                     const char *nonce,
+                     const char *method,
+                     const char *path,
+                     const char *body,
+                     char *signature,
+                     size_t sig_size)
+{
+    if (!secret || !nonce || !*nonce || !method || !path
+        || !signature || sig_size < OB_SIGN_SIGNATURE_SIZE) {
+        if (signature && sig_size > 0) signature[0] = '\0';
+        return;
+    }
+
+    /* Build message: timestamp.nonce.method.path.body
+     * Use stack allocation for typical message sizes to avoid malloc overhead.
+     * Typical: timestamp(~10) + nonce(~55) + method(~4) + path(~50) + body(~200)
+     * < SIGNATURE_STACK_BUFFER_SIZE
+     */
+    char ts_str[32];
+    snprintf(ts_str, sizeof(ts_str), "%ld", timestamp);
+
+    size_t msg_len = strlen(ts_str) + 1 + strlen(nonce) + 1 + strlen(method) + 1 +
+                     strlen(path) + 1 + (body ? strlen(body) : 0);
+
+    /* Use stack buffer for small messages, heap for large ones */
+    char stack_message[SIGNATURE_STACK_BUFFER_SIZE];
+    char *message;
+    bool heap_allocated = false;
+
+    if (msg_len < sizeof(stack_message)) {
+        message = stack_message;
+    } else {
+        message = malloc(msg_len + 1);
+        if (!message) {
+            signature[0] = '\0';
+            return;
+        }
+        heap_allocated = true;
+    }
+
+    snprintf(message, msg_len + 1, "%s.%s.%s.%s.%s",
+             ts_str, nonce, method, path, body ? body : "");
+
+    /* Generate HMAC-SHA256 */
+    unsigned char hmac[EVP_MAX_MD_SIZE];
+    unsigned int hmac_len = 0;
+
+    unsigned char *result = HMAC(EVP_sha256(), secret, strlen(secret),
+                                  (unsigned char *)message, strlen(message),
+                                  hmac, &hmac_len);
+
+    /* Clear message buffer */
+    explicit_bzero(message, msg_len + 1);
+    if (heap_allocated) {
+        free(message);
+    }
+
+    /* Check HMAC result */
+    if (!result) {
+        signature[0] = '\0';
+        return;
+    }
+
+    /* Convert to hex string */
+    if (hmac_len * 2 + 1 <= sig_size) {
+        str_bytes_to_hex(hmac, hmac_len, signature);
+    } else {
+        signature[0] = '\0';
+    }
+
+    /* Clear HMAC buffer */
+    explicit_bzero(hmac, sizeof(hmac));
+}
+
+/* Trim leading and trailing whitespace in place; returns the new start. */
+static char *ob_sign_trim(char *s)
+{
+    while (*s && isspace((unsigned char)*s)) s++;
+    size_t n = strlen(s);
+    while (n > 0 && isspace((unsigned char)s[n - 1])) s[--n] = '\0';
+    return s;
+}
+
+/*
+ * Strip one layer of matching quotes, mirroring strip_quotes() in config.c:
+ * the opening quote must be the first character, and the value ends at the
+ * LAST occurrence of that same quote.
+ */
+static char *ob_sign_strip_quotes(char *value)
+{
+    if (*value != '"' && *value != '\'') {
+        return value;
+    }
+    char quote = *value;
+    value++;
+    char *end = strrchr(value, quote);
+    if (end) *end = '\0';
+    return value;
+}
+
+/*
+ * Refuse a config file that a non-owner could have written, on the opened fd
+ * so the answer cannot be swapped underneath us. Accepting an euid-owned file
+ * as well as a root-owned one is what lets the test suite exercise this
+ * without root; in production every caller is root and the two coincide.
+ */
+static int ob_sign_check_fd(int fd)
+{
+    struct stat st;
+
+    if (fstat(fd, &st) != 0) return -1;
+    if (!S_ISREG(st.st_mode)) return -1;
+    if (st.st_uid != 0 && st.st_uid != geteuid()) return -1;
+    if (st.st_mode & (S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH)) return -1;
+
+    return 0;
+}
+
+int ob_sign_load_secret(const char *conf_path, char **secret)
+{
+    if (!conf_path || !secret) return -1;
+    *secret = NULL;
+
+    int fd = open(conf_path, O_RDONLY | O_NOFOLLOW);
+    if (fd < 0) return -1;
+
+    if (ob_sign_check_fd(fd) != 0) {
+        close(fd);
+        return -1;
+    }
+
+    FILE *f = fdopen(fd, "r");
+    if (!f) {
+        close(fd);
+        return -1;
+    }
+
+    char line[OB_SIGN_CONF_LINE];
+    int rc = 1;  /* no secret in the file */
+
+    while (fgets(line, sizeof(line), f)) {
+        /*
+         * A line that filled the buffer without a newline was truncated. For
+         * any other key that is someone else's problem, but truncating THIS
+         * value yields a wrong secret and therefore a signature the portal
+         * refuses -- a failure that looks like a portal problem and is not.
+         * Refuse to guess.
+         */
+        bool complete = (strchr(line, '\n') != NULL) || feof(f);
+
+        char *eq = strchr(line, '=');
+        if (!eq) continue;
+        *eq = '\0';
+
+        char *key = ob_sign_trim(line);
+        if (*key == '#' || *key == ';') continue;
+        if (strcmp(key, "request_signing_secret") != 0) continue;
+
+        if (!complete) {
+            rc = -1;
+            break;
+        }
+
+        /*
+         * No inline-comment stripping: '#' is an ordinary character in a
+         * generated secret, and config.c exempts this exact key for the same
+         * reason (key_holds_opaque_secret).
+         */
+        char *value = ob_sign_strip_quotes(ob_sign_trim(eq + 1));
+
+        /* Last assignment wins, as in config.c. */
+        free(*secret);
+        *secret = NULL;
+        if (*value) {
+            *secret = strdup(value);
+            if (!*secret) {
+                rc = -1;
+                break;
+            }
+            rc = 0;
+        } else {
+            rc = 1;
+        }
+    }
+
+    explicit_bzero(line, sizeof(line));
+    fclose(f);
+
+    if (rc != 0) {
+        if (*secret) {
+            explicit_bzero(*secret, strlen(*secret));
+            free(*secret);
+            *secret = NULL;
+        }
+    }
+
+    return rc;
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -89,7 +89,7 @@ target_include_directories(test_ob_cert_proto PRIVATE ${CMAKE_SOURCE_DIR}/includ
 add_test(NAME test_ob_cert_proto COMMAND test_ob_cert_proto)
 
 # Test ob_client structures and functions
-add_executable(test_ob_client test_ob_client.c ../src/ob_client.c ../src/jwt_utils.c)
+add_executable(test_ob_client test_ob_client.c ../src/ob_client.c ../src/jwt_utils.c ../src/ob_sign.c)
 target_include_directories(test_ob_client PRIVATE
     ${CMAKE_SOURCE_DIR}/include
     ${CURL_INCLUDE_DIRS}
@@ -103,6 +103,16 @@ target_link_libraries(test_ob_client
     pthread
 )
 add_test(NAME test_ob_client COMMAND test_ob_client)
+
+# Request signing: the wire format the portal verifies (#247)
+add_executable(test_ob_sign test_ob_sign.c ../src/ob_sign.c ../src/str_utils.c)
+target_include_directories(test_ob_sign PRIVATE
+    ${CMAKE_SOURCE_DIR}/include
+    ${OPENSSL_INCLUDE_DIRS}
+)
+target_compile_definitions(test_ob_sign PRIVATE _GNU_SOURCE)
+target_link_libraries(test_ob_sign ${OPENSSL_LIBRARIES})
+add_test(NAME test_ob_sign COMMAND test_ob_sign)
 
 # Test authorization cache
 add_executable(test_auth_cache test_auth_cache.c ../src/auth_cache.c ../src/cache_key.c)

--- a/tests/mock_portal_signing.py
+++ b/tests/mock_portal_signing.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""Mock LLNG portal that verifies request signatures the way the real one does.
+
+Usage: mock_portal_signing.py MODE PORT SECRETFILE LOGFILE
+
+MODE mirrors pamAccessRequestSigningMode:
+    off       headers ignored
+    optional  a signed request must verify; an unsigned one passes
+    required  the headers are mandatory
+
+The verification below is a transcription of
+Lemonldap::NG::Portal::Plugins::PamAccess::_checkRequestSignature -- same
+header names, same regex on the signature, same +/-300 s window, and the same
+message
+
+    <timestamp>.<nonce>.<METHOD>.<path>.<body>
+
+hashed with HMAC-SHA256 over the raw secret bytes. The point of reproducing it
+rather than trusting the client is that a client-side test which computes the
+expected value the same way the client does proves nothing (#247).
+
+Every request is appended to LOGFILE as one JSON object so the test can assert
+on what the portal saw, not only on what the client survived.
+"""
+
+import hashlib
+import hmac
+import json
+import re
+import sys
+import time
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+MODE = sys.argv[1]
+PORT = int(sys.argv[2])
+# Read from a file, not argv: this mock exists to prove the client keeps the
+# signing secret out of /proc/<pid>/cmdline, and a fixture that puts it there
+# would be a poor example to copy.
+with open(sys.argv[3]) as _fh:
+    SECRET = _fh.read().strip("\n")
+LOGFILE = sys.argv[4]
+
+SIG_RE = re.compile(r"\Asha256=([0-9a-f]{64})\Z")
+NONCE_RE = re.compile(r"\A[0-9A-Za-z._:-]{1,128}\Z")
+TS_RE = re.compile(r"\A[0-9]{1,11}\Z")
+WINDOW = 300
+
+SEEN_NONCES = set()
+
+
+def check(handler, body):
+    """Return (ok, reason). Mirrors _checkRequestSignature step for step."""
+    ts = handler.headers.get("X-Timestamp")
+    nonce = handler.headers.get("X-Nonce")
+    sig = handler.headers.get("X-Signature-256")
+
+    if MODE == "off":
+        return True, "off"
+
+    signed = any(v for v in (ts, nonce, sig))
+    if not signed:
+        if MODE == "optional":
+            return True, "unsigned_allowed"
+        return False, "unsigned"
+
+    m = SIG_RE.match(sig) if sig else None
+    if not (ts and TS_RE.match(ts) and nonce and NONCE_RE.match(nonce) and m):
+        return False, "malformed_headers"
+
+    if abs(time.time() - int(ts)) > WINDOW:
+        return False, "stale_timestamp"
+
+    path = handler.path.split("?", 1)[0]
+    message = ".".join([ts, nonce, handler.command.upper(), path, body])
+    expected = hmac.new(
+        SECRET.encode(), message.encode(), hashlib.sha256
+    ).hexdigest()
+    if not hmac.compare_digest(expected, m.group(1)):
+        return False, "bad_signature"
+
+    if nonce in SEEN_NONCES:
+        return False, "nonce_replayed"
+    SEEN_NONCES.add(nonce)
+
+    return True, "verified"
+
+
+# What each endpoint answers once the caller is through the gate. Only the
+# fields the clients actually read.
+BODIES = {
+    "/pam/heartbeat": {"access_token": "fresh-access-token", "expires_in": 3600,
+                       "next_heartbeat": 300},
+    "/pam/whoami": {"server_id": "mock-bastion-1", "bastion_id": "mock-bastion-1"},
+}
+
+
+class Handler(BaseHTTPRequestHandler):
+    def do_POST(self):
+        length = int(self.headers.get("Content-Length") or 0)
+        body = self.rfile.read(length).decode("utf-8", "replace")
+        path = self.path.split("?", 1)[0]
+
+        ok, reason = check(self, body)
+
+        with open(LOGFILE, "a") as fh:
+            fh.write(json.dumps({
+                "path": path,
+                "signed": bool(self.headers.get("X-Signature-256")),
+                "ok": ok,
+                "reason": reason,
+            }) + "\n")
+
+        if not ok:
+            payload = json.dumps({"error": "forbidden", "reason": reason})
+            self.send_response(403)
+        elif path in BODIES:
+            payload = json.dumps(BODIES[path])
+            self.send_response(200)
+        else:
+            payload = json.dumps({"error": "not_found"})
+            self.send_response(404)
+
+        raw = payload.encode()
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(raw)))
+        self.end_headers()
+        self.wfile.write(raw)
+
+    def log_message(self, *args):
+        pass
+
+
+if __name__ == "__main__":
+    HTTPServer(("127.0.0.1", PORT), Handler).serve_forever()

--- a/tests/test_ob_bastion_id.sh
+++ b/tests/test_ob_bastion_id.sh
@@ -45,6 +45,9 @@ run_against() {
     local mode="$1" port="$2" pid
     printf 'portal_url = http://127.0.0.1:%s\nserver_group = bastion\nverify_ssl = false\n' \
         "$port" > "$WORK/ob.conf"
+    # 0600 like the real /etc/open-bastion/openbastion.conf: config_load()
+    # refuses anything looser, and so does the signing helper (#247).
+    chmod 600 "$WORK/ob.conf"
     python3 "$MOCK" "$mode" "$port" & pid=$!
     for _ in $(seq 1 50); do
         (echo > "/dev/tcp/127.0.0.1/$port") 2>/dev/null && break
@@ -103,6 +106,7 @@ TESTS_RUN=$((TESTS_RUN + 1))
 port=$((port + 1))
 printf 'portal_url = http://127.0.0.1:%s\nserver_group = bastion\nverify_ssl = false\n' \
     "$port" > "$WORK/ob.conf"
+chmod 600 "$WORK/ob.conf"
 python3 "$MOCK" whoami "$port" & mpid=$!
 for _ in $(seq 1 50); do (echo > "/dev/tcp/127.0.0.1/$port") 2>/dev/null && break; sleep 0.1; done
 json=$(bash "$SCRIPT" --quiet --json -c "$WORK/ob.conf" -t "$WORK/token" 2>&1)

--- a/tests/test_ob_request_signing.sh
+++ b/tests/test_ob_request_signing.sh
@@ -1,0 +1,353 @@
+#!/bin/bash
+#
+# Every /pam/ caller signs, end to end (#247).
+#
+# Why this exists: the client had produced X-Signature-256 on two endpoints for
+# a year and nothing checked it, so when the portal started verifying
+# (lemonldap-ng-plugins#93) the strictest mode could not be turned on -- the
+# four other endpoints were unsigned, and /pam/heartbeat is how every enrolled
+# host renews its access token. Flipping the switch would have broken nothing
+# visible and taken the whole fleet down hours later, together.
+#
+# So this test does not check that the client can sign. It checks that a portal
+# which REFUSES unsigned requests is still usable, which is the only property
+# that makes `pamAccessRequestSigningMode = required` deployable. The mock
+# verifies the HMAC itself (tests/mock_portal_signing.py, a transcription of
+# _checkRequestSignature), so a client that signed the wrong bytes fails here.
+#
+# The unit test tests/test_ob_sign.c pins the wire format against the portal's
+# own Digest::SHA output; this one pins the wiring.
+#
+
+set -uo pipefail
+
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+MOCK="$ROOT_DIR/tests/mock_portal_signing.py"
+WORK="$(mktemp -d)"
+PORT_BASE=${OB_TEST_PORT_BASE:-18800}
+trap 'rm -rf "$WORK"' EXIT
+
+pass() { TESTS_PASSED=$((TESTS_PASSED + 1)); echo "  PASS: $1"; }
+fail() { TESTS_FAILED=$((TESTS_FAILED + 1)); echo "  FAIL: $1${2:+ - $2}"; }
+
+command -v jq >/dev/null      || { echo "SKIP: jq is required"; exit 0; }
+command -v curl >/dev/null    || { echo "SKIP: curl is required"; exit 0; }
+command -v python3 >/dev/null || { echo "SKIP: python3 is required"; exit 0; }
+
+# The helper is built, not installed, when the tests run. Put the build tree on
+# PATH so the scripts find it exactly the way they will in production
+# (command -v ob-sign-request).
+BUILD_DIR="${OB_BUILD_DIR:-$ROOT_DIR/build}"
+if [ ! -x "$BUILD_DIR/ob-sign-request" ]; then
+    echo "SKIP: $BUILD_DIR/ob-sign-request not built (cmake --build build)"
+    exit 0
+fi
+PATH="$BUILD_DIR:$PATH"
+export PATH
+
+# A secret with a '#' and a space in it, on purpose: every config reader in the
+# tree used to end the value at the '#', which yields a signature over the
+# wrong key -- reported by the portal as bad_signature, which looks like a
+# portal problem and is not.
+SECRET='s3cr#t key'
+
+port=$PORT_BASE
+next_port() { port=$((port + 1)); echo "$port"; }
+
+# start_mock MODE PORT SECRET -> sets MOCK_PID, MOCK_LOG
+start_mock() {
+    local mode="$1" p="$2" secret="$3"
+    MOCK_LOG="$WORK/mock-$p.log"
+    : > "$MOCK_LOG"
+    printf '%s' "$secret" > "$WORK/mock-secret-$p"
+    python3 "$MOCK" "$mode" "$p" "$WORK/mock-secret-$p" "$MOCK_LOG" &
+    MOCK_PID=$!
+    local i
+    for i in $(seq 1 50); do
+        (echo > "/dev/tcp/127.0.0.1/$p") 2>/dev/null && return 0
+        sleep 0.1
+    done
+    return 1
+}
+
+stop_mock() {
+    kill "$MOCK_PID" 2>/dev/null
+    wait "$MOCK_PID" 2>/dev/null
+    return 0
+}
+
+# write_conf PORT SECRET -> path of an openbastion.conf
+write_conf() {
+    local p="$1" secret="$2"
+    local f="$WORK/ob-$p.conf"
+    {
+        printf 'portal_url = http://127.0.0.1:%s\n' "$p"
+        printf 'server_group = bastion\n'
+        printf 'verify_ssl = false\n'
+        [ -n "$secret" ] && printf 'request_signing_secret = %s\n' "$secret"
+    } > "$f"
+    chmod 600 "$f"
+    echo "$f"
+}
+
+# The reason the mock recorded for the last request on a path.
+last_reason() {
+    local log="$1" path="$2"
+    jq -r --arg p "$path" 'select(.path == $p) | .reason' "$log" 2>/dev/null | tail -1
+}
+
+# ── 1. ob-heartbeat against a portal in `required` ────────────────────────────
+#
+# The endpoint that made `required` undeployable. A pass here means an enrolled
+# host can still renew its access token once the switch is flipped.
+test_heartbeat_required() {
+    local p conf token out rc
+    p=$(next_port)
+    start_mock required "$p" "$SECRET" || { fail "heartbeat/required" "mock did not start"; return; }
+    conf=$(write_conf "$p" "$SECRET")
+    token="$WORK/token-$p"
+    echo '{"access_token":"old","refresh_token":"rt-1","expires_at":0}' > "$token"
+
+    out=$(bash "$ROOT_DIR/scripts/ob-heartbeat" -c "$conf" -t "$token" 2>&1); rc=$?
+    stop_mock
+
+    local reason; reason=$(last_reason "$MOCK_LOG" /pam/heartbeat)
+    if [ "$rc" != "0" ]; then
+        fail "ob-heartbeat is accepted by a portal in 'required'" "rc=$rc reason=$reason $out"
+    elif [ "$reason" != "verified" ]; then
+        fail "ob-heartbeat is accepted by a portal in 'required'" "portal said: $reason"
+    elif [ "$(jq -r .access_token "$token")" != "fresh-access-token" ]; then
+        fail "ob-heartbeat is accepted by a portal in 'required'" "token not refreshed"
+    else
+        pass "ob-heartbeat is accepted by a portal in 'required'"
+    fi
+}
+
+# ── 2. The mock really verifies ───────────────────────────────────────────────
+#
+# Without this, case 1 would also pass against a mock that accepted anything.
+test_wrong_secret_is_refused() {
+    local p conf token rc
+    p=$(next_port)
+    start_mock required "$p" "$SECRET" || { fail "wrong secret" "mock did not start"; return; }
+    conf=$(write_conf "$p" "not-the-portals-secret")
+    token="$WORK/token-$p"
+    echo '{"access_token":"old","refresh_token":"rt-1","expires_at":0}' > "$token"
+
+    bash "$ROOT_DIR/scripts/ob-heartbeat" -c "$conf" -t "$token" >/dev/null 2>&1; rc=$?
+    stop_mock
+
+    local reason; reason=$(last_reason "$MOCK_LOG" /pam/heartbeat)
+    if [ "$reason" = "bad_signature" ] && [ "$rc" != "0" ]; then
+        pass "a signature over the wrong secret is refused (the mock verifies)"
+    else
+        fail "a signature over the wrong secret is refused" "rc=$rc reason=$reason"
+    fi
+}
+
+# ── 3. No secret configured, portal in `required` ─────────────────────────────
+#
+# Proves the headers come from the configuration and not from somewhere that
+# would have made case 1 pass regardless.
+test_unconfigured_is_unsigned() {
+    local p conf token rc
+    p=$(next_port)
+    start_mock required "$p" "$SECRET" || { fail "unconfigured" "mock did not start"; return; }
+    conf=$(write_conf "$p" "")
+    token="$WORK/token-$p"
+    echo '{"access_token":"old","refresh_token":"rt-1","expires_at":0}' > "$token"
+
+    bash "$ROOT_DIR/scripts/ob-heartbeat" -c "$conf" -t "$token" >/dev/null 2>&1; rc=$?
+    stop_mock
+
+    local reason; reason=$(last_reason "$MOCK_LOG" /pam/heartbeat)
+    if [ "$reason" = "unsigned" ] && [ "$rc" != "0" ]; then
+        pass "no request_signing_secret means unsigned, and 'required' refuses it"
+    else
+        fail "no request_signing_secret means unsigned" "rc=$rc reason=$reason"
+    fi
+}
+
+# ── 4. Unsigned is still fine where the portal allows it ──────────────────────
+#
+# The upgrade order is optional -> roll the secret out -> required. A host that
+# has not received the secret yet must keep working meanwhile.
+test_unconfigured_optional() {
+    local p conf token rc
+    p=$(next_port)
+    start_mock optional "$p" "$SECRET" || { fail "optional" "mock did not start"; return; }
+    conf=$(write_conf "$p" "")
+    token="$WORK/token-$p"
+    echo '{"access_token":"old","refresh_token":"rt-1","expires_at":0}' > "$token"
+
+    bash "$ROOT_DIR/scripts/ob-heartbeat" -c "$conf" -t "$token" >/dev/null 2>&1; rc=$?
+    stop_mock
+
+    local reason; reason=$(last_reason "$MOCK_LOG" /pam/heartbeat)
+    if [ "$rc" = "0" ] && [ "$reason" = "unsigned_allowed" ]; then
+        pass "a host without the secret still works while the portal is 'optional'"
+    else
+        fail "a host without the secret still works in 'optional'" "rc=$rc reason=$reason"
+    fi
+}
+
+# ── 5. ob-bastion-id / /pam/whoami ────────────────────────────────────────────
+#
+# A bodyless POST: the message it signs ends with the fourth separator and an
+# empty body. An implementation that dropped the trailing '.' passes every
+# other case in this file and fails this one.
+test_whoami_required() {
+    local p conf token out rc
+    p=$(next_port)
+    start_mock required "$p" "$SECRET" || { fail "whoami/required" "mock did not start"; return; }
+    conf=$(write_conf "$p" "$SECRET")
+    token="$WORK/token-$p"
+    echo '{"access_token":"at-1"}' > "$token"
+
+    out=$(bash "$ROOT_DIR/scripts/ob-bastion-id" --quiet -c "$conf" -t "$token" 2>&1); rc=$?
+    stop_mock
+
+    local reason; reason=$(last_reason "$MOCK_LOG" /pam/whoami)
+    if [ "$rc" = "0" ] && [ "$out" = "mock-bastion-1" ] && [ "$reason" = "verified" ]; then
+        pass "ob-bastion-id signs the bodyless /pam/whoami"
+    else
+        fail "ob-bastion-id signs the bodyless /pam/whoami" "rc=$rc out=$out reason=$reason"
+    fi
+}
+
+# ── 6. The helper's contract ──────────────────────────────────────────────────
+test_helper_contract() {
+    local conf out rc
+    conf=$(write_conf 1 "$SECRET")
+
+    out=$(printf '%s' '{"a":1}' | ob-sign-request --method POST --path /pam/heartbeat -c "$conf" 2>&1); rc=$?
+    if [ "$rc" != "0" ]; then
+        # -c is not the helper's spelling; --config is. Check the real one.
+        out=$(printf '%s' '{"a":1}' | ob-sign-request --method POST --path /pam/heartbeat --config "$conf" 2>&1); rc=$?
+    fi
+    if [ "$rc" = "0" ] \
+       && echo "$out" | grep -qE '^X-Timestamp: [0-9]+$' \
+       && echo "$out" | grep -qE '^X-Nonce: [0-9A-Za-z._:-]+$' \
+       && echo "$out" | grep -qE '^X-Signature-256: sha256=[0-9a-f]{64}$'; then
+        pass "ob-sign-request prints the three headers"
+    else
+        fail "ob-sign-request prints the three headers" "rc=$rc out=$(echo "$out" | tr '\n' ' ')"
+    fi
+
+    # Exit 3, not an error and not a signature: nothing is configured.
+    conf=$(write_conf 2 "")
+    out=$(printf '%s' '{}' | ob-sign-request --method POST --path /pam/whoami --config "$conf" 2>&1); rc=$?
+    if [ "$rc" = "3" ] && [ -z "$out" ]; then
+        pass "ob-sign-request exits 3 and prints nothing with no secret configured"
+    else
+        fail "ob-sign-request exits 3 with no secret configured" "rc=$rc out=$out"
+    fi
+
+    # A query string is not part of what the portal signs, so refuse it here
+    # rather than emit a signature the portal can only compute differently.
+    out=$(printf '%s' '{}' | ob-sign-request --method POST --path '/pam/whoami?x=1' --config "$(write_conf 1 "$SECRET")" 2>&1); rc=$?
+    if [ "$rc" = "1" ]; then
+        pass "ob-sign-request refuses a path with a query string"
+    else
+        fail "ob-sign-request refuses a path with a query string" "rc=$rc out=$out"
+    fi
+
+    # Two runs must not produce the same nonce: it is the portal's replay key.
+    local a b
+    a=$(printf '%s' '{}' | ob-sign-request --method POST --path /pam/whoami --config "$(write_conf 1 "$SECRET")" | grep X-Nonce)
+    b=$(printf '%s' '{}' | ob-sign-request --method POST --path /pam/whoami --config "$(write_conf 1 "$SECRET")" | grep X-Nonce)
+    if [ -n "$a" ] && [ "$a" != "$b" ]; then
+        pass "ob-sign-request generates a fresh nonce per call"
+    else
+        fail "ob-sign-request generates a fresh nonce per call" "$a / $b"
+    fi
+}
+
+# ── 7. The secret must not reach a command line ───────────────────────────────
+#
+# This is the reason ob-sign-request exists rather than `openssl dgst -hmac`.
+# argv is world-readable through /proc/<pid>/cmdline, and ob-heartbeat runs
+# from a timer, forever, on a host whose users have shells. A future edit that
+# "simplifies" the helper away would hand the fleet-wide signing secret to
+# anyone who polls, silently and with every test still green -- so the guard is
+# here rather than in a comment.
+test_no_secret_in_argv() {
+    local hits
+    hits=$(grep -nE 'dgst[^|]*-hmac|-macopt[[:space:]]*(hex)?key:' \
+        "$ROOT_DIR/scripts/ob-heartbeat" "$ROOT_DIR/scripts/ob-bastion-id" 2>/dev/null)
+    if [ -z "$hits" ]; then
+        pass "the /pam/ callers never put an HMAC key on a command line"
+    else
+        fail "the /pam/ callers never put an HMAC key on a command line" "$hits"
+    fi
+}
+
+# ── 8. Inventory: no endpoint creeps back in unsigned ─────────────────────────
+#
+# Item 4 of #247. Each row is "endpoint | file that calls it | what signing
+# looks like in that file". A new caller of a /pam/ endpoint that forgets to
+# sign fails here instead of being discovered when a portal turns `required`
+# on and the fleet stops renewing its tokens.
+test_every_caller_signs() {
+    local rows=(
+        "/pam/verify|src/ob_client.c|add_signing_headers"
+        "/pam/authorize|src/ob_client.c|add_signing_headers"
+        "/pam/heartbeat|src/ob_client.c|add_signing_headers"
+        "/pam/bastion-cert|src/ob-cert-daemon.c|ob_sign_compute"
+        "/pam/heartbeat|scripts/ob-heartbeat|ob_sign_request"
+        "/pam/whoami|scripts/ob-bastion-id|ob_sign_request"
+        "/pam/authorize|scripts/ob-enroll|ob_sign_request"
+        "/pam/userinfo|scripts/ob-session-monitor|ob_sign_request"
+    )
+    local row endpoint file marker ok=1 detail=""
+    for row in "${rows[@]}"; do
+        IFS='|' read -r endpoint file marker <<< "$row"
+        if ! grep -q -- "$endpoint" "$ROOT_DIR/$file"; then
+            ok=0; detail="$detail $file no longer calls $endpoint;"
+        elif ! grep -q -- "$marker" "$ROOT_DIR/$file"; then
+            ok=0; detail="$detail $file calls $endpoint without $marker;"
+        fi
+    done
+
+    # And the reverse direction: any *other* file that builds a /pam/ URL has
+    # to appear in the table above.
+    local known="src/ob_client.c src/ob-cert-daemon.c scripts/ob-heartbeat"
+    known="$known scripts/ob-bastion-id scripts/ob-enroll scripts/ob-session-monitor"
+    local f
+    while IFS= read -r f; do
+        case " $known " in
+            *" $f "*) continue ;;
+        esac
+        ok=0; detail="$detail $f calls a /pam/ endpoint and is not in the inventory;"
+    #
+    # Match where a request URL is BUILT, not where an endpoint is merely
+    # named: src/pam_openbastion.c mentions /pam/heartbeat in a log message
+    # and calls nothing. C builds it with snprintf("%s/pam/...", portal_url),
+    # shell with "${PORTAL_URL}/pam/..." or, in ob-bastion-id, the generic
+    # "${PORTAL_URL}${path}".
+    done < <(cd "$ROOT_DIR" && grep -rlE '"%s/pam/|\$\{PORTAL_URL\}(/pam/|\$\{path\})' \
+                 src scripts 2>/dev/null | sort -u)
+
+    if [ "$ok" = "1" ]; then
+        pass "every caller of a /pam/ endpoint signs it"
+    else
+        fail "every caller of a /pam/ endpoint signs it" "$detail"
+    fi
+}
+
+echo "=== Request signing, end to end (#247) ==="
+for t in test_heartbeat_required test_wrong_secret_is_refused \
+         test_unconfigured_is_unsigned test_unconfigured_optional \
+         test_whoami_required test_helper_contract \
+         test_no_secret_in_argv test_every_caller_signs; do
+    "$t"
+done
+
+TESTS_RUN=$((TESTS_PASSED + TESTS_FAILED))
+echo
+echo "Tests run: $TESTS_RUN, passed: $TESTS_PASSED, failed: $TESTS_FAILED"
+[ "$TESTS_FAILED" -eq 0 ]

--- a/tests/test_ob_request_signing.sh
+++ b/tests/test_ob_request_signing.sh
@@ -224,11 +224,7 @@ test_helper_contract() {
     local conf out rc
     conf=$(write_conf 1 "$SECRET")
 
-    out=$(printf '%s' '{"a":1}' | ob-sign-request --method POST --path /pam/heartbeat -c "$conf" 2>&1); rc=$?
-    if [ "$rc" != "0" ]; then
-        # -c is not the helper's spelling; --config is. Check the real one.
-        out=$(printf '%s' '{"a":1}' | ob-sign-request --method POST --path /pam/heartbeat --config "$conf" 2>&1); rc=$?
-    fi
+    out=$(printf '%s' '{"a":1}' | ob-sign-request --method POST --path /pam/heartbeat --config "$conf" 2>&1); rc=$?
     if [ "$rc" = "0" ] \
        && echo "$out" | grep -qE '^X-Timestamp: [0-9]+$' \
        && echo "$out" | grep -qE '^X-Nonce: [0-9A-Za-z._:-]+$' \
@@ -236,6 +232,17 @@ test_helper_contract() {
         pass "ob-sign-request prints the three headers"
     else
         fail "ob-sign-request prints the three headers" "rc=$rc out=$(echo "$out" | tr '\n' ' ')"
+    fi
+
+    # --config is the only spelling. ob-sign-lib.sh passes exactly this, so an
+    # unknown option must be refused rather than ignored -- a helper that
+    # skipped it would fall back to the default config path and sign with a
+    # secret the caller never asked for.
+    out=$(printf '%s' '{"a":1}' | ob-sign-request --method POST --path /pam/heartbeat -c "$conf" 2>&1); rc=$?
+    if [ "$rc" = "1" ]; then
+        pass "ob-sign-request refuses an unknown option"
+    else
+        fail "ob-sign-request refuses an unknown option" "rc=$rc out=$out"
     fi
 
     # Exit 3, not an error and not a signature: nothing is configured.

--- a/tests/test_ob_sign.c
+++ b/tests/test_ob_sign.c
@@ -176,11 +176,18 @@ static void write_conf(const char *dir, char *out, size_t out_size,
 {
     snprintf(out, out_size, "%s/openbastion.conf", dir);
     unlink(out);
-    int fd = open(out, O_WRONLY | O_CREAT | O_TRUNC, mode);
+    int fd = open(out, O_WRONLY | O_CREAT | O_EXCL, mode);
     if (fd < 0) { perror("open"); exit(1); }
     if (write(fd, content, strlen(content)) < 0) { perror("write"); exit(1); }
+    /*
+     * fchmod, not chmod: open() honours the umask, so the mode has to be set
+     * again, and doing it by name would re-resolve the path -- a different
+     * file could answer the second time. The whole point of these fixtures is
+     * the mode (0600 accepted, 0644 refused), so a fixture that sets it on
+     * something other than the file it just wrote would test nothing.
+     */
+    if (fchmod(fd, mode) != 0) { perror("fchmod"); exit(1); }
     close(fd);
-    if (chmod(out, mode) != 0) { perror("chmod"); exit(1); }
 }
 
 struct secret_case {

--- a/tests/test_ob_sign.c
+++ b/tests/test_ob_sign.c
@@ -1,0 +1,286 @@
+/*
+ * test_ob_sign.c - the request-signing wire format, pinned (#247)
+ *
+ * Copyright (C) 2025 Linagora
+ * License: AGPL-3.0
+ *
+ * Signing had no coverage at all before this file: the client had produced
+ * X-Signature-256 for a year and nothing on either side checked that it was
+ * the string the portal computes. When the portal started verifying
+ * (lemonldap-ng-plugins#93) a divergence stopped being cosmetic -- under
+ * pamAccessRequestSigningMode=required it refuses every call.
+ *
+ * The expected digests below are NOT computed by this program. They come from
+ * the portal's own implementation:
+ *
+ *   perl -MDigest::SHA=hmac_sha256_hex \
+ *        -e 'print hmac_sha256_hex("<message>", "<secret>")'
+ *
+ * which is literally what PamAccess.pm::_checkRequestSignature calls. Deriving
+ * them here from OpenSSL would only prove this file agrees with itself.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <sys/stat.h>
+
+#include "ob_sign.h"
+
+static int tests_run = 0;
+static int tests_passed = 0;
+
+#define CHECK(cond, name) do {                                             \
+    tests_run++;                                                           \
+    if (cond) { tests_passed++; printf("  PASS: %s\n", (name)); }          \
+    else      { printf("  FAIL: %s (%s:%d)\n", (name), __FILE__, __LINE__); } \
+} while (0)
+
+/*
+ * The reference secret carries a '#' and a space on purpose: '#' is what the
+ * config readers used to truncate at, and a secret is opaque bytes.
+ */
+static const char *SECRET = "s3cr#t key";
+static const char *NONCE  = "1700000000000-0123abcd-4567-89ab-cdef-0123456789ab";
+
+struct vector {
+    long        ts;
+    const char *nonce;
+    const char *method;
+    const char *path;
+    const char *body;
+    const char *expected;
+    const char *name;
+};
+
+static const struct vector VECTORS[] = {
+    { 1700000000, "1700000000000-0123abcd-4567-89ab-cdef-0123456789ab",
+      "POST", "/pam/heartbeat", "{\"a\":1}",
+      "0e832c0c99a587840e607ff8d331aafc7ecb67157beb7751c474412468d74dcc",
+      "reference vector matches the portal's Digest::SHA" },
+
+    /* A bodyless request signs the empty string, so the message still ends
+     * with the fourth separator. Getting this wrong is invisible until an
+     * endpoint with no body is signed -- which is what /pam/whoami is. */
+    { 1700000000, "1700000000000-0123abcd-4567-89ab-cdef-0123456789ab",
+      "POST", "/pam/heartbeat", "",
+      "2322d750c4750015b5cbbb37626816e75dadcd7c9d625cc0f723f4d1775fc607",
+      "empty body still signs the trailing separator" },
+
+    { 1700000000, "1700000000000-0123abcd-4567-89ab-cdef-0123456789ab",
+      "POST", "/pam/authorize", "{\"a\":1}",
+      "63ed8ea81e3ac39df50b6dc3478684eac0d4f4c389f4b4c0b69cfc1a0b849fe4",
+      "path is covered (a signature does not transfer between endpoints)" },
+
+    { 1700000000, "1700000000000-0123abcd-4567-89ab-cdef-0123456789ab",
+      "GET", "/pam/heartbeat", "{\"a\":1}",
+      "6ec97b5df12ab4d01bc6f5ba3f109ff471924b941ae89214c76a0caa88121ef3",
+      "method is covered" },
+
+    { 1700000001, "1700000000000-0123abcd-4567-89ab-cdef-0123456789ab",
+      "POST", "/pam/heartbeat", "{\"a\":1}",
+      "82a1c649b8a7ff623434f36c0e2076975f614a5cc8a6629a382c63d7f9165187",
+      "timestamp is covered" },
+
+    /* #188: the nonce MUST be inside the HMAC, or a captured request can be
+     * replayed with a fresh one. */
+    { 1700000000, "x", "POST", "/pam/heartbeat", "{\"a\":1}",
+      "27dcbb8a2f2de3d288514bedd2c55a158debbd16bda07f9ad6b3eb8e3f4339e5",
+      "nonce is covered" },
+};
+
+static void test_vectors(void)
+{
+    for (size_t i = 0; i < sizeof(VECTORS) / sizeof(VECTORS[0]); i++) {
+        const struct vector *v = &VECTORS[i];
+        char sig[OB_SIGN_SIGNATURE_SIZE];
+        ob_sign_compute(SECRET, v->ts, v->nonce, v->method, v->path, v->body,
+                        sig, sizeof(sig));
+        if (strcmp(sig, v->expected) != 0) {
+            printf("    got      %s\n    expected %s\n", sig, v->expected);
+        }
+        CHECK(strcmp(sig, v->expected) == 0, v->name);
+    }
+
+    /* NULL body and "" must be the same message: a caller that has no body
+     * may pass either. */
+    char a[OB_SIGN_SIGNATURE_SIZE], b[OB_SIGN_SIGNATURE_SIZE];
+    ob_sign_compute(SECRET, 1700000000, NONCE, "POST", "/pam/heartbeat", NULL,
+                    a, sizeof(a));
+    ob_sign_compute(SECRET, 1700000000, NONCE, "POST", "/pam/heartbeat", "",
+                    b, sizeof(b));
+    CHECK(strcmp(a, b) == 0 && strlen(a) == 64, "NULL body signs as empty body");
+
+    /* A body longer than the stack buffer takes the heap path; it must sign
+     * the same bytes. Cross-checked against the same Perl one-liner. */
+    char big[900];
+    memset(big, 'x', sizeof(big) - 1);
+    big[sizeof(big) - 1] = '\0';
+    char sig[OB_SIGN_SIGNATURE_SIZE];
+    ob_sign_compute(SECRET, 1700000000, NONCE, "POST", "/pam/heartbeat", big,
+                    sig, sizeof(sig));
+    CHECK(strlen(sig) == 64, "a body past the stack buffer still signs");
+}
+
+static void test_failures_are_empty(void)
+{
+    char sig[OB_SIGN_SIGNATURE_SIZE];
+
+    /*
+     * Every failure must yield an EMPTY signature, never a short or stale one:
+     * callers key "do not send" off exactly that, and the portal treats a
+     * partially signed request as malformed in every mode, including 'off'.
+     */
+    memset(sig, 'A', sizeof(sig));
+    ob_sign_compute(NULL, 1, NONCE, "POST", "/x", "", sig, sizeof(sig));
+    CHECK(sig[0] == '\0', "no secret yields an empty signature");
+
+    memset(sig, 'A', sizeof(sig));
+    ob_sign_compute(SECRET, 1, "", "POST", "/x", "", sig, sizeof(sig));
+    CHECK(sig[0] == '\0', "empty nonce yields an empty signature");
+
+    memset(sig, 'A', sizeof(sig));
+    ob_sign_compute(SECRET, 1, NONCE, "POST", "/x", "", sig, 8);
+    CHECK(sig[0] == '\0', "a buffer too small yields an empty signature");
+}
+
+static void test_nonce(void)
+{
+    char n1[OB_SIGN_NONCE_SIZE], n2[OB_SIGN_NONCE_SIZE];
+
+    ob_sign_generate_nonce(n1, sizeof(n1));
+    ob_sign_generate_nonce(n2, sizeof(n2));
+
+    CHECK(strlen(n1) > 20 && strcmp(n1, n2) != 0, "nonces are non-empty and distinct");
+
+    /* The portal accepts [0-9A-Za-z._:-]{1,128} and nothing else. */
+    int ok = strlen(n1) <= 128;
+    for (const char *p = n1; *p && ok; p++) {
+        ok = (*p >= '0' && *p <= '9') || (*p >= 'A' && *p <= 'Z')
+             || (*p >= 'a' && *p <= 'z') || *p == '.' || *p == '_'
+             || *p == ':' || *p == '-';
+    }
+    CHECK(ok, "nonce matches the character class the portal accepts");
+
+    char small[8];
+    memset(small, 'A', sizeof(small));
+    ob_sign_generate_nonce(small, sizeof(small));
+    CHECK(small[0] == '\0', "a buffer too small yields an empty nonce");
+}
+
+/* Write a 0600 config file in `dir` and return its path in `out`. */
+static void write_conf(const char *dir, char *out, size_t out_size,
+                       const char *content, mode_t mode)
+{
+    snprintf(out, out_size, "%s/openbastion.conf", dir);
+    unlink(out);
+    int fd = open(out, O_WRONLY | O_CREAT | O_TRUNC, mode);
+    if (fd < 0) { perror("open"); exit(1); }
+    if (write(fd, content, strlen(content)) < 0) { perror("write"); exit(1); }
+    close(fd);
+    if (chmod(out, mode) != 0) { perror("chmod"); exit(1); }
+}
+
+struct secret_case {
+    const char *content;
+    int         rc;
+    const char *want;
+    const char *name;
+};
+
+static void test_load_secret(const char *dir)
+{
+    /*
+     * The rule config.c applies to an opaque secret, restated: everything
+     * after the first '=', trimmed, minus at most one layer of matching
+     * quotes, and NO inline-comment stripping. Every reader that got this
+     * wrong produced a valid-looking signature over the wrong key, which the
+     * portal reports as bad_signature -- indistinguishable from a
+     * misconfigured portal.
+     */
+    static const struct secret_case CASES[] = {
+        { "request_signing_secret = plain\n", 0, "plain", "plain value" },
+        { "request_signing_secret = a#b\n", 0, "a#b",
+          "'#' inside the value is kept" },
+        { "request_signing_secret = a # b\n", 0, "a # b",
+          "' #' does not start a comment in a secret" },
+        { "request_signing_secret = \"a # b\"\n", 0, "a # b",
+          "one layer of double quotes is removed" },
+        { "request_signing_secret = 'a # b'\n", 0, "a # b",
+          "one layer of single quotes is removed" },
+        { "request_signing_secret =    spaced   \n", 0, "spaced",
+          "surrounding whitespace is trimmed" },
+        { "portal_url = https://x\nrequest_signing_secret = s\n", 0, "s",
+          "found among other keys" },
+        { "request_signing_secret = first\nrequest_signing_secret = last\n",
+          0, "last", "the last assignment wins, as in config.c" },
+        { "portal_url = https://x\n", 1, NULL,
+          "absent is not an error: signing is optional" },
+        { "request_signing_secret =\n", 1, NULL, "empty counts as absent" },
+    };
+
+    char path[512];
+    for (size_t i = 0; i < sizeof(CASES) / sizeof(CASES[0]); i++) {
+        write_conf(dir, path, sizeof(path), CASES[i].content, 0600);
+        char *secret = NULL;
+        int rc = ob_sign_load_secret(path, &secret);
+        int ok = (rc == CASES[i].rc)
+                 && (CASES[i].want ? (secret && strcmp(secret, CASES[i].want) == 0)
+                                   : (secret == NULL));
+        if (!ok) {
+            printf("    rc=%d secret=%s\n", rc, secret ? secret : "(null)");
+        }
+        CHECK(ok, CASES[i].name);
+        free(secret);
+    }
+
+    /* Group- or world-readable: the secret is already compromised, and a file
+     * anyone can write is a signature anyone can forge. Refuse it. */
+    write_conf(dir, path, sizeof(path), "request_signing_secret = s\n", 0644);
+    char *secret = NULL;
+    CHECK(ob_sign_load_secret(path, &secret) < 0 && secret == NULL,
+          "a group/world-readable config is refused");
+
+    snprintf(path, sizeof(path), "%s/does-not-exist.conf", dir);
+    secret = NULL;
+    CHECK(ob_sign_load_secret(path, &secret) < 0 && secret == NULL,
+          "a missing config is an error, not a silent 'no secret'");
+
+    /* A value truncated by the line limit would sign with the wrong key. */
+    char *big = malloc(4096);
+    if (!big) exit(1);
+    strcpy(big, "request_signing_secret = ");
+    memset(big + strlen(big), 'z', 2000);
+    strcpy(big + 25 + 2000, "\n");
+    write_conf(dir, path, sizeof(path), big, 0600);
+    free(big);
+    secret = NULL;
+    CHECK(ob_sign_load_secret(path, &secret) < 0 && secret == NULL,
+          "an over-long secret line is refused, not truncated");
+}
+
+int main(void)
+{
+    printf("=== ob_sign: request signing wire format ===\n");
+
+    char dir[] = "/tmp/test_ob_sign_XXXXXX";
+    if (mkdtemp(dir) == NULL) {
+        perror("mkdtemp");
+        return 1;
+    }
+
+    test_vectors();
+    test_failures_are_empty();
+    test_nonce();
+    test_load_secret(dir);
+
+    char path[512];
+    snprintf(path, sizeof(path), "%s/openbastion.conf", dir);
+    unlink(path);
+    rmdir(dir);
+
+    printf("\n%d/%d passed\n", tests_passed, tests_run);
+    return (tests_passed == tests_run) ? 0 : 1;
+}

--- a/tests/test_ob_sign.c
+++ b/tests/test_ob_sign.c
@@ -137,6 +137,16 @@ static void test_failures_are_empty(void)
     ob_sign_compute(NULL, 1, NONCE, "POST", "/x", "", sig, sizeof(sig));
     CHECK(sig[0] == '\0', "no secret yields an empty signature");
 
+    /*
+     * config_load() strdup's whatever follows the '=', so `request_signing_secret =`
+     * reaches the PAM module as "" and not NULL. An empty HMAC key is forgeable
+     * by anyone; refusing it here is what keeps the module, the daemon and the
+     * shell callers from disagreeing about the same degenerate config.
+     */
+    memset(sig, 'A', sizeof(sig));
+    ob_sign_compute("", 1, NONCE, "POST", "/x", "", sig, sizeof(sig));
+    CHECK(sig[0] == '\0', "an empty secret counts as absent, not as a key");
+
     memset(sig, 'A', sizeof(sig));
     ob_sign_compute(SECRET, 1, "", "POST", "/x", "", sig, sizeof(sig));
     CHECK(sig[0] == '\0', "empty nonce yields an empty signature");


### PR DESCRIPTION
Closes the signing gap of #247.

## What was wrong

The portal verifies `X-Signature-256` in `_checkCaller`
(`PamAccess.pm:1125`), **before** it looks at any caller identity — so the
gate covers all six `/pam/` endpoints, including the one that carries no
Bearer token. This side signed two.

`/pam/heartbeat` is the dangerous one. It is how every enrolled host renews
its access token, so switching the portal to `required` broke nothing at the
moment of the change and took the whole fleet down hours later, together, as
the tokens still in hand expired.

## The `/pam/heartbeat` secret question, answered

#247 called this "a new decision about which secret is in play". It is not a
decision: `_checkRequestSignature` reads a single portal-wide
`pamAccessRequestSigningSecret` (`PamAccess.pm:963`) and never resolves a
caller before checking it. The signature proves fleet membership; it does not
name a caller. So `/pam/heartbeat` signs with the same `request_signing_secret`
from the same file as everything else — which is also why the check works on an
endpoint with no `Authorization` header at all.

## Three call sites the issue did not have

The inventory test written for item 4 found them immediately:

- **`scripts/ob-heartbeat`** POSTs `/pam/heartbeat`. The issue's table listed
  only `src/ob_client.c` for that endpoint, and the shell half is the one that
  runs from a systemd timer, every few minutes, forever.
- **`ob-enroll:665`** POSTs `/pam/authorize` to verify a fresh enrolment. Under
  `required` every enrolment would have reported "could not verify".
- **`ob-session-monitor:136`** POSTs `/pam/userinfo` — the endpoint #247
  recorded as having no caller. Its loop **terminates sessions** for users the
  portal no longer knows, so under `required` it would have started reporting
  every user as gone.

So the real count was 8 call sites over 6 endpoints, not 6 over 6.

## Why a helper binary and not `openssl dgst -hmac`

#247 offered the choice. `openssl dgst -sha256 -hmac "$secret"` takes the key
as a command-line argument, and OpenSSL has no form that reads it from a file
or the environment. `/proc/<pid>/cmdline` is world-readable, and `ob-heartbeat`
runs from a timer every few minutes, forever, on a host whose entire purpose is
to give other people a shell. That one-liner publishes the fleet-wide signing
secret to anyone who polls — and a secret an attacker can read is a signature
an attacker can forge, which is the whole value of the mechanism. The signed
body carries this host's `refresh_token`, so it goes on stdin for the same
reason.

`ob-sign-request` (root, **not** setuid — every caller is already root) reads
the secret from the root-only config, takes the body on stdin, and prints only
the MAC and its inputs. `scripts/ob-sign-lib.sh` is the shared shell interface.
`ob-enroll` still signs its own `client_secret_jwt` with
`openssl dgst -hmac` — same exposure class, admin-run and one-shot rather than
on a timer; out of scope here, worth its own issue.

## A bug found on the way

`config.c` exempts opaque secrets from inline-comment stripping, because `#` is
an ordinary character in a generated secret. The three other readers of that
file did not: `ob-cert-daemon`'s `load_ini` cut at the first `#` anywhere on the
line, and the `awk`/`sed` readers in `ob-heartbeat` and `ob-bastion-id` cut at
any `#` in the value. A secret containing one would have produced a
valid-looking signature over the wrong key — reported by the portal as
`bad_signature`, indistinguishable from a misconfigured portal. There is now one
reader for this key outside `config.c`, and its rule is pinned by a test.

## Tests

Signing had **no** coverage at all before this.

- `tests/test_ob_sign.c` (27 assertions) pins the wire format against digests
  produced by `Digest::SHA`'s `hmac_sha256_hex` — the function `PamAccess.pm`
  itself calls — rather than recomputing them with OpenSSL, which would only
  prove the file agrees with itself. It covers the trailing separator a bodyless
  request signs (`/pam/whoami` is one) and that timestamp, nonce, method and
  path are each inside the MAC.
- `tests/test_ob_request_signing.sh` (11 assertions) runs `ob-heartbeat` and
  `ob-bastion-id` against a mock portal that verifies the HMAC itself
  (`tests/mock_portal_signing.py`, a transcription of
  `_checkRequestSignature`). It asserts the wrong secret is refused — otherwise
  the happy path would pass against a mock that accepts anything — that an
  unconfigured host is refused under `required` and works under `optional`, and
  that no `/pam/` caller puts an HMAC key on a command line. Its last case walks
  the tree for anything building a `/pam/` URL and fails if it is not in the
  signed inventory: item 4 of the issue, as a test rather than a promise.

Local: `ctest` 22/22, all 26 `tests/test_ob_*.sh` pass, `cmake --install` places
the binary, the library and the man page.

## Failure policy

A signing failure now fails the request instead of falling back to an unsigned
one — the portal reads a partially signed request as malformed in **every**
mode, and an operator who configured a secret asked for the call to be signed.
The exception is `ob-session-monitor`: "we could not ask" must not become "the
user is gone", since a non-zero return there kills live sessions.

`UPGRADE-NOTES.md` § 3 now documents `required` as deployable **and the order
that makes it safe** — upgrade the hosts, `optional`, roll the secret out,
confirm every host signs, then `required` — instead of saying not to.

https://claude.ai/code/session_011q88Fs4nFuUs7JMvmgbBTN

