### PR TITLE
fix(session-monitor): tell "the user is gone" apart from "we could not ask"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- **`ob-session-monitor` no longer terminates sessions because it failed to
+  reach the portal (#257).** `check_user_valid()` ended its call with
+  `curl -sf ... || return 1`, and the caller reads a non-zero return as "this
+  user was revoked" — it runs `loginctl terminate-session` on their live
+  sessions and deletes their offline marker. But `curl -sf` fails on a
+  connection error, a DNS or TLS failure, the 10-second timeout **and on any
+  HTTP status >= 400**, so a portal answering 500, a rate limit, or a
+  `SERVER_TOKEN` that expired overnight and got a 401 all terminated every
+  offline session while logging "no longer valid on LLNG" — which was not true.
+
+  The reachability probe in the main loop did not cover this: `check_portal()`
+  fetches `/desktop/login?check=1`, so a healthy front end says nothing about
+  whether `/pam/userinfo` works. Nor did the one-hour `MAX_SSO_UNREACHABLE`
+  grace period, which this path skipped entirely.
+
+  `check_user_valid()` now has three outcomes — valid, revoked, unknown — and
+  only a portal that actually answered `found: false` can terminate anything. A
+  `/pam/userinfo` that stays unusable still converges on the same one-hour bound
+  as Part D, through its own counter: the existing one is reset by
+  `check_portal()` on every cycle, so sharing it would have meant never
+  converging at all. A 401 or 403 is logged as our own credentials being
+  refused, naming the server token and the heartbeat timer, rather than as a
+  generic failure.
+
 - **The SSH fingerprint spool no longer trusts `nobody` (#249).**
   `pam_openbastion` recovers the fingerprint of the key that authenticated a
   session from `/run/open-bastion/ssh-fp/<anchor>.fp`, because OpenSSH does not

--- a/scripts/ob-session-monitor
+++ b/scripts/ob-session-monitor
@@ -38,6 +38,12 @@ MAX_SSO_UNREACHABLE=3600    # 1 hour
 
 # State
 sso_unreachable_since=0
+# Separate from sso_unreachable_since on purpose (#257): check_portal() resets
+# that one every time the front end answers, so a working /desktop/login would
+# wipe the counter each cycle and a permanently broken /pam/userinfo would never
+# converge on any bound at all.
+userinfo_unusable_since=0
+userinfo_unusable=false
 
 # Verify required dependencies
 for cmd in curl jq loginctl; do
@@ -136,6 +142,26 @@ check_network() {
 }
 
 # Check if a user is still valid on LLNG
+# Ask the portal whether a user is still valid.
+#
+# THREE outcomes, not two (#257). "The portal says this user is gone" and "we
+# could not ask the portal" are different answers, and the caller terminates
+# live sessions on the first one:
+#
+#   0  valid    -- the portal answered, found: true
+#   1  revoked  -- the portal answered, and the answer is not "found"
+#   2  unknown  -- we could not ask, or could not understand the reply
+#
+# Until #257 every failure returned 1. `curl -sf` fails on a connection error, a
+# DNS or TLS failure, the timeout AND on any HTTP status >= 400, so a portal
+# returning 500, a rate limit, or an expired SERVER_TOKEN answering 401 all
+# terminated every offline session while logging "no longer valid on LLNG" --
+# a statement that was not true. The reachability probe in the main loop does
+# not cover this: it fetches /desktop/login, a different endpoint, so a healthy
+# front end says nothing about /pam/userinfo.
+#
+# `-f` is therefore gone: we need to tell an HTTP error apart from a transport
+# failure, and from a 200 that genuinely says the user is revoked.
 check_user_valid() {
     local user="$1"
     local auth_header=""
@@ -154,28 +180,56 @@ check_user_valid() {
     # shellcheck disable=SC2034
     OB_SIGN_CONFIG="$CONFIG_FILE"
     if ! ob_sign_request POST /pam/userinfo "$payload"; then
-        # "we could not ask" is not "the user is gone": a non-zero return here
-        # reaches the caller as an invalid user and terminates live sessions.
-        # A local signing misconfiguration must not do that.
-        log_warn "$OB_SIGN_ERROR -- treating $user as still valid"
-        return 0
+        log_warn "$OB_SIGN_ERROR -- cannot ask about $user"
+        return 2
     fi
 
-    local response
-    response=$(curl -sf -m 10 \
+    local raw curl_rc=0
+    raw=$(curl -s -m 10 -w '\n%{http_code}' \
         -H "Content-Type: application/json" \
         ${auth_header:+-H "$auth_header"} \
         "${SIGN_HEADERS[@]}" \
         -d "$payload" \
-        "${PORTAL_URL}/pam/userinfo" 2>/dev/null) || return 1
+        "${PORTAL_URL}/pam/userinfo" 2>/dev/null) || curl_rc=$?
 
-    # Check if user is found
-    local found
-    found=$(echo "$response" | jq -r '.found // empty' 2>/dev/null)
-    if [ "$found" = "true" ]; then
-        return 0
+    if [ "$curl_rc" -ne 0 ]; then
+        log_warn "cannot reach ${PORTAL_URL}/pam/userinfo (curl exit $curl_rc) -- $user left alone"
+        return 2
     fi
-    return 1
+
+    local http_code body
+    http_code=${raw##*$'\n'}
+    body=${raw%$'\n'*}
+
+    case "$http_code" in
+        200) ;;
+        401|403)
+            # Our credentials, not the user's status. A SERVER_TOKEN that died
+            # overnight because the heartbeat timer was not armed is a bug this
+            # project has shipped before (#159); it must not read as "every user
+            # was revoked".
+            log_crit "portal refused our own credentials on /pam/userinfo (HTTP $http_code): check the server token and the heartbeat timer -- $user left alone"
+            return 2 ;;
+        *)
+            log_warn "/pam/userinfo answered HTTP $http_code -- $user left alone"
+            return 2 ;;
+    esac
+
+    # NOT `.found // empty`: jq's alternative operator treats `false` as empty,
+    # so a genuine "found": false would come back indistinguishable from a
+    # missing field. That did not matter while every non-true answer meant the
+    # same thing; with three verdicts it would turn every revocation into
+    # "unknown" and the user would keep their session forever.
+    local found
+    found=$(echo "$body" | jq -r 'if has("found") then (.found|tostring) else "missing" end' 2>/dev/null)
+    case "$found" in
+        true)  return 0 ;;
+        false) return 1 ;;
+        *)
+            # A 200 we cannot parse is not a verdict either.
+            log_warn "/pam/userinfo returned an answer without a usable 'found' field -- $user left alone"
+            return 2 ;;
+    esac
 }
 
 # Get age of offline credential cache for a user
