### PR TITLE
fix(enroll): keep the OIDC client secret off the command line

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,20 @@ jobs:
           bash "$test"
         done
 
+    # Same reasoning as the fingerprint sink below: this suite is the only thing
+    # proving the OIDC client secret stays out of /proc/<pid>/cmdline (#256),
+    # and it skips when ob-client-jwt is not built. A packaging change that
+    # stopped building the helper would leave CI green while ob-enroll refused
+    # to enrol at all.
+    - name: The client-assertion suite must actually run
+      run: |
+        out=$(bash tests/test_ob_client_jwt.sh 2>&1); echo "$out"
+        case "$out" in
+          *SKIP*)
+            echo "::error::tests/test_ob_client_jwt.sh skipped; it must run in CI"
+            exit 1 ;;
+        esac
+
     # The loop above treats a SKIP as success, which is right for suites that
     # need docker or a portal. It is wrong for the fingerprint sink: that suite
     # is the only thing guarding the trust root moved in #249, and if it skipped

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- **`ob-enroll` no longer puts the OIDC client secret on a command line
+  (#256).** It authenticates to the token endpoint with a `client_secret_jwt`
+  assertion, and signed that assertion in shell with
+  `openssl dgst -sha256 -hmac "$client_secret"`. OpenSSL takes the HMAC key as
+  a command-line argument and has no form that reads it from a file, a
+  descriptor or the environment, so for the lifetime of each `openssl` process
+  the host's client secret was readable by any local user through the
+  world-readable `/proc/<pid>/cmdline` — the same defect #247 fixed for the
+  request-signing secret.
+
+  It was not a one-shot exposure: the call sits inside the device-grant polling
+  loop, so the secret landed in `argv` once every five seconds for up to the
+  device-code lifetime — of the order of sixty times over five minutes, during
+  exactly the interval when an operator has been sent to a browser to approve
+  the grant and someone else is most likely to be on the host.
+
+  A new `ob-client-jwt`(8) builds the assertion instead, reading the secret on
+  stdin; a pipe has no `/proc` entry. It does not read the secret from
+  `openbastion.conf` the way `ob-sign-request`(8) does, because `ob-enroll` may
+  hold it from the environment, from `--client-secret`, or from a config file
+  that on a first enrolment does not exist yet — so `ob-enroll` decides and
+  hands it over, rather than two implementations of that precedence having to
+  agree forever. The signing itself is the `generate_client_jwt()` the PAM
+  module already uses, so the shell stops carrying a second implementation of
+  the same assertion. There is deliberately no fallback to the `openssl` path:
+  a missing helper stops enrolment with an error rather than silently going
+  back to leaking the secret.
+
+  The guard in `tests/test_ob_request_signing.sh` that asserted "no HMAC key on
+  a command line" named `ob-heartbeat` and `ob-bastion-id` explicitly, which is
+  why it had nothing to say about `ob-enroll`; it now scans every script under
+  `scripts/`. `tests/test_ob_client_jwt.sh` checks the property from outside the
+  process, by reading `/proc/<pid>/cmdline` of the running helper, and proves
+  the probe is not vacuous by catching the old `openssl` invocation with it.
+
 - **`ob-session-monitor` no longer terminates sessions because it failed to
   reach the portal (#257).** `check_user_valid()` ended its call with
   `curl -sf ... || return 1`, and the caller reads a non-zero return as "this

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -356,6 +356,43 @@ install(TARGETS ob-sign-request
     RUNTIME DESTINATION ${CMAKE_INSTALL_SBINDIR}
 )
 
+# client_secret_jwt assertions for ob-enroll (#256). Same reason as
+# ob-sign-request above, for the other secret: `openssl dgst -hmac "$secret"`
+# publishes the OIDC client secret through /proc/<pid>/cmdline, once per poll of
+# the device-grant loop. The secret arrives on stdin instead -- ob-enroll may
+# hold it from the environment, from --client-secret or from a config file that
+# does not exist yet, so it is ob-enroll that decides, not this helper. The
+# signing is the same generate_client_jwt() the PAM module uses.
+add_executable(ob-client-jwt
+    src/ob-client-jwt.c
+    src/jwt_utils.c
+)
+target_include_directories(ob-client-jwt PRIVATE
+    ${CMAKE_SOURCE_DIR}/include
+    ${JSON_C_INCLUDE_DIRS}
+    ${OPENSSL_INCLUDE_DIRS}
+)
+target_compile_options(ob-client-jwt PRIVATE
+    -Wall -Wextra -Werror
+    -D_GNU_SOURCE
+    -fstack-protector-strong
+    -Wformat -Wformat-security
+    $<$<CONFIG:Release>:-flto>
+)
+target_link_libraries(ob-client-jwt
+    ${JSON_C_LIBRARIES}
+    ${OPENSSL_LIBRARIES}
+)
+target_link_options(ob-client-jwt PRIVATE
+    -Wl,-z,relro
+    -Wl,-z,now
+    -Wl,-z,noexecstack
+    $<$<CONFIG:Release>:-flto>
+)
+install(TARGETS ob-client-jwt
+    RUNTIME DESTINATION ${CMAKE_INSTALL_SBINDIR}
+)
+
 # Tamper-evident session recording: socket-activated root sink + unprivileged
 # connector. ob-record-sink (root, socket-activated) writes recordings root-owned
 # under /var/lib/open-bastion/sessions/<user>/ (the recorded user cannot touch
@@ -479,6 +516,7 @@ install(FILES
     ${CMAKE_SOURCE_DIR}/man/ob-fp-submit.8
     ${CMAKE_SOURCE_DIR}/man/ob-record-sink.8
     ${CMAKE_SOURCE_DIR}/man/ob-sign-request.8
+    ${CMAKE_SOURCE_DIR}/man/ob-client-jwt.8
     DESTINATION ${CMAKE_INSTALL_MANDIR}/man8
 )
 

--- a/debian/open-bastion.install
+++ b/debian/open-bastion.install
@@ -24,6 +24,7 @@ usr/sbin/ob-cert-daemon
 usr/sbin/ob-fp-daemon
 usr/sbin/ob-fp-submit
 usr/sbin/ob-sign-request
+usr/sbin/ob-client-jwt
 usr/sbin/ob-record-sink
 usr/sbin/ob-cache-admin
 usr/sbin/ob-session-prune
@@ -61,6 +62,7 @@ usr/share/man/man8/ob-fp-daemon.8
 usr/share/man/man8/ob-fp-submit.8
 usr/share/man/man8/ob-record-sink.8
 usr/share/man/man8/ob-sign-request.8
+usr/share/man/man8/ob-client-jwt.8
 
 # Audit trace templates (deployed by `ob-bastion-setup --enable-audit-trace`)
 usr/share/open-bastion/audit/rules.d/open-bastion.rules

--- a/doc/security/01-enrollment.md
+++ b/doc/security/01-enrollment.md
@@ -566,6 +566,15 @@ oidcServiceDeviceAuthorizationUserCodeLength: 8 # Longueur du code (défaut: 8)
   - Le JWT contient les claims `iss`, `sub`, `aud`, `exp`, `iat`, `jti`
   - Le `jti` (JWT ID) est un UUID unique pour chaque requête, empêchant le replay
   - Le secret sert uniquement à signer le JWT localement, il ne transite jamais sur le réseau
+- **La signature locale ne passe plus par `argv` (#256)** : jusqu'à la 0.6.x, `ob-enroll`
+  calculait cette signature avec `openssl dgst -sha256 -hmac "$client_secret"`, et OpenSSL
+  n'accepte la clé HMAC que sur la ligne de commande. La menace listée juste au-dessus
+  (« `ps aux` montre le secret ») était donc réintroduite par la remédiation elle-même, à
+  chaque tour de la boucle de polling du device grant — de l'ordre de soixante fois en cinq
+  minutes, pendant que l'opérateur est parti approuver la demande dans un navigateur.
+  La signature est désormais faite par `ob-client-jwt`(8), qui reçoit le secret sur son
+  entrée standard ; un tube n'a pas d'entrée dans `/proc`. Même raison et même forme que
+  `ob-sign-request`(8) pour le secret de signature des requêtes (#247).
 - TLS 1.3 par défaut (`src/ob_client.c:410`)
 - Vérification SSL activée par défaut
 - Support du certificate pinning (`src/ob_client.c:512-521`)

--- a/man/ob-client-jwt.8
+++ b/man/ob-client-jwt.8
@@ -81,11 +81,11 @@ Becomes the
 .B aud
 claim.
 .SH INPUT
-The client secret on standard input. One trailing newline is stripped, so
-.B printf
-and
+The client secret on standard input. Every trailing CR and LF is stripped, so
+.BR printf ,
 .B echo
-callers produce the same key; everything else is part of the secret. A secret
+and a secret read from a CRLF file all produce the same key; nothing else is
+stripped, and leading or interior spaces are part of the secret. A secret
 containing a NUL byte is refused rather than silently truncated, since the HMAC
 is keyed by string length.
 .SH EXIT STATUS

--- a/man/ob-client-jwt.8
+++ b/man/ob-client-jwt.8
@@ -1,0 +1,106 @@
+.TH OB-CLIENT-JWT 8 "September 2026" "open-bastion" "System Administration"
+.SH NAME
+ob-client-jwt \- print a client_secret_jwt assertion without putting the secret on a command line
+.SH SYNOPSIS
+.B ob-client-jwt
+.B \-\-client\-id
+.I ID
+.B \-\-audience
+.I URL
+.RI "< " secret
+.SH DESCRIPTION
+Reads an OIDC client secret on standard input and prints a
+.B client_secret_jwt
+client assertion (RFC 7523) for it on standard output, signed HMAC\-SHA256.
+.PP
+.BR ob-enroll (8)
+used to build this assertion in shell, ending in
+.IP
+.EX
+openssl dgst \-sha256 \-hmac "$client_secret" \-binary
+.EE
+.PP
+.BR openssl (1)
+takes the HMAC key as a command\-line argument and offers no form that reads it
+from a file, a descriptor or the environment.
+.I /proc/<pid>/cmdline
+is world\-readable, so for the lifetime of that process the host's OIDC client
+secret was readable by any local user \(em the same defect issue #247 fixed for
+the request\-signing secret, and the same reason
+.BR ob-sign-request (8)
+exists.
+.PP
+It was not a one\-shot exposure. The call sits inside the device\-grant polling
+loop: one assertion every
+.B POLL_INTERVAL
+seconds for up to the device\-code lifetime, of the order of sixty times over
+five minutes \(em during exactly the interval when an operator has been sent to
+a browser to approve the grant.
+.SS Where the secret comes from
+.BR ob-sign-request (8)
+reads its secret from
+.IR openbastion.conf ,
+which is right for it: the request\-signing secret is only ever configured
+there. This helper deliberately does not, because
+.BR ob-enroll (8)
+may hold the client secret from any of three places \(em
+.B OB_CLIENT_SECRET
+in the environment,
+.B \-\-client\-secret
+on the command line, or
+.B client_secret
+in a configuration file that on a first enrolment does not exist yet.
+.PP
+Re\-deriving that precedence here would mean keeping two implementations of it
+in agreement forever. So this helper does not decide:
+.BR ob-enroll (8)
+already knows which secret it is using and hands it over on standard input. A
+pipe has no
+.I /proc
+entry and no name in the filesystem.
+.PP
+.B \-\-client\-id
+and
+.B \-\-audience
+are public. Both are echoed verbatim in the assertion's own payload, which is
+base64url of plaintext and goes on the wire; only the key has to be kept off
+.BR argv .
+.SH OPTIONS
+.TP
+.BI \-\-client\-id " ID"
+The OIDC client identifier. Becomes the
+.B iss
+and
+.B sub
+claims.
+.TP
+.BI \-\-audience " URL"
+The endpoint the assertion is for, normally
+.IR <portal>/oauth2/token .
+Becomes the
+.B aud
+claim.
+.SH INPUT
+The client secret on standard input. One trailing newline is stripped, so
+.B printf
+and
+.B echo
+callers produce the same key; everything else is part of the secret. A secret
+containing a NUL byte is refused rather than silently truncated, since the HMAC
+is keyed by string length.
+.SH EXIT STATUS
+.TP
+.B 0
+the assertion was printed
+.TP
+.B 1
+signing failed, or the secret could not be read
+.TP
+.B 2
+usage error
+.SH SEE ALSO
+.BR ob-sign-request (8),
+.BR ob-enroll (8),
+.BR ob-heartbeat (8)
+.SH AUTHOR
+Linagora

--- a/rpm/open-bastion.spec
+++ b/rpm/open-bastion.spec
@@ -100,6 +100,7 @@ mkdir -p %{buildroot}/var/cache/nss_llng/byname
 %{_sbindir}/ob-fp-daemon
 %{_sbindir}/ob-fp-submit
 %{_sbindir}/ob-sign-request
+%{_sbindir}/ob-client-jwt
 %{_sbindir}/ob-record-sink
 %{_sbindir}/ob-cache-admin
 %{_sbindir}/ob-session-prune
@@ -156,6 +157,7 @@ mkdir -p %{buildroot}/var/cache/nss_llng/byname
 %{_mandir}/man8/ob-fp-submit.8*
 %{_mandir}/man8/ob-record-sink.8*
 %{_mandir}/man8/ob-sign-request.8*
+%{_mandir}/man8/ob-client-jwt.8*
 %{_mandir}/man1/ob-ssh.1*
 %{_mandir}/man1/ob-scp.1*
 %{_mandir}/man1/ob-sftp.1*

--- a/scripts/ob-enroll
+++ b/scripts/ob-enroll
@@ -42,6 +42,24 @@ else
         OB_SIGN_NOTE="ob-sign-lib.sh not found; sending $2 unsigned"; return 0; }
 fi
 
+# client_secret_jwt assertions are signed by ob-client-jwt so the OIDC client
+# secret never reaches a command line (#256). Installed beside ob-sign-request;
+# the source-tree fallbacks are for running this script uninstalled.
+OB_CLIENT_JWT="${OB_CLIENT_JWT:-}"
+if [ -z "$OB_CLIENT_JWT" ]; then
+    for _candidate in /usr/sbin/ob-client-jwt /usr/local/sbin/ob-client-jwt \
+                      "$(dirname "$(readlink -f "$0")")/../build/ob-client-jwt" \
+                      "$(dirname "$(readlink -f "$0")")/ob-client-jwt"; do
+        if [ -x "$_candidate" ]; then
+            OB_CLIENT_JWT="$_candidate"
+            break
+        fi
+    done
+fi
+if [ -z "$OB_CLIENT_JWT" ] && command -v ob-client-jwt >/dev/null 2>&1; then
+    OB_CLIENT_JWT="$(command -v ob-client-jwt)"
+fi
+
 # Colors for output (disabled if not a terminal)
 if [ -t 1 ]; then
     RED='\033[0;31m'
@@ -163,50 +181,35 @@ generate_client_jwt() {
     local client_secret="$2"
     local token_endpoint="$3"
 
-    local now
-    now=$(date +%s)
-    local exp=$((now + 300))  # 5 minutes validity
-
-    # Generate unique JWT ID (jti) for replay protection
-    local jti
-    if command -v uuidgen &> /dev/null; then
-        jti=$(uuidgen)
-    elif [ -f /proc/sys/kernel/random/uuid ]; then
-        jti=$(cat /proc/sys/kernel/random/uuid)
-    else
-        # Fallback: add entropy from /dev/urandom for uniqueness
-        local rand_suffix
-        if [ -r /dev/urandom ]; then
-            rand_suffix=$(head -c 16 /dev/urandom | od -An -tx1 | tr -d ' \n')
-        else
-            rand_suffix="${RANDOM}${RANDOM}${RANDOM}${RANDOM}"
-        fi
-        jti="$(hostname)-${now}-$$-${rand_suffix}"
+    # The assertion is built by ob-client-jwt, not here (#256).
+    #
+    # This used to be forty lines of shell ending in
+    #     openssl dgst -sha256 -hmac "$client_secret"
+    # and openssl has no form that takes the HMAC key anywhere but argv.
+    # /proc/<pid>/cmdline is world-readable, so every call published this
+    # host's OIDC client secret to any local user -- and the caller is the
+    # device-grant polling loop, so that is of the order of sixty times over
+    # five minutes, while an operator is away in a browser approving the grant.
+    #
+    # The secret goes down a pipe instead. `printf` is a shell builtin: it
+    # forks no process and creates no argv, and a pipe has no name anything
+    # else can open.
+    #
+    # There is deliberately no fallback to the openssl path. A missing helper
+    # must stop enrolment with an error, not silently go back to leaking the
+    # secret -- that is the whole point of the change.
+    if [ -z "$OB_CLIENT_JWT" ]; then
+        log_error "ob-client-jwt not found: cannot authenticate to the token endpoint"
+        log_error "It ships with open-bastion; set OB_CLIENT_JWT to its path if it is elsewhere."
+        return 1
     fi
 
-    # Header: {"alg":"HS256","typ":"JWT"}
-    local header
-    header=$(echo -n '{"alg":"HS256","typ":"JWT"}' | openssl base64 -e -A | tr '+/' '-_' | tr -d '=')
-
-    # Payload with standard claims per RFC 7523
-    # Use jq to properly escape JSON strings (handles special chars in client_id, etc.)
-    local payload_json
-    payload_json=$(jq -n -c \
-        --arg iss "$client_id" \
-        --arg sub "$client_id" \
-        --arg aud "$token_endpoint" \
-        --argjson exp "$exp" \
-        --argjson iat "$now" \
-        --arg jti "$jti" \
-        '{iss: $iss, sub: $sub, aud: $aud, exp: $exp, iat: $iat, jti: $jti}')
-    local payload
-    payload=$(echo -n "$payload_json" | openssl base64 -e -A | tr '+/' '-_' | tr -d '=')
-
-    # Signature: HMAC-SHA256(secret, header.payload)
-    local signature
-    signature=$(echo -n "${header}.${payload}" | openssl dgst -sha256 -hmac "$client_secret" -binary | openssl base64 -e -A | tr '+/' '-_' | tr -d '=')
-
-    echo "${header}.${payload}.${signature}"
+    local jwt
+    if ! jwt=$(printf '%s' "$client_secret" \
+        | "$OB_CLIENT_JWT" --client-id "$client_id" --audience "$token_endpoint"); then
+        return 1
+    fi
+    printf '%s\n' "$jwt"
 }
 
 # Read value from config file
@@ -491,7 +494,13 @@ poll_for_token() {
             # Generate JWT for client_secret_jwt authentication (RFC 7523)
             # This avoids sending client_secret in plaintext over the network
             local client_jwt
-            client_jwt=$(generate_client_jwt "$CLIENT_ID" "$CLIENT_SECRET" "$token_endpoint")
+            # A failure here is not transient -- a missing helper or a secret
+            # the helper refuses will fail identically on every remaining poll
+            # -- so stop with the reason rather than spin out the device code.
+            if ! client_jwt=$(generate_client_jwt "$CLIENT_ID" "$CLIENT_SECRET" "$token_endpoint"); then
+                log_error "Cannot build the client assertion; aborting enrolment"
+                exit 1
+            fi
 
             response=$(curl "${CURL_OPTS[@]}" \
                 -X POST "$token_endpoint" \

--- a/scripts/ob-session-monitor
+++ b/scripts/ob-session-monitor
@@ -221,7 +221,13 @@ check_user_valid() {
     # same thing; with three verdicts it would turn every revocation into
     # "unknown" and the user would keep their session forever.
     local found
-    found=$(echo "$body" | jq -r 'if has("found") then (.found|tostring) else "missing" end' 2>/dev/null)
+    # `|| true` because the assignment's status is jq's: today's only caller is
+    # `check_user_valid "$user" || verdict=$?`, which suspends errexit for the
+    # whole function, so a jq failure falls through to the "unknown" branch
+    # below. A future caller that invokes this plainly would instead die here
+    # under `set -e`, at the one input the branch exists for -- and the test
+    # harness, which drops errexit to capture the return value, could not see it.
+    found=$(echo "$body" | jq -r 'if has("found") then (.found|tostring) else "missing" end' 2>/dev/null) || true
     case "$found" in
         true)  return 0 ;;
         false) return 1 ;;

--- a/src/ob-client-jwt.c
+++ b/src/ob-client-jwt.c
@@ -38,9 +38,9 @@
  * has no /proc entry and no name in the filesystem; nothing but the two
  * processes can see it.
  *
- * The signing itself is the C generate_client_jwt() that pam_openbastion and
- * ob-heartbeat already use (src/jwt_utils.c), so the shell stops carrying a
- * second implementation of the same assertion.
+ * The signing itself is the C generate_client_jwt() that pam_openbastion
+ * already uses (src/jwt_utils.c, via token_manager.c and ob_client.c), so the
+ * shell stops carrying a second implementation of the same assertion.
  *
  * Usage:
  *     ob-client-jwt --client-id ID --audience URL < secret
@@ -80,10 +80,10 @@ static void usage(FILE *out)
 }
 
 /*
- * Read the secret from stdin. It is one line: a trailing newline is stripped
- * so that both `printf '%s'` and `echo` callers produce the same key, and a
- * bare newline is the only thing stripped -- everything else is part of the
- * secret, including spaces, which some issuers do generate.
+ * Read the secret from stdin. It is one line: every trailing CR and LF is
+ * stripped, so `printf '%s'`, `echo` and a secret read from a CRLF file all
+ * produce the same key. Nothing else is stripped -- leading and interior
+ * spaces are part of the secret, and some issuers do generate them.
  */
 static char *read_secret(size_t *len_out)
 {
@@ -105,7 +105,10 @@ static char *read_secret(size_t *len_out)
         if (used == MAX_SECRET) {
             /* Distinguish "exactly full" from "truncated": one more read. */
             char probe;
-            ssize_t extra = read(STDIN_FILENO, &probe, 1);
+            ssize_t extra;
+            do {
+                extra = read(STDIN_FILENO, &probe, 1);
+            } while (extra < 0 && errno == EINTR);
             if (extra > 0) {
                 explicit_bzero(&probe, sizeof(probe));
                 fprintf(stderr, "ob-client-jwt: secret larger than %d bytes\n", MAX_SECRET);

--- a/src/ob-client-jwt.c
+++ b/src/ob-client-jwt.c
@@ -1,0 +1,201 @@
+/*
+ * ob-client-jwt - print a client_secret_jwt assertion, with the secret off argv
+ *
+ * Copyright (C) 2026 Linagora
+ * License: AGPL-3.0
+ *
+ * ob-enroll authenticates to the OIDC token endpoint with a client_secret_jwt
+ * assertion (RFC 7523). It used to build that assertion in shell:
+ *
+ *     openssl dgst -sha256 -hmac "$client_secret" -binary
+ *
+ * openssl takes the HMAC key as a command-line argument and offers no form
+ * that reads it from a file, a descriptor or the environment. argv is
+ * world-readable through /proc/<pid>/cmdline, so for the lifetime of that
+ * process the host's OIDC client secret was readable by any local user -- the
+ * same defect #247 fixed for the /pam/ request-signing secret, and the same
+ * reason ob-sign-request exists.
+ *
+ * It was not a single one-shot exposure. The call sits inside the device-grant
+ * polling loop: one assertion every POLL_INTERVAL seconds for up to the
+ * device-code lifetime, of the order of sixty times over five minutes --
+ * during exactly the interval when a human has been sent to a browser to
+ * approve the grant, which is when someone else is most likely to be sitting
+ * on that host.
+ *
+ * Where the secret comes from
+ * ---------------------------
+ * ob-sign-request reads its secret from openbastion.conf, and that is right
+ * for it: the request-signing secret is only ever configured there. This
+ * helper deliberately does NOT do that, because ob-enroll may hold the client
+ * secret from any of three places -- OB_CLIENT_SECRET in the environment,
+ * --client-secret on the command line, or client_secret in a configuration
+ * file that on a first enrolment does not exist yet.
+ *
+ * Re-deriving that here would mean reimplementing ob-enroll's precedence and
+ * getting it to agree, forever. So this helper does not decide: ob-enroll
+ * already knows which secret it is using, and hands it over on stdin. A pipe
+ * has no /proc entry and no name in the filesystem; nothing but the two
+ * processes can see it.
+ *
+ * The signing itself is the C generate_client_jwt() that pam_openbastion and
+ * ob-heartbeat already use (src/jwt_utils.c), so the shell stops carrying a
+ * second implementation of the same assertion.
+ *
+ * Usage:
+ *     ob-client-jwt --client-id ID --audience URL < secret
+ *
+ * --client-id and --audience are public: both are echoed verbatim in the
+ * assertion's own payload, which is base64url of plaintext and goes on the
+ * wire. Only the key must be kept off argv.
+ *
+ * Exit status:
+ *     0  the assertion was printed on stdout
+ *     1  signing failed, or the secret could not be read
+ *     2  usage error
+ */
+
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "jwt_utils.h"
+
+/*
+ * An OIDC client secret is a password-shaped string. This is far above any
+ * real one and still bounds a runaway producer on stdin.
+ */
+#define MAX_SECRET 4096
+
+static void usage(FILE *out)
+{
+    fprintf(out,
+        "Usage: ob-client-jwt --client-id ID --audience URL < secret\n"
+        "\n"
+        "Reads the OIDC client secret on stdin and prints a client_secret_jwt\n"
+        "assertion (RFC 7523) for it on stdout.\n"
+        "The secret is never placed on a command line.\n");
+}
+
+/*
+ * Read the secret from stdin. It is one line: a trailing newline is stripped
+ * so that both `printf '%s'` and `echo` callers produce the same key, and a
+ * bare newline is the only thing stripped -- everything else is part of the
+ * secret, including spaces, which some issuers do generate.
+ */
+static char *read_secret(size_t *len_out)
+{
+    char *buf = malloc(MAX_SECRET + 1);
+    if (!buf) return NULL;
+
+    size_t used = 0;
+    for (;;) {
+        ssize_t r = read(STDIN_FILENO, buf + used, MAX_SECRET - used);
+        if (r < 0) {
+            if (errno == EINTR) continue;
+            fprintf(stderr, "ob-client-jwt: read error on stdin: %s\n", strerror(errno));
+            explicit_bzero(buf, MAX_SECRET);
+            free(buf);
+            return NULL;
+        }
+        if (r == 0) break;                      /* EOF */
+        used += (size_t)r;
+        if (used == MAX_SECRET) {
+            /* Distinguish "exactly full" from "truncated": one more read. */
+            char probe;
+            ssize_t extra = read(STDIN_FILENO, &probe, 1);
+            if (extra > 0) {
+                explicit_bzero(&probe, sizeof(probe));
+                fprintf(stderr, "ob-client-jwt: secret larger than %d bytes\n", MAX_SECRET);
+                explicit_bzero(buf, MAX_SECRET);
+                free(buf);
+                return NULL;
+            }
+            break;
+        }
+    }
+
+    while (used > 0 && (buf[used - 1] == '\n' || buf[used - 1] == '\r')) {
+        used--;
+    }
+    buf[used] = '\0';
+
+    if (used == 0) {
+        fprintf(stderr, "ob-client-jwt: empty secret on stdin\n");
+        explicit_bzero(buf, MAX_SECRET);
+        free(buf);
+        return NULL;
+    }
+
+    /*
+     * generate_client_jwt() keys the HMAC with strlen(), so a NUL would
+     * silently shorten the key and produce an assertion the portal computes
+     * differently -- a signature failure with no visible cause. Refuse it.
+     */
+    if (strlen(buf) != used) {
+        fprintf(stderr, "ob-client-jwt: secret contains a NUL byte\n");
+        explicit_bzero(buf, MAX_SECRET);
+        free(buf);
+        return NULL;
+    }
+
+    *len_out = used;
+    return buf;
+}
+
+int main(int argc, char **argv)
+{
+    const char *client_id = NULL, *audience = NULL;
+
+    for (int i = 1; i < argc; i++) {
+        if (strcmp(argv[i], "--client-id") == 0 && i + 1 < argc) {
+            client_id = argv[++i];
+        } else if (strcmp(argv[i], "--audience") == 0 && i + 1 < argc) {
+            audience = argv[++i];
+        } else if (strcmp(argv[i], "-h") == 0 || strcmp(argv[i], "--help") == 0) {
+            usage(stdout);
+            return 0;
+        } else {
+            fprintf(stderr, "ob-client-jwt: unexpected argument '%s'\n", argv[i]);
+            usage(stderr);
+            return 2;
+        }
+    }
+
+    if (!client_id || !*client_id) {
+        fprintf(stderr, "ob-client-jwt: --client-id is required\n");
+        usage(stderr);
+        return 2;
+    }
+    if (!audience || !*audience) {
+        fprintf(stderr, "ob-client-jwt: --audience is required\n");
+        usage(stderr);
+        return 2;
+    }
+
+    size_t secret_len = 0;
+    char *secret = read_secret(&secret_len);
+    if (!secret) return 1;
+
+    char *jwt = generate_client_jwt(client_id, secret, audience);
+
+    explicit_bzero(secret, MAX_SECRET);
+    free(secret);
+
+    if (!jwt) {
+        fprintf(stderr, "ob-client-jwt: could not build the assertion\n");
+        return 1;
+    }
+
+    printf("%s\n", jwt);
+    free(jwt);
+
+    if (fflush(stdout) != 0) {
+        fprintf(stderr, "ob-client-jwt: cannot write the assertion: %s\n", strerror(errno));
+        return 1;
+    }
+
+    return 0;
+}

--- a/tests/test_ob_client_jwt.sh
+++ b/tests/test_ob_client_jwt.sh
@@ -116,15 +116,31 @@ test_fresh_jti() {
     fi
 }
 
-# ── 4. THE POINT: the secret is not in the helper's argv ─────────────────────
+# ── 4. THE POINT: the secret is not visible in any process's argv ────────────
 #
-# Read from outside, the way any local user would. A slow secret producer keeps
-# the helper alive long enough to sample /proc/<pid>/cmdline and /proc/<pid>/environ.
-# This fails if anyone ever "simplifies" the helper into taking --secret.
+# Read from outside, the way any local user would: a slow secret producer keeps
+# the helper alive long enough to sample /proc.
+#
+# The scan is over EVERY process, not just the helper's own pid. Scanning only
+# the helper would miss the regression that actually threatens this -- a helper
+# that shells out to `openssl dgst -hmac "$secret"` leaks from a *child*, and
+# the helper's own cmdline stays clean. That is precisely the code this change
+# removed, so it is precisely the shape a regression would take.
+#
+# (An interface change -- teaching the helper to take --secret -- is caught by
+# the refusals test below instead, since it means accepting an option that does
+# not exist. It cannot be caught here: the shipped invocation only ever feeds
+# stdin, so no mutation of the helper alone puts the marker on this cmdline.)
 test_secret_never_in_proc() {
     local marker="MARKER-$$-do-not-appear-in-proc"
     local fifo="${TMPDIR:-/tmp}/objwt.$$.fifo"
-    mkfifo "$fifo" || { fail "the secret never appears in /proc" "mkfifo"; return; }
+    local pat="${TMPDIR:-/tmp}/objwt.$$.pat"
+    mkfifo "$fifo" || { fail "the secret never reaches any process's argv" "mkfifo"; return; }
+    # The marker goes in a file, and every scan uses -f. Putting it in a grep
+    # argument would plant it in the scanner's own argv, and a scan that starts
+    # while a previous one is still exiting then finds it and reports a leak
+    # that is entirely the test's own doing. That happened; this is the fix.
+    printf '%s\n' "$marker" > "$pat"
 
     # Feed the secret slowly so the helper is still running when we look.
     ( exec >"$fifo"; printf '%s' "$marker"; sleep 2 ) &
@@ -139,29 +155,31 @@ test_secret_never_in_proc() {
     for _ in $(seq 1 20); do
         local cl="" en=""
         { cl=$(tr '\0' ' ' < "/proc/$hpid/cmdline"); } 2>/dev/null
+        [ -n "$cl" ] && observed=yes
+
+        # Every process, so a leak from a child (the openssl shape) is caught.
+        if grep -rlFf "$pat" /proc/[0-9]*/cmdline 2>/dev/null | grep -q .; then
+            seen="cmdline"
+        fi
         # environ is 0400 owner-only, unlike world-readable cmdline; this test
         # runs as the owner, so it sees the worst case.
         { en=$(tr '\0' '\n' < "/proc/$hpid/environ"); } 2>/dev/null
-        if [ -n "$cl" ]; then
-            observed=yes
-            printf '%s' "$cl" | grep -qF "$marker" && seen="cmdline"
-            printf '%s' "$en" | grep -qF "$marker" && seen="$seen environ"
-            [ -n "$seen" ] && break
-        fi
+        printf '%s' "$en" | grep -qFf "$pat" && seen="$seen environ"
+        [ -n "$seen" ] && break
         sleep 0.1
     done
 
     wait "$feeder" 2>/dev/null
     wait "$hpid" 2>/dev/null
-    rm -f "$fifo"
+    rm -f "$fifo" "$pat"
 
     if [ -z "$observed" ]; then
-        fail "the secret never appears in the helper's /proc/<pid>/cmdline or environ" \
+        fail "the secret never reaches any process's argv, the helper's or a child's" \
              "never caught the helper running, so nothing was actually checked"
     elif [ -z "$seen" ]; then
-        pass "the secret never appears in the helper's /proc/<pid>/cmdline or environ"
+        pass "the secret never reaches any process's argv, the helper's or a child's"
     else
-        fail "the secret never appears in the helper's /proc/<pid>/cmdline or environ" \
+        fail "the secret never reaches any process's argv, the helper's or a child's" \
              "found in: $seen"
     fi
 }
@@ -174,19 +192,28 @@ test_secret_never_in_proc() {
 test_probe_catches_the_old_leak() {
     command -v openssl >/dev/null 2>&1 || { pass "(skipped: no openssl to demonstrate the leak)"; return; }
     local marker="MARKER-$$-old-leak"
-    # The line as it was in ob-enroll before #256.
-    ( echo -n "msg" | openssl dgst -sha256 -hmac "$marker" -binary >/dev/null 2>&1; sleep 2 ) &
+    local pat="${TMPDIR:-/tmp}/objwt.$$.leak.pat"
+    printf '%s\n' "$marker" > "$pat"
+
+    # The line as it was in ob-enroll before #256. openssl is fed from a slow
+    # pipe so it is still alive to be sampled: it hashes in microseconds, and an
+    # earlier version of this test put the `sleep` after it instead, so the
+    # process was always gone before the first sample. That version passed --
+    # on the test's own `grep "$marker"` argv, which is why the marker now
+    # lives in a file.
+    ( printf 'msg'; sleep 2 ) | openssl dgst -sha256 -hmac "$marker" -binary >/dev/null 2>&1 &
     local wrapper=$!
 
     local found=""
     for _ in $(seq 1 20); do
-        # openssl is a child of the subshell; scan every live process.
-        if grep -rlF "$marker" /proc/[0-9]*/cmdline 2>/dev/null | head -1 | grep -q .; then
+        # Same scan as test 4, marker from a file for the same reason.
+        if grep -rlFf "$pat" /proc/[0-9]*/cmdline 2>/dev/null | grep -q .; then
             found=yes; break
         fi
         sleep 0.1
     done
     wait "$wrapper" 2>/dev/null
+    rm -f "$pat"
 
     if [ -n "$found" ]; then
         pass "the probe does catch the openssl -hmac leak it is aimed at"
@@ -223,24 +250,30 @@ test_refusals() {
 # `printf '%s'` and `echo` must produce the same assertion, or an operator who
 # pipes the secret from a file gets bad_client_credentials with no clue why.
 test_trailing_newline() {
-    local a b
-    a=$(printf '%s'   "$SECRET" | "$HELPER" --client-id "$CID" --audience "$AUD" | cut -d. -f3)
-    b=$(printf '%s\n' "$SECRET" | "$HELPER" --client-id "$CID" --audience "$AUD" | cut -d. -f3)
-    # Same key, but jti/iat differ, so compare by re-verifying b's own signature
-    # against the un-newlined secret rather than comparing signatures directly.
-    local jwt
-    jwt=$(printf '%s\n' "$SECRET" | "$HELPER" --client-id "$CID" --audience "$AUD")
-    if [ -n "$a" ] && [ -n "$b" ] && python3 - "$SECRET" "$jwt" <<'PY'
+    local bad="" form jwt
+    # No newline, LF and CRLF must all key the HMAC with the same secret. An
+    # operator whose secret file came from a Windows editor otherwise gets
+    # bad_client_credentials with nothing to go on.
+    for form in '%s' '%s\n' '%s\r\n'; do
+        # shellcheck disable=SC2059  # the format is ours, not user input
+        jwt=$(printf "$form" "$SECRET" | "$HELPER" --client-id "$CID" --audience "$AUD")
+        if [ -z "$jwt" ]; then
+            bad="$bad no-output-for[$form]"
+            continue
+        fi
+        python3 - "$SECRET" "$jwt" <<'VERIFY' || bad="$bad wrong-key-for[$form]"
 import sys, hmac, hashlib, base64
 secret, jwt = sys.argv[1], sys.argv[2]
 h, p, sig = jwt.split('.')
 mac = hmac.new(secret.encode(), f"{h}.{p}".encode(), hashlib.sha256).digest()
 sys.exit(0 if base64.urlsafe_b64encode(mac).decode().rstrip('=') == sig else 1)
-PY
-    then
-        pass "a trailing newline on the secret is stripped, not signed"
+VERIFY
+    done
+
+    if [ -z "$bad" ]; then
+        pass "no newline, LF and CRLF on the secret all key the same HMAC"
     else
-        fail "a trailing newline on the secret is stripped, not signed"
+        fail "no newline, LF and CRLF on the secret all key the same HMAC" "$bad"
     fi
 }
 

--- a/tests/test_ob_client_jwt.sh
+++ b/tests/test_ob_client_jwt.sh
@@ -1,0 +1,257 @@
+#!/bin/bash
+# test_ob_client_jwt.sh
+#
+# Guards the client_secret_jwt assertion helper (issue #256).
+#
+# ob-enroll authenticates to the OIDC token endpoint with a client_secret_jwt
+# assertion. It used to build it in shell, ending in
+#
+#     openssl dgst -sha256 -hmac "$client_secret" -binary
+#
+# and openssl has no form that takes the HMAC key anywhere but argv.
+# /proc/<pid>/cmdline is world-readable, so the host's OIDC client secret was
+# readable by any local user -- once per poll of the device-grant loop, of the
+# order of sixty times over five minutes, while an operator is away in a
+# browser approving the grant.
+#
+# Two things are asserted here, and the second is the one that matters:
+#
+#   1. the assertion is correct -- claims per RFC 7523, and a signature an
+#      independent implementation agrees with;
+#   2. the secret is not observable from outside the process. That is checked
+#      by reading /proc/<pid>/cmdline of the running helper, not by reading the
+#      source, because "we pass it on stdin now" is exactly the kind of claim
+#      that survives a refactor in prose while stopping being true in fact.
+
+set -uo pipefail
+
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+pass() { TESTS_PASSED=$((TESTS_PASSED + 1)); echo "  PASS: $1"; }
+fail() { TESTS_FAILED=$((TESTS_FAILED + 1)); echo "  FAIL: $1${2:+ - $2}"; }
+run_test() {
+    TESTS_RUN=$((TESTS_RUN + 1))
+    if ! declare -F "$1" >/dev/null; then
+        fail "$1 is listed as a test but is not defined"
+        return
+    fi
+    "$@"
+}
+
+HELPER=""
+for c in "$ROOT_DIR/build/ob-client-jwt" "$(command -v ob-client-jwt 2>/dev/null)"; do
+    [ -n "$c" ] && [ -x "$c" ] && { HELPER="$c"; break; }
+done
+[ -n "$HELPER" ] || { echo "SKIP: ob-client-jwt not built (cmake --build build)"; exit 0; }
+command -v python3 >/dev/null 2>&1 || { echo "SKIP: python3 is required"; exit 0; }
+
+AUD="https://sso.example.com/oauth2/token"
+CID="pam-access"
+# Deliberately awkward: spaces, quotes, a dollar and a backslash all survive a
+# pipe but would need quoting on a command line.
+SECRET='s3cr3t with "quotes" and $dollar and \back'
+
+echo "=== ob-client-jwt: client_secret_jwt assertions (issue #256) ==="
+
+# ── 1. The assertion verifies against an independent implementation ──────────
+test_signature_is_correct() {
+    local jwt
+    jwt=$(printf '%s' "$SECRET" | "$HELPER" --client-id "$CID" --audience "$AUD") || {
+        fail "the assertion verifies against an independent HMAC" "helper failed"
+        return
+    }
+    if python3 - "$SECRET" "$jwt" <<'PY'
+import sys, hmac, hashlib, base64
+secret, jwt = sys.argv[1], sys.argv[2]
+h, p, sig = jwt.split('.')
+mac = hmac.new(secret.encode(), f"{h}.{p}".encode(), hashlib.sha256).digest()
+sys.exit(0 if base64.urlsafe_b64encode(mac).decode().rstrip('=') == sig else 1)
+PY
+    then
+        pass "the assertion verifies against an independent HMAC"
+    else
+        fail "the assertion verifies against an independent HMAC"
+    fi
+}
+
+# ── 2. The claims are the ones RFC 7523 asks for ─────────────────────────────
+test_claims() {
+    local jwt
+    jwt=$(printf '%s' "$SECRET" | "$HELPER" --client-id "$CID" --audience "$AUD")
+    local report
+    report=$(python3 - "$jwt" "$CID" "$AUD" <<'PY'
+import sys, json, base64
+jwt, cid, aud = sys.argv[1], sys.argv[2], sys.argv[3]
+def d(s): return base64.urlsafe_b64decode(s + '=' * (-len(s) % 4))
+h, p, _ = jwt.split('.')
+head, pay = json.loads(d(h)), json.loads(d(p))
+bad = []
+if head != {"alg": "HS256", "typ": "JWT"}: bad.append(f"header={head}")
+for k, v in (("iss", cid), ("sub", cid), ("aud", aud)):
+    if pay.get(k) != v: bad.append(f"{k}={pay.get(k)!r}")
+if pay.get("exp", 0) - pay.get("iat", 0) != 300: bad.append("exp-iat != 300")
+if len(str(pay.get("jti", ""))) != 36: bad.append("jti is not a uuid")
+print(" ".join(bad))
+PY
+)
+    if [ -z "$report" ]; then
+        pass "iss, sub, aud, exp, iat and jti are as RFC 7523 requires"
+    else
+        fail "iss, sub, aud, exp, iat and jti are as RFC 7523 requires" "$report"
+    fi
+}
+
+# ── 3. A fresh jti per call: it is the portal's replay key ───────────────────
+test_fresh_jti() {
+    local a b
+    a=$(printf '%s' "$SECRET" | "$HELPER" --client-id "$CID" --audience "$AUD" | cut -d. -f2)
+    b=$(printf '%s' "$SECRET" | "$HELPER" --client-id "$CID" --audience "$AUD" | cut -d. -f2)
+    if [ -n "$a" ] && [ "$a" != "$b" ]; then
+        pass "each call carries a fresh jti"
+    else
+        fail "each call carries a fresh jti" "identical payloads"
+    fi
+}
+
+# ── 4. THE POINT: the secret is not in the helper's argv ─────────────────────
+#
+# Read from outside, the way any local user would. A slow secret producer keeps
+# the helper alive long enough to sample /proc/<pid>/cmdline and /proc/<pid>/environ.
+# This fails if anyone ever "simplifies" the helper into taking --secret.
+test_secret_never_in_proc() {
+    local marker="MARKER-$$-do-not-appear-in-proc"
+    local fifo="${TMPDIR:-/tmp}/objwt.$$.fifo"
+    mkfifo "$fifo" || { fail "the secret never appears in /proc" "mkfifo"; return; }
+
+    # Feed the secret slowly so the helper is still running when we look.
+    ( exec >"$fifo"; printf '%s' "$marker"; sleep 2 ) &
+    local feeder=$!
+
+    "$HELPER" --client-id "$CID" --audience "$AUD" < "$fifo" >/dev/null 2>&1 &
+    local hpid=$!
+
+    # observed: proof we actually caught the process alive. Without it, a helper
+    # that exited too fast to sample would make this test pass by never looking.
+    local seen="" observed=""
+    for _ in $(seq 1 20); do
+        local cl="" en=""
+        { cl=$(tr '\0' ' ' < "/proc/$hpid/cmdline"); } 2>/dev/null
+        # environ is 0400 owner-only, unlike world-readable cmdline; this test
+        # runs as the owner, so it sees the worst case.
+        { en=$(tr '\0' '\n' < "/proc/$hpid/environ"); } 2>/dev/null
+        if [ -n "$cl" ]; then
+            observed=yes
+            printf '%s' "$cl" | grep -qF "$marker" && seen="cmdline"
+            printf '%s' "$en" | grep -qF "$marker" && seen="$seen environ"
+            [ -n "$seen" ] && break
+        fi
+        sleep 0.1
+    done
+
+    wait "$feeder" 2>/dev/null
+    wait "$hpid" 2>/dev/null
+    rm -f "$fifo"
+
+    if [ -z "$observed" ]; then
+        fail "the secret never appears in the helper's /proc/<pid>/cmdline or environ" \
+             "never caught the helper running, so nothing was actually checked"
+    elif [ -z "$seen" ]; then
+        pass "the secret never appears in the helper's /proc/<pid>/cmdline or environ"
+    else
+        fail "the secret never appears in the helper's /proc/<pid>/cmdline or environ" \
+             "found in: $seen"
+    fi
+}
+
+# ── 5. The old shell path leaked, and this test can see it ───────────────────
+#
+# Without this, test 4 proves nothing: a probe that never catches anything
+# passes just as happily against a helper that does leak. So run the exact
+# openssl invocation ob-enroll used to make, and require the probe to find it.
+test_probe_catches_the_old_leak() {
+    command -v openssl >/dev/null 2>&1 || { pass "(skipped: no openssl to demonstrate the leak)"; return; }
+    local marker="MARKER-$$-old-leak"
+    # The line as it was in ob-enroll before #256.
+    ( echo -n "msg" | openssl dgst -sha256 -hmac "$marker" -binary >/dev/null 2>&1; sleep 2 ) &
+    local wrapper=$!
+
+    local found=""
+    for _ in $(seq 1 20); do
+        # openssl is a child of the subshell; scan every live process.
+        if grep -rlF "$marker" /proc/[0-9]*/cmdline 2>/dev/null | head -1 | grep -q .; then
+            found=yes; break
+        fi
+        sleep 0.1
+    done
+    wait "$wrapper" 2>/dev/null
+
+    if [ -n "$found" ]; then
+        pass "the probe does catch the openssl -hmac leak it is aimed at"
+    else
+        fail "the probe does catch the openssl -hmac leak it is aimed at" \
+             "the probe found nothing, so test 4 proves nothing"
+    fi
+}
+
+# ── 6. Refusals ──────────────────────────────────────────────────────────────
+test_refusals() {
+    local bad=""
+    printf '' | "$HELPER" --client-id "$CID" --audience "$AUD" >/dev/null 2>&1 \
+        && bad="$bad empty-secret-accepted"
+    printf 'a\0b' | "$HELPER" --client-id "$CID" --audience "$AUD" >/dev/null 2>&1 \
+        && bad="$bad nul-accepted"
+    head -c 5000 /dev/zero | tr '\0' 'x' | "$HELPER" --client-id "$CID" --audience "$AUD" >/dev/null 2>&1 \
+        && bad="$bad oversize-accepted"
+    printf '%s' "$SECRET" | "$HELPER" --audience "$AUD" >/dev/null 2>&1 \
+        && bad="$bad missing-client-id-accepted"
+    printf '%s' "$SECRET" | "$HELPER" --client-id "$CID" >/dev/null 2>&1 \
+        && bad="$bad missing-audience-accepted"
+    printf '%s' "$SECRET" | "$HELPER" --client-id "$CID" --audience "$AUD" --secret "$SECRET" >/dev/null 2>&1 \
+        && bad="$bad unknown-option-accepted"
+
+    if [ -z "$bad" ]; then
+        pass "an empty, NUL-bearing or oversized secret and a bad invocation are all refused"
+    else
+        fail "an empty, NUL-bearing or oversized secret and a bad invocation are all refused" "$bad"
+    fi
+}
+
+# ── 7. A trailing newline must not change the key ────────────────────────────
+# `printf '%s'` and `echo` must produce the same assertion, or an operator who
+# pipes the secret from a file gets bad_client_credentials with no clue why.
+test_trailing_newline() {
+    local a b
+    a=$(printf '%s'   "$SECRET" | "$HELPER" --client-id "$CID" --audience "$AUD" | cut -d. -f3)
+    b=$(printf '%s\n' "$SECRET" | "$HELPER" --client-id "$CID" --audience "$AUD" | cut -d. -f3)
+    # Same key, but jti/iat differ, so compare by re-verifying b's own signature
+    # against the un-newlined secret rather than comparing signatures directly.
+    local jwt
+    jwt=$(printf '%s\n' "$SECRET" | "$HELPER" --client-id "$CID" --audience "$AUD")
+    if [ -n "$a" ] && [ -n "$b" ] && python3 - "$SECRET" "$jwt" <<'PY'
+import sys, hmac, hashlib, base64
+secret, jwt = sys.argv[1], sys.argv[2]
+h, p, sig = jwt.split('.')
+mac = hmac.new(secret.encode(), f"{h}.{p}".encode(), hashlib.sha256).digest()
+sys.exit(0 if base64.urlsafe_b64encode(mac).decode().rstrip('=') == sig else 1)
+PY
+    then
+        pass "a trailing newline on the secret is stripped, not signed"
+    else
+        fail "a trailing newline on the secret is stripped, not signed"
+    fi
+}
+
+run_test test_signature_is_correct
+run_test test_claims
+run_test test_fresh_jti
+run_test test_secret_never_in_proc
+run_test test_probe_catches_the_old_leak
+run_test test_refusals
+run_test test_trailing_newline
+
+echo
+echo "Tests run: $((TESTS_PASSED + TESTS_FAILED)), passed: $TESTS_PASSED, failed: $TESTS_FAILED"
+[ "$TESTS_FAILED" -eq 0 ]

--- a/tests/test_ob_request_signing.sh
+++ b/tests/test_ob_request_signing.sh
@@ -274,7 +274,7 @@ test_helper_contract() {
     fi
 }
 
-# ── 7. The secret must not reach a command line ───────────────────────────────
+# ── 7. No secret must reach a command line, anywhere under scripts/ ──────────
 #
 # This is the reason ob-sign-request exists rather than `openssl dgst -hmac`.
 # argv is world-readable through /proc/<pid>/cmdline, and ob-heartbeat runs
@@ -282,14 +282,45 @@ test_helper_contract() {
 # "simplifies" the helper away would hand the fleet-wide signing secret to
 # anyone who polls, silently and with every test still green -- so the guard is
 # here rather than in a comment.
+#
+# The scan is over every script rather than a named few (#256). It used to list
+# ob-heartbeat and ob-bastion-id, which made it a guard about the /pam/
+# endpoints; meanwhile ob-enroll signed its client_secret_jwt assertion with the
+# OIDC client secret on openssl's command line, once per poll of the device
+# grant loop, and this test had nothing to say about it. The property is not
+# "the /pam/ callers are careful", it is "no script puts an HMAC key in argv" --
+# so nothing has to be remembered when the next script is written.
+#
+# Full-line comments are stripped: this file and ob-enroll both quote the old
+# leaking line in prose to explain why it went, and prose is not a call.
 test_no_secret_in_argv() {
     local hits
-    hits=$(grep -nE 'dgst[^|]*-hmac|-macopt[[:space:]]*(hex)?key:' \
-        "$ROOT_DIR/scripts/ob-heartbeat" "$ROOT_DIR/scripts/ob-bastion-id" 2>/dev/null)
+    hits=$(for f in "$ROOT_DIR"/scripts/*; do
+               [ -f "$f" ] || continue
+               grep -nE 'dgst[^|]*-hmac|-macopt[[:space:]]*(hex)?key:' "$f" \
+                   | grep -vE '^[0-9]+:[[:space:]]*#' \
+                   | sed "s|^|$(basename "$f"):|"
+           done)
     if [ -z "$hits" ]; then
-        pass "the /pam/ callers never put an HMAC key on a command line"
+        pass "no script under scripts/ puts an HMAC key on a command line"
     else
-        fail "the /pam/ callers never put an HMAC key on a command line" "$hits"
+        fail "no script under scripts/ puts an HMAC key on a command line" "$hits"
+    fi
+}
+
+# The replacement must not be reachable around: ob-enroll must have no fallback
+# to openssl for when the helper is missing. A fallback would put the leak back
+# exactly on the hosts where it is hardest to notice, and the suite would still
+# be green because the helper is present here.
+test_enroll_has_no_openssl_fallback() {
+    local leaks
+    leaks=$(grep -nE 'dgst[^|]*-hmac' "$ROOT_DIR/scripts/ob-enroll" \
+            | grep -vE '^[0-9]+:[[:space:]]*#')
+    if grep -q 'ob-client-jwt' "$ROOT_DIR/scripts/ob-enroll" && [ -z "$leaks" ]; then
+        pass "ob-enroll signs its client assertion with ob-client-jwt, with no openssl fallback"
+    else
+        fail "ob-enroll signs its client assertion with ob-client-jwt, with no openssl fallback" \
+             "${leaks:-ob-client-jwt is not called}"
     fi
 }
 
@@ -347,10 +378,18 @@ test_every_caller_signs() {
 }
 
 echo "=== Request signing, end to end (#247) ==="
+# A name in this list that is not a defined function used to be a shell error
+# the loop walked straight past, leaving the suite green with a test that never
+# ran -- found while adding one below. Fail loudly instead.
 for t in test_heartbeat_required test_wrong_secret_is_refused \
          test_unconfigured_is_unsigned test_unconfigured_optional \
          test_whoami_required test_helper_contract \
-         test_no_secret_in_argv test_every_caller_signs; do
+         test_no_secret_in_argv test_enroll_has_no_openssl_fallback \
+         test_every_caller_signs; do
+    if ! declare -F "$t" >/dev/null; then
+        fail "$t is listed as a test but is not defined"
+        continue
+    fi
     "$t"
 done
 

--- a/tests/test_ob_session_monitor.sh
+++ b/tests/test_ob_session_monitor.sh
@@ -216,6 +216,55 @@ test_signing_failure_is_unknown() {
 }
 run_test test_signing_failure_is_unknown
 
+# ── The unknown branch must survive errexit ──────────────────────────────────
+# The shipped script runs under `set -euo pipefail`; this harness does not,
+# because it has to capture a return value. That gap has bitten this project
+# before: a command whose non-zero status is fine in the tests kills the real
+# script.
+#
+# `found=$(... | jq ...)` takes jq's exit status, and jq exits non-zero on
+# exactly the input the "unknown" branch exists to handle. Today's caller is
+# `check_user_valid "$user" || verdict=$?`, which suspends errexit for the whole
+# function, so nothing breaks -- but a future plain call would die at the
+# assignment and never reach the branch, and no test that drops errexit could
+# tell. So this one puts errexit back and calls plainly.
+test_unknown_branch_survives_errexit() {
+    PORT=$((PORT + 1))
+    python3 "$WORK/mock.py" garbage "$PORT" & MOCK_PID=$!
+    for _ in $(seq 1 50); do
+        (echo > "/dev/tcp/127.0.0.1/$PORT") 2>/dev/null && break
+        sleep 0.1
+    done
+
+    {
+        echo 'set -euo pipefail'          # as shipped, not as the harness runs
+        echo "PORTAL_URL='http://127.0.0.1:$PORT'"
+        echo "CONFIG_FILE='$WORK/ob.conf'"
+        echo 'SERVER_TOKEN=""'
+        echo 'SIGN_HEADERS=()'
+        echo 'ob_sign_request() { SIGN_HEADERS=(); return 0; }'
+        echo 'log_warn() { echo "WARN: $*" >&2; }'
+        echo 'log_crit() { echo "CRIT: $*" >&2; }'
+        echo 'log_debug() { :; }'
+        extract_function
+        echo 'check_user_valid alice'     # plain call: errexit is live
+    } > "$WORK/errexit.sh"
+
+    local out
+    out=$(bash "$WORK/errexit.sh" 2>&1)
+    kill "$MOCK_PID" 2>/dev/null; wait "$MOCK_PID" 2>/dev/null; MOCK_PID=""
+
+    # The branch ran if it logged. Without `|| true` the shell dies at the
+    # assignment with jq's status and nothing is logged at all.
+    if printf '%s' "$out" | grep -q "without a usable 'found' field"; then
+        pass "the unknown branch is reached under errexit, not skipped by jq's status"
+    else
+        fail "the unknown branch is reached under errexit, not skipped by jq's status" \
+             "out=$(printf '%s' "$out" | tr '\n' ' ')"
+    fi
+}
+run_test test_unknown_branch_survives_errexit
+
 # ── The caller must act on the distinction ───────────────────────────────────
 # A three-valued check_user_valid is worthless if the caller still writes
 # `if check_user_valid`, which treats 1 and 2 alike.


### PR DESCRIPTION
Closes #256.

## The defect

`ob-enroll` authenticates to the OIDC token endpoint with a `client_secret_jwt`
assertion (RFC 7523), and signed it in shell:

```sh
signature=$(echo -n "${header}.${payload}" \
    | openssl dgst -sha256 -hmac "$client_secret" -binary | ...)
```

OpenSSL takes the HMAC key as a command-line argument and offers no form that
reads it from a file, a descriptor or the environment. `/proc/<pid>/cmdline` is
world-readable, so for the lifetime of each `openssl` process the host's OIDC
client secret was readable by any local user — the same defect #247 fixed for
the request-signing secret, and explicitly left out of scope there.

**It was not a one-shot exposure.** The call sits inside the device-grant
polling loop (`POLL_INTERVAL=5`, up to the device-code lifetime), so the secret
landed in `argv` of the order of sixty times over five minutes — during exactly
the interval when an operator has been sent to a browser to approve the grant,
which is when someone else is most likely to be sitting on that host.

Worth noting: `doc/security/01-enrollment.md` already listed *"`ps aux` montre
le secret"* as a threat and `client_secret_jwt` as its remediation. The
remediation was reintroducing the threat. That paragraph is corrected here.

## The fix, and the design question #256 left open

The issue asked where a helper should read the client secret from, since
`ob-enroll` runs before `openbastion.conf` necessarily holds it.

**The helper does not decide.** `ob-sign-request` reads its secret from the
config file, which is right for it — the request-signing secret is only ever
configured there. But `ob-enroll` may hold the client secret from any of three
places: `OB_CLIENT_SECRET`, `--client-secret`, or `client_secret` in a config
file that on a first enrolment does not exist yet. Re-deriving that precedence
in a second place would mean keeping two implementations in agreement forever.
So `ob-enroll` — which already knows which secret it is using — hands it over
on stdin. A pipe has no `/proc` entry and no name in the filesystem.

`printf` is a shell builtin: it forks no process and creates no `argv`.

The signing itself is the C `generate_client_jwt()` that `pam_openbastion` and
`token_manager` already use, so the shell stops carrying a second
implementation of the same assertion.

**There is no fallback to the openssl path.** A missing helper stops enrolment
with an error rather than silently going back to leaking the secret.

### On the encoding change

json-c escapes `/` as `\/` in the `aud` claim; jq did not. This is not a
compatibility risk, and not because I reasoned it through: `token_manager.c:227`
builds the identical `"%s/oauth2/token"` audience and passes it to the *same*
function on every token refresh, so the portal has been accepting this exact
encoding in production all along.

## Evidence

The central assertion in `tests/test_ob_client_jwt.sh` checks the property
**from outside the process** — reading `/proc/<pid>/cmdline` of the running
helper — rather than reading the source, because "we pass it on stdin now" is
exactly the kind of claim that survives a refactor in prose while ceasing to be
true in fact.

A probe that never catches anything passes just as happily against a helper
that leaks, so test 5 runs the exact `openssl` invocation `ob-enroll` used to
make and **requires the probe to find it**.

**Correction (review nit, fixed in 38796a7).** This section originally claimed
that teaching the helper to accept `--secret` makes the suite report
`found in: cmdline`. It does not: test 4 only ever feeds stdin, so no mutation
of the helper alone can put the marker on the invocation it samples. That
mutation is caught by the refusals test, as accepting an option that does not
exist.

Fixing the claim exposed two real weaknesses, both now fixed:

- **Test 4 sampled only the helper's own pid.** The regression that actually
  threatens this property is a helper that shells out to
  `openssl dgst -hmac "$secret"` — the exact code this change removes — and that
  leaks from a *child*, leaving the helper's own cmdline clean. The scan now
  covers every process, and that mutation is caught with the shipped
  invocation:

  ```
  FAIL: the secret never reaches any process's argv, the helper's or a child's - found in: cmdline
  ```

- **Test 5 — the test whose whole job is to prove the probe is not vacuous —
  was itself vacuous.** It scanned with `grep -rlF "$marker"`, which puts the
  marker in the scanner's own argv, and a scan starting while a previous one was
  still exiting found *that*. Meanwhile the openssl it was meant to catch had
  already exited: it hashes in microseconds and the `sleep` was after it rather
  than feeding it. So the guarantee that the probe worked was passing on the
  test's own noise, and would have kept passing with no leak present at all.
  The marker now lives in a file scanned with `-f`, so it appears in no argv,
  and openssl is fed from a slow pipe. Test 5 now fails when there is nothing to
  find.

Two guards that were weaker than they looked:

- `test_no_secret_in_argv` named `ob-heartbeat` and `ob-bastion-id` explicitly,
  which made it a guard about the `/pam/` endpoints. Meanwhile `ob-enroll` was
  leaking, and the test had nothing to say. It now scans every script under
  `scripts/`, so nothing has to be remembered when the next script is written.
- that suite's runner walked straight past a name that was not a defined
  function, leaving it green with a test that never ran. Found while adding
  one; it now fails loudly.

`tests/test_ob_client_jwt.sh` can SKIP when the helper is not built, and a skip
reads as a pass — so CI gets the same "must actually run" guard #249 added for
the fingerprint sink.

## Also in this PR: the review nit on #257

The `jq` assignment in `check_user_valid` takes jq's exit status, and jq exits
non-zero on exactly the input the `unknown` branch exists to handle.

Verified empirically rather than assumed: with today's caller
(`check_user_valid "$user" || verdict=$?`) errexit is suspended for the whole
function and the branch *is* reached. But a plain call dies at the assignment
under `set -e` with jq's status, never reaching the branch — and the harness,
which drops errexit to capture the return value, cannot see that. So `|| true`,
plus an assertion that puts errexit back and calls plainly. Removing `|| true`
makes it fail with empty output: the shell died before logging anything.

The `9 of 12` figure in #259's body was wrong — it is 10 of 12. Corrected there.

## Verification

- `ctest` 20/20 — the same count as `main` from a clean configure (the campaign's
  earlier "22/22" does not match this configuration).
- all 30 `tests/test_ob_*.sh` pass, **none skipped**.
- `shellcheck -S warning ./scripts` finding count identical to `main` (15, all
  pre-existing in `session-recorder.conf.example`); `ob-enroll` itself clean.
- prettier clean on `doc/security/01-enrollment.md`; `CHANGELOG.md` fails
  pre-existing on `main`, and the added lines are byte-identical to prettier's
  own output.
- `dpkg-buildpackage -b` OK; the `.deb` carries `/usr/sbin/ob-client-jwt` and
  its man page.
- **acceptance, end to end**: `tests/test_integration_docker.sh` 17/17, including
  *"Auto-approve protocol completed; ob-enroll obtained token (233B)"* — a real
  `ob-enroll` against a real LLNG portal with `client_secret` configured. I
  checked the images were rebuilt from this tree (54s old at run time) and that
  the enrolling container carries `/usr/sbin/ob-client-jwt`, with the only
  remaining `dgst -hmac` match in it being the comment that explains why it went.

https://claude.ai/code/session_011q88Fs4nFuUs7JMvmgbBTN