@@ -197,6 +251,7 @@ get_cache_age() {
 
 # Revalidate all offline sessions
 revalidate_sessions() {
+    userinfo_unusable=false
     if [ ! -d "$MARKER_DIR" ]; then
         return
     fi
@@ -242,8 +297,19 @@ revalidate_sessions() {
             continue
         fi
 
-        # Check if user is still valid on LLNG
-        if check_user_valid "$user"; then
+        # Check if user is still valid on LLNG. Three outcomes (#257): the
+        # `unknown` one must not terminate anything.
+        local verdict=0
+        check_user_valid "$user" || verdict=$?
+        if [ "$verdict" -eq 2 ]; then
+            # We could not ask. Leave the session alone, but remember it: a
+            # /pam/userinfo that stays unusable is still a reason to stop
+            # trusting offline sessions eventually -- see the counter below,
+            # which mirrors Part D's bound rather than tolerating it forever.
+            userinfo_unusable=true
+            continue
+        fi
+        if [ "$verdict" -eq 0 ]; then
             log_debug "User $user is valid on LLNG"
 
             # Check cache age
@@ -277,6 +343,60 @@ revalidate_sessions() {
             # Clean up marker
             rm -f "$MARKER_DIR/$user"
         fi
+    done
+}
+
+# /pam/userinfo unusable while the portal front end answers (#257).
+#
+# Mirrors Part D's bound rather than inventing a new one: leaving a session
+# alive forever because the endpoint that would revoke it is broken is the same
+# hole Part D exists to close, just reached by a different route. The message is
+# deliberately different from Part D's, because the operator has to look in a
+# different place -- the portal is up, it is the pam-access route or our own
+# credentials that are not.
+handle_userinfo_unusable() {
+    local now
+    now=$(date +%s)
+
+    if [ "$userinfo_unusable_since" -eq 0 ]; then
+        userinfo_unusable_since=$now
+        log_warn "/pam/userinfo is unusable although the portal answers; sessions left alone for now"
+        return
+    fi
+
+    local duration=$(( now - userinfo_unusable_since ))
+    if [ "$duration" -lt "$MAX_SSO_UNREACHABLE" ]; then
+        log_warn "/pam/userinfo unusable for ${duration}s (max: ${MAX_SSO_UNREACHABLE}s)"
+        return
+    fi
+
+    log_crit "/pam/userinfo unusable for ${duration}s, terminating all offline sessions"
+    if [ ! -d "$MARKER_DIR" ]; then
+        return
+    fi
+    local marker_path
+    for marker_path in "$MARKER_DIR"/*; do
+        [ -e "$marker_path" ] || continue
+        local user_file
+        user_file=$(basename "$marker_path")
+        case "$user_file" in
+            *.* ) continue ;;
+        esac
+
+        local user="$user_file"
+        log_crit "Terminating offline session for $user (/pam/userinfo unusable for ${duration}s)"
+
+        while IFS= read -r line; do
+            local session_id
+            session_id=$(echo "$line" | awk '{print $1}')
+            local session_user
+            session_user=$(loginctl show-session "$session_id" -p Name --value 2>/dev/null) || continue
+            if [ "$session_user" = "$user" ]; then
+                loginctl terminate-session "$session_id" 2>/dev/null || true
+            fi
+        done < <(loginctl list-sessions --no-legend 2>/dev/null)
+
+        rm -f "$MARKER_DIR/$user"
     done
 }
 
@@ -376,6 +496,12 @@ main() {
         if [ "$network_up" = "true" ] && [ "$sso_up" = "true" ]; then
             # Network and SSO both up: revalidate offline sessions
             revalidate_sessions
+            if [ "$userinfo_unusable" = "true" ]; then
+                handle_userinfo_unusable
+            elif [ "$userinfo_unusable_since" -gt 0 ]; then
+                log_info "/pam/userinfo is usable again"
+                userinfo_unusable_since=0
+            fi
         elif [ "$network_up" = "true" ] && [ "$sso_up" = "false" ]; then
             # Network up but SSO down: potential firewall bypass (Part D)
             handle_sso_unreachable

--- a/tests/test_ob_session_monitor.sh
+++ b/tests/test_ob_session_monitor.sh
@@ -1,0 +1,263 @@
+#!/bin/bash
+# test_ob_session_monitor.sh
+#
+# Guards the verdict semantics of check_user_valid (issue #257).
+#
+# The loop this function feeds calls `loginctl terminate-session` on live user
+# sessions. Until #257 it had two outcomes: valid, and everything else. Because
+# `curl -sf` fails on a connection error, a DNS or TLS failure, the timeout AND
+# on any HTTP status >= 400, a portal answering 500, a rate limit, or an expired
+# SERVER_TOKEN answering 401 all read as "the user was revoked" -- and killed
+# their sessions while logging "no longer valid on LLNG", which was false.
+#
+# The reachability probe in the main loop does not cover it: check_portal()
+# fetches /desktop/login?check=1, a different endpoint, so a healthy front end
+# says nothing about whether /pam/userinfo works.
+#
+# What is asserted here is the distinction itself:
+#
+#   0  valid    -- 200 with found: true
+#   1  revoked  -- 200 with found: false, the only case that may terminate
+#   2  unknown  -- connection refused, timeout, 401, 403, 500, unparseable body
+#
+# The function is sourced out of the script rather than reimplemented, so the
+# test breaks when the shipped code changes rather than when a copy of it does.
+
+set -uo pipefail
+
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+SCRIPT="$ROOT_DIR/scripts/ob-session-monitor"
+
+pass() { TESTS_PASSED=$((TESTS_PASSED + 1)); echo "  PASS: $1"; }
+fail() { TESTS_FAILED=$((TESTS_FAILED + 1)); echo "  FAIL: $1${2:+ - $2}"; }
+run_test() { TESTS_RUN=$((TESTS_RUN + 1)); "$@"; }
+
+command -v curl >/dev/null 2>&1 || { echo "SKIP: curl is required"; exit 0; }
+command -v jq >/dev/null 2>&1 || { echo "SKIP: jq is required"; exit 0; }
+command -v python3 >/dev/null 2>&1 || { echo "SKIP: python3 is required"; exit 0; }
+
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"; [ -n "${MOCK_PID:-}" ] && kill "$MOCK_PID" 2>/dev/null' EXIT
+
+# A portal that answers /pam/userinfo however the test tells it to.
+cat > "$WORK/mock.py" <<'MOCK'
+import json, sys
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+MODE = sys.argv[1]
+PORT = int(sys.argv[2])
+
+class H(BaseHTTPRequestHandler):
+    def log_message(self, *a):
+        pass
+
+    def do_POST(self):
+        n = int(self.headers.get("Content-Length", 0))
+        self.rfile.read(n)
+        if MODE == "valid":
+            body, code = json.dumps({"found": True}), 200
+        elif MODE == "revoked":
+            body, code = json.dumps({"found": False}), 200
+        elif MODE == "unauthorized":
+            body, code = json.dumps({"error": "invalid_token"}), 401
+        elif MODE == "forbidden":
+            body, code = json.dumps({"error": "forbidden"}), 403
+        elif MODE == "server_error":
+            body, code = "upstream exploded", 500
+        elif MODE == "garbage":
+            body, code = "not json at all", 200
+        elif MODE == "no_found_field":
+            body, code = json.dumps({"user": "alice"}), 200
+        else:
+            body, code = "?", 500
+        raw = body.encode()
+        self.send_response(code)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(raw)))
+        self.end_headers()
+        self.wfile.write(raw)
+
+HTTPServer(("127.0.0.1", PORT), H).serve_forever()
+MOCK
+
+# Pull check_user_valid out of the shipped script, with just enough scaffolding
+# around it. Sourcing the whole script would start its main loop.
+extract_function() {
+    awk '/^check_user_valid\(\) \{/{f=1} f{print} f&&/^\}$/{exit}' "$SCRIPT"
+}
+
+PORT=18257
+run_case() {
+    local mode="$1"
+    PORT=$((PORT + 1))
+
+    python3 "$WORK/mock.py" "$mode" "$PORT" & MOCK_PID=$!
+    for _ in $(seq 1 50); do
+        (echo > "/dev/tcp/127.0.0.1/$PORT") 2>/dev/null && break
+        sleep 0.1
+    done
+
+    {
+        echo 'set -uo pipefail'
+        echo "PORTAL_URL='http://127.0.0.1:$PORT'"
+        echo "CONFIG_FILE='$WORK/ob.conf'"
+        echo 'SERVER_TOKEN=""'
+        echo 'SIGN_HEADERS=()'
+        echo 'ob_sign_request() { SIGN_HEADERS=(); return 0; }'
+        echo 'log_warn() { echo "WARN: $*" >&2; }'
+        echo 'log_crit() { echo "CRIT: $*" >&2; }'
+        echo 'log_debug() { :; }'
+        extract_function
+        echo 'check_user_valid alice; echo "VERDICT=$?"'
+    } > "$WORK/case.sh"
+
+    CASE_OUT=$(bash "$WORK/case.sh" 2>&1)
+    kill "$MOCK_PID" 2>/dev/null; wait "$MOCK_PID" 2>/dev/null; MOCK_PID=""
+    CASE_VERDICT=$(printf '%s' "$CASE_OUT" | sed -n 's/^VERDICT=//p' | tail -1)
+}
+
+# The one case that needs no server: nothing is listening.
+run_unreachable_case() {
+    PORT=$((PORT + 1))
+    {
+        echo 'set -uo pipefail'
+        echo "PORTAL_URL='http://127.0.0.1:$PORT'"
+        echo "CONFIG_FILE='$WORK/ob.conf'"
+        echo 'SERVER_TOKEN=""'
+        echo 'SIGN_HEADERS=()'
+        echo 'ob_sign_request() { SIGN_HEADERS=(); return 0; }'
+        echo 'log_warn() { echo "WARN: $*" >&2; }'
+        echo 'log_crit() { echo "CRIT: $*" >&2; }'
+        echo 'log_debug() { :; }'
+        extract_function
+        echo 'check_user_valid alice; echo "VERDICT=$?"'
+    } > "$WORK/case.sh"
+    CASE_OUT=$(bash "$WORK/case.sh" 2>&1)
+    CASE_VERDICT=$(printf '%s' "$CASE_OUT" | sed -n 's/^VERDICT=//p' | tail -1)
+}
+
+expect() {
+    local mode="$1" want="$2" label="$3"
+    if [ "$mode" = "__unreachable__" ]; then
+        run_unreachable_case
+    else
+        run_case "$mode"
+    fi
+    if [ "$CASE_VERDICT" = "$want" ]; then
+        pass "$label"
+    else
+        fail "$label" "verdict=$CASE_VERDICT expected=$want out=$(printf '%s' "$CASE_OUT" | tr '\n' ' ')"
+    fi
+}
+
+echo "=== ob-session-monitor: check_user_valid verdicts (issue #257) ==="
+
+# ── The two real answers ─────────────────────────────────────────────────────
+run_test expect valid    0 "200 found:true  -> valid (0)"
+run_test expect revoked  1 "200 found:false -> revoked (1), the only case that may terminate"
+
+# ── Everything that is not an answer ─────────────────────────────────────────
+# Each of these returned 1 before #257 and terminated the user's sessions.
+run_test expect __unreachable__ 2 "connection refused -> unknown (2), not revoked"
+run_test expect server_error    2 "HTTP 500 -> unknown (2), not revoked"
+run_test expect unauthorized    2 "HTTP 401 (our own token) -> unknown (2), not revoked"
+run_test expect forbidden       2 "HTTP 403 -> unknown (2), not revoked"
+run_test expect garbage         2 "200 with an unparseable body -> unknown (2)"
+run_test expect no_found_field  2 "200 without a 'found' field -> unknown (2)"
+
+# ── A 401 must be diagnosed, not just survived ───────────────────────────────
+# Every non-answer yields verdict 2, so the verdict alone cannot tell an expired
+# SERVER_TOKEN from a network blip -- with `curl -f` both land in the transport
+# branch and are indistinguishable. Dropping `-f` is what buys the operator a
+# message naming the actual cause, and this is what keeps it: an expired server
+# token, from a heartbeat timer that never armed, is a failure this project has
+# already shipped once (#159), and "check the server token" is the sentence that
+# saves the next hour.
+test_401_names_the_cause() {
+    run_case unauthorized
+    if [ "$CASE_VERDICT" = "2" ] \
+       && printf '%s' "$CASE_OUT" | grep -q "refused our own credentials"; then
+        pass "a 401 is reported as our credentials, not as a generic failure"
+    else
+        fail "a 401 is reported as our credentials, not as a generic failure" \
+             "out=$(printf '%s' "$CASE_OUT" | tr '\n' ' ')"
+    fi
+}
+run_test test_401_names_the_cause
+
+# ── A signing failure is not a verdict either ────────────────────────────────
+test_signing_failure_is_unknown() {
+    {
+        echo 'set -uo pipefail'
+        echo "PORTAL_URL='http://127.0.0.1:1'"
+        echo "CONFIG_FILE='$WORK/ob.conf'"
+        echo 'SERVER_TOKEN=""'
+        echo 'SIGN_HEADERS=()'
+        echo 'OB_SIGN_ERROR="cannot sign /pam/userinfo: boom"'
+        echo 'ob_sign_request() { return 1; }'
+        echo 'log_warn() { echo "WARN: $*" >&2; }'
+        echo 'log_crit() { echo "CRIT: $*" >&2; }'
+        echo 'log_debug() { :; }'
+        extract_function
+        echo 'check_user_valid alice; echo "VERDICT=$?"'
+    } > "$WORK/case.sh"
+    local out verdict
+    out=$(bash "$WORK/case.sh" 2>&1)
+    verdict=$(printf '%s' "$out" | sed -n 's/^VERDICT=//p' | tail -1)
+    if [ "$verdict" = "2" ]; then
+        pass "a local signing failure -> unknown (2), and no request is sent"
+    else
+        fail "a local signing failure -> unknown (2)" "verdict=$verdict"
+    fi
+}
+run_test test_signing_failure_is_unknown
+
+# ── The caller must act on the distinction ───────────────────────────────────
+# A three-valued check_user_valid is worthless if the caller still writes
+# `if check_user_valid`, which treats 1 and 2 alike.
+test_caller_distinguishes_unknown() {
+    if grep -qE '^\s*if check_user_valid "\$user"; then' "$SCRIPT"; then
+        fail "the caller distinguishes unknown from revoked" \
+             "still uses 'if check_user_valid', which folds 2 into 1"
+        return
+    fi
+    if grep -qF '"$verdict" -eq 2' "$SCRIPT" \
+       && grep -qF 'check_user_valid "$user" || verdict=$?' "$SCRIPT"; then
+        pass "the caller distinguishes unknown from revoked"
+    else
+        fail "the caller distinguishes unknown from revoked" \
+             "no verdict==2 branch found"
+    fi
+}
+run_test test_caller_distinguishes_unknown
+
+# ── An unusable endpoint still converges on a bound ──────────────────────────
+# Leaving sessions alive forever because the endpoint that would revoke them is
+# broken is the hole Part D exists to close, reached by another route.
+test_unknown_still_bounded() {
+    local missing=""
+    grep -q "handle_userinfo_unusable" "$SCRIPT" || missing="$missing handler"
+    grep -q "userinfo_unusable_since" "$SCRIPT" || missing="$missing counter"
+    grep -q 'duration" -lt "\$MAX_SSO_UNREACHABLE' "$SCRIPT" || missing="$missing bound"
+    # The counter must NOT be the one check_portal resets, or a working front
+    # end wipes it every cycle and it never converges.
+    if grep -q "userinfo_unusable_since=0" "$SCRIPT" \
+       && grep -A3 "^check_portal()" "$SCRIPT" | grep -q "userinfo_unusable_since"; then
+        missing="$missing shares-check_portal-reset"
+    fi
+    if [ -z "$missing" ]; then
+        pass "a persistently unusable /pam/userinfo still terminates after MAX_SSO_UNREACHABLE"
+    else
+        fail "a persistently unusable /pam/userinfo still terminates after MAX_SSO_UNREACHABLE" \
+             "$missing"
+    fi
+}
+run_test test_unknown_still_bounded
+
+echo
+echo "Tests run: $((TESTS_PASSED + TESTS_FAILED)), passed: $TESTS_PASSED, failed: $TESTS_FAILED"
+[ "$TESTS_FAILED" -eq 0 ]


### PR DESCRIPTION
Closes #257.

## What was wrong

`check_user_valid()` ended its portal call with:

```sh
    response=$(curl -sf -m 10 ... "${PORTAL_URL}/pam/userinfo" 2>/dev/null) || return 1
```

and the caller reads a non-zero return as an authoritative revocation — it runs
`loginctl terminate-session` on that user's **live sessions** and deletes their
offline marker, logging `User X no longer valid on LLNG`.

`curl -sf` returns non-zero for a connection error, a DNS or TLS failure, the
10-second timeout **and for any HTTP status >= 400**. A portal answering 500, a
rate limit, or a `SERVER_TOKEN` that expired overnight and got a 401 therefore
terminated every offline session, while logging a statement that was not true.

Neither existing guard covered it:

- `check_portal()` fetches `/desktop/login?check=1` — a different endpoint, so a
  healthy front end says nothing about whether `/pam/userinfo` works;
- `handle_sso_unreachable()` (Part D) exists precisely to bound how long an
  unreachable portal is tolerated — one hour — and this path skipped it.

The expired-token case is not hypothetical: a heartbeat timer that never armed,
killing the server token overnight, is a bug this project has shipped and fixed
before (#159). It now reached a path that terminates sessions.

## The fix

Three outcomes instead of two — `0` valid, `1` revoked, `2` unknown — and only a
portal that actually answered `found: false` can terminate anything.

Two details that are not obvious:

**The jq idiom had to change.** `.found // empty` treats `false` as empty, so a
genuine revocation was indistinguishable from a missing field. Harmless while
every non-`true` answer meant the same thing; with three verdicts it would have
turned every revocation into "unknown" and left revoked users their sessions
forever. The test caught this, not review.

**The new counter is deliberately separate from `sso_unreachable_since`.**
`check_portal()` resets that one whenever the front end answers, so sharing it
would mean a working `/desktop/login` wipes the counter every cycle and a
permanently broken `/pam/userinfo` never converges on any bound at all.

An unusable `/pam/userinfo` therefore still terminates offline sessions after
`MAX_SSO_UNREACHABLE`, mirroring Part D rather than inventing a policy: leaving
a session alive forever because the endpoint that would revoke it is broken is
the same hole Part D closes, reached by another route.

## On dropping `curl -f`

Worth being precise, because it would be easy to overclaim: removing `-f` buys
**diagnostics, not correctness**. With `-f`, an HTTP error lands in the
transport branch and still yields verdict 2 — I confirmed that by mutation, and
the suite stayed green. What it buys is the 401/403 message naming the server
token and the heartbeat timer instead of a generic "cannot reach", and the test
pins that message for exactly that reason.

## Tests

`tests/test_ob_session_monitor.sh` is **new**. The acceptance criterion in #257
said it already existed; that was wrong, and I have corrected the issue — I had
conflated it with `test_ob_session_prune.sh`.

It extracts `check_user_valid` from the shipped script rather than
reimplementing it, so it breaks when the real code changes, and drives it
against a mock portal: `found:true`, `found:false`, connection refused, 500,
401, 403, an unparseable 200, a 200 with no `found` field, and a local signing
failure. Two further assertions check the caller actually branches on the third
verdict, and that the bound still exists and does not share `check_portal()`'s
reset.

**Run against the pre-fix code it fails 10 of 12** — and the 2 that pass are the
two genuine answers. That is the bug, demonstrated rather than described:

```
FAIL: connection refused -> unknown (2), not revoked - verdict=1
FAIL: HTTP 500 -> unknown (2), not revoked           - verdict=1
FAIL: HTTP 401 (our own token) -> unknown (2)        - verdict=1
FAIL: HTTP 403 -> unknown (2), not revoked           - verdict=1
```

Mutation coverage on the new code — folding `unknown` back into `revoked`,
treating 401 as a revocation, restoring the `.found // empty` idiom, and
restoring `curl -f` are each caught.

`ctest` 22/22, all 29 shell suites, `shellcheck -S warning` clean on `./scripts`
and the new test, prettier clean on the added `CHANGELOG.md` lines.

https://claude.ai/code/session_011q88Fs4nFuUs7JMvmgbBTN

