### PR TITLE
feat(builder): carry the service-account public key, and derive its fingerprint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,18 @@ the `auth` line of certificate-mode PAM stacks, and the accepted permissions of
   told `pam_openbastion` what fingerprint to expect and gave sshd nothing to
   accept, so the deployment looked complete while the account could not log in.
 
+  When any account carries a key the bundle passes `--enable-service-keys` to
+  the setup it runs (`service_keys:` overrides), and `/etc/open-bastion` is left
+  traversable. Without either, the feature could not work: the setup run removed
+  the drop-in the bundle had just deployed, and at `0700` the
+  `AuthorizedKeysCommandUser` could not reach the keys — both silently, with
+  everything looking deployed.
+
+  Keys are also removed when an account is dropped from the configuration.
+  `ob-service-account-keys` serves any `.pub` present without consulting
+  `service-accounts.conf`, so a write-only deployment meant revocation did not
+  revoke.
+
   `key_fingerprint` is now **derived** from the key. Supplying both cross-checks
   them, and a mismatch stops the build: two values maintained apart is how a
   login gets refused with a key that looks correct in every listing. Neither

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,19 @@ the `auth` line of certificate-mode PAM stacks, and the accepted permissions of
   systemd units of #254 drifted apart.
 - **`ob-client-jwt`(8)** builds `ob-enroll`'s `client_secret_jwt` assertion with
   the secret on stdin (#256). See Security below.
+- **`ob-builder` deploys the service-account key** (#263). A `service_accounts:`
+  entry takes `public_key` or `public_key_file`, and the generated bundle —
+  shell installer and Ansible role alike — writes
+  `/etc/open-bastion/service-accounts.d/<name>.pub`. `service-accounts.conf`
+  told `pam_openbastion` what fingerprint to expect and gave sshd nothing to
+  accept, so the deployment looked complete while the account could not log in.
+
+  `key_fingerprint` is now **derived** from the key. Supplying both cross-checks
+  them, and a mismatch stops the build: two values maintained apart is how a
+  login gets refused with a key that looks correct in every listing. Neither
+  artefact can turn on the `AuthorizedKeysCommand` itself — that is host-wide,
+  and stays with `--enable-service-keys` — so both report when they find none.
+
 - **`--enable-service-keys`** on `ob-bastion-setup` and `ob-backend-setup`
   (#263). Writes the sshd drop-in that makes a service account able to log in —
   `AuthorizedKeysCommand` pointing at `ob-service-account-keys`,

--- a/admin-builder/ob-builder
+++ b/admin-builder/ob-builder
@@ -99,7 +99,15 @@ DISABLE_SESSION_RECORDER=""
 # Service accounts (SSH-key-only local accounts: ansible, backup, …). Each entry
 # is one account encoded as a single record whose fields are joined by the ASCII
 # Unit Separator (US, \x1f) in this fixed order:
-#   name, key_fingerprint, sudo_allowed, sudo_nopasswd, shell, home, gecos, uid, gid
+#   name, key_fingerprint, sudo_allowed, sudo_nopasswd, shell, home, gecos,
+#   uid, gid, public_key
+#
+# public_key is the account's authorized SSH public key. It is what
+# service-accounts.conf could never carry (#263): the fingerprint alone tells
+# pam_openbastion what to expect but gives sshd nothing to accept, so the
+# operator had to deploy the key by hand and the deployment looked complete
+# when it was not. With the key here, ob-builder writes
+# /etc/open-bastion/service-accounts.d/<name>.pub itself.
 # Populated from the questionnaire or from the YAML `service_accounts:` list, and
 # rendered into /etc/open-bastion/service-accounts.conf on the target.
 SERVICE_ACCOUNTS_RECORDS=()
@@ -175,10 +183,24 @@ QUESTIONNAIRE (asked when no --config is given):
 SERVICE ACCOUNTS (--config YAML):
   Declare SSH-key-only local accounts under a 'service_accounts:' list. They are
   rendered into /etc/open-bastion/service-accounts.conf (0600) on the target and
-  apply to every role. Example:
+  apply to every role.
+
+  Give each account its public_key (or public_key_file): the fingerprint alone
+  tells pam_openbastion what to expect but gives sshd nothing to accept, so
+  without the key the account cannot log in and the deployment looks complete
+  (#263). With it, the bundle also writes
+  /etc/open-bastion/service-accounts.d/<name>.pub.
+
+  sshd still needs the AuthorizedKeysCommand that serves those files, which is
+  a host-wide change: run "ob-bastion-setup --enable-service-keys" (or
+  ob-backend-setup) on the target. The generated installer says so when it
+  cannot find one. Example:
     service_accounts:
       - name: ci-ansible            # dedicated name (not an existing system user)
-        key_fingerprint: "SHA256:…" # from: ssh-keygen -lf key.pub
+        public_key_file: keys/ci.pub  # or public_key: "ssh-ed25519 AAAA… ci@host"
+        # key_fingerprint is DERIVED from the key. Give it too only if you want
+        # it cross-checked: a mismatch stops the build rather than shipping a
+        # bundle that installs cleanly and refuses the login.
         sudo_allowed: true
         sudo_nopasswd: true
         shell: /bin/bash
@@ -408,7 +430,7 @@ _load_config_awk() {
                 apt_component)       [ "$APT_COMPONENT" = "$DEFAULT_APT_COMPONENT" ] && APT_COMPONENT="$val" ;;
                 # Service-account list keys: consumed by _parse_service_accounts_block,
                 # ignored here (they only appear nested under `service_accounts:`).
-                service_accounts|name|key_fingerprint|fingerprint|sudo_allowed|sudo_nopasswd|shell|home|gecos|uid|gid) : ;;
+                service_accounts|name|key_fingerprint|fingerprint|sudo_allowed|sudo_nopasswd|shell|home|gecos|uid|gid|public_key|public_key_file) : ;;
                 *) log_warn "Unknown config key '$key' (ignored)" ;;
             esac
         fi
@@ -418,7 +440,7 @@ _load_config_awk() {
 
 # ─────────────────────────────────────────────────────────────────────────
 # Service-account helpers.
-# A record packs the 9 fields (in the fixed order documented next to
+# A record packs the 10 fields (in the fixed order documented next to
 # SERVICE_ACCOUNTS_RECORDS) joined by the Unit Separator. _sa_pack builds one;
 # _sa_field N extracts the Nth field (1-based) from a record.
 # ─────────────────────────────────────────────────────────────────────────
@@ -431,6 +453,76 @@ _sa_field() {
     local -a _parts
     IFS="$_OB_SA_US" read -r -a _parts <<< "$rec"
     printf '%s' "${_parts[$((n - 1))]:-}"
+}
+
+# Compute the SHA256 fingerprint of an SSH public key, the way ssh-keygen -lf
+# prints it. Deriving it removes a whole class of failure: a fingerprint typed
+# or pasted separately from the key it is supposed to describe silently matches
+# nothing, and the login fails at the fingerprint check with the key looking
+# perfectly correct on both ends.
+_sa_fingerprint_of() {
+    local pub="$1" tmp out
+    command -v ssh-keygen >/dev/null 2>&1 || return 1
+    tmp=$(mktemp) || return 1
+    printf '%s\n' "$pub" > "$tmp"
+    out=$(ssh-keygen -lf "$tmp" 2>/dev/null) || { rm -f "$tmp"; return 1; }
+    rm -f "$tmp"
+    printf '%s' "$out" | awk '{print $2}' | grep -q '^SHA256:' || return 1
+    printf '%s' "$out" | awk '{print $2}'
+}
+
+# An SSH public key is one line: "<type> <base64> [comment]".
+_sa_is_valid_pubkey() {
+    local pub="$1"
+    case "$pub" in
+        ssh-rsa\ *|ssh-ed25519\ *|ecdsa-sha2-*\ *|sk-ssh-ed25519@*\ *|sk-ecdsa-sha2-*\ *) ;;
+        *) return 1 ;;
+    esac
+    case "$pub" in *$'\n'*) return 1 ;; esac
+    return 0
+}
+
+# Reconcile the public key and the fingerprint of the account being parsed.
+#
+# Three cases, and only the third can go wrong silently today:
+#   - key only        -> derive the fingerprint from it;
+#   - fingerprint only -> keep it, and say the key is still needed on the target;
+#   - both            -> derive and COMPARE. A mismatch is a build-time error,
+#                        not a warning: it means the two were maintained apart,
+#                        and on the target it shows up as a login refused with a
+#                        key that looks right in every listing.
+_sa_reconcile_key() {
+    local derived
+    if [ -n "$pubkey" ]; then
+        if ! _sa_is_valid_pubkey "$pubkey"; then
+            log_warn "service account '$name': public_key is not a single-line SSH public key; ignoring it."
+            pubkey=""
+        fi
+    fi
+    if [ -z "$pubkey" ]; then
+        [ -n "$fp" ] || return 0
+        return 0
+    fi
+
+    if ! derived=$(_sa_fingerprint_of "$pubkey"); then
+        log_warn "service account '$name': could not compute the fingerprint of public_key"
+        log_warn "  (is ssh-keygen installed on this build host?). The key is still deployed."
+        return 0
+    fi
+
+    if [ -z "$fp" ]; then
+        fp="$derived"
+        log_info "service account '$name': fingerprint derived from public_key ($fp)."
+        return 0
+    fi
+    if [ "$fp" != "$derived" ]; then
+        log_error "service account '$name': key_fingerprint does not match public_key."
+        log_error "  configured: $fp"
+        log_error "  actual:     $derived"
+        log_error "  One of the two is stale. On the target this is a login refused by PAM"
+        log_error "  with a key that looks correct everywhere you would think to check."
+        return 1
+    fi
 }
 
 # Validate one packed record. Mirrors the authoritative checks in
@@ -524,12 +616,17 @@ warn_service_account_unapproved() {
 _parse_service_accounts_block() {
     local f="$1"
     local in_block=0 line key val
-    local name fp sudo_allowed sudo_nopasswd shell home gecos uid gid
-    _sa_reset_fields() { name=""; fp=""; sudo_allowed="false"; sudo_nopasswd="false"; shell=""; home=""; gecos=""; uid=""; gid=""; }
+    local name fp sudo_allowed sudo_nopasswd shell home gecos uid gid pubkey
+    _sa_reset_fields() { name=""; fp=""; sudo_allowed="false"; sudo_nopasswd="false"; shell=""; home=""; gecos=""; uid=""; gid=""; pubkey=""; }
     local have_acct=0
     _sa_flush() {
         [ "$have_acct" = 1 ] || return 0
-        SERVICE_ACCOUNTS_RECORDS+=("$(_sa_pack "$name" "$fp" "$sudo_allowed" "$sudo_nopasswd" "$shell" "$home" "$gecos" "$uid" "$gid")")
+        # A key/fingerprint mismatch stops the build. Not a warning: the bundle
+        # would install cleanly and refuse the login on the target, which is the
+        # most expensive place to discover it. Explicit rather than relying on
+        # errexit, whose behaviour here depends on the calling context.
+        _sa_reconcile_key || exit 1
+        SERVICE_ACCOUNTS_RECORDS+=("$(_sa_pack "$name" "$fp" "$sudo_allowed" "$sudo_nopasswd" "$shell" "$home" "$gecos" "$uid" "$gid" "$pubkey")")
         have_acct=0
     }
     _sa_reset_fields
@@ -573,6 +670,17 @@ _parse_service_accounts_block() {
                 gecos)           gecos="$val" ;;
                 uid)             uid="$val" ;;
                 gid)             gid="$val" ;;
+                public_key)      pubkey="$val" ;;
+                public_key_file)
+                    # Read at BUILD time: the target has no access to the
+                    # builder's filesystem, and shipping a path would be a
+                    # promise the installer cannot keep.
+                    if [ -r "$val" ]; then
+                        pubkey=$(head -n1 "$val")
+                    else
+                        log_warn "service account '$name': public_key_file '$val' is not readable; ignoring."
+                    fi
+                    ;;
             esac
         fi
     done < "$f"
@@ -628,6 +736,21 @@ _render_service_accounts_conf() {
     # Explicit success: the loop's last command is a `&&` chain that is false
     # whenever the final account has no gid (the common case), which would make
     # this function return non-zero and trip `set -e` in the caller.
+    return 0
+}
+
+# Render the service-account public keys as "<name> <key>" lines, one per
+# account that has one. The installer writes each to
+# /etc/open-bastion/service-accounts.d/<name>.pub, which is what lets sshd
+# accept the key at all -- service-accounts.conf only says what to expect.
+_render_service_account_keys() {
+    local rec name pub
+    for rec in "${SERVICE_ACCOUNTS_RECORDS[@]}"; do
+        name=$(_sa_field 1 "$rec")
+        pub=$(_sa_field 10 "$rec")
+        [ -n "$pub" ] || continue
+        printf '%s %s\n' "$name" "$pub"
+    done
     return 0
 }
 
@@ -1338,6 +1461,7 @@ build_placeholder_map() {
     local _sa_enabled_bool="false" _sa_conf="" _sa_conf_b64="" _sa_file_line="" _sa_defaults_yaml
     if [ "${#SERVICE_ACCOUNTS_RECORDS[@]}" -gt 0 ]; then
         _sa_enabled_bool="true"
+        local _sa_keys _sa_keys_b64
         _sa_conf=$(_render_service_accounts_conf)
         _sa_conf_b64=$(base64_string "$_sa_conf")
         _sa_file_line=$'# Service accounts (SSH-key-only local accounts)\nservice_accounts_file = /etc/open-bastion/service-accounts.conf'
@@ -1345,11 +1469,22 @@ build_placeholder_map() {
         local _indented
         _indented=$(printf '%s\n' "$_sa_conf" | sed 's/^/  /')
         _sa_defaults_yaml=$'ob_service_accounts_enabled: true\nob_service_accounts_content: |\n'"$_indented"
+        _sa_keys=$(_render_service_account_keys)
+        _sa_keys_b64=$(base64_string "$_sa_keys")
+        if [ -n "$_sa_keys" ]; then
+            local _kindent
+            _kindent=$(printf '%s\n' "$_sa_keys" | sed 's/^/  /')
+            _sa_defaults_yaml="$_sa_defaults_yaml"$'\nob_service_account_keys: |\n'"$_kindent"
+        else
+            _sa_defaults_yaml="$_sa_defaults_yaml"$'\nob_service_account_keys: ""'
+        fi
     else
-        _sa_defaults_yaml='ob_service_accounts_enabled: false'$'\n''ob_service_accounts_content: ""'
+        _sa_defaults_yaml='ob_service_accounts_enabled: false'$'\n''ob_service_accounts_content: ""'$'\n''ob_service_account_keys: ""'
     fi
+    _sa_keys_b64="${_sa_keys_b64:-}"
     ph_set SERVICE_ACCOUNTS_ENABLED_BOOL  "$_sa_enabled_bool"
     ph_set SERVICE_ACCOUNTS_CONF_B64      "$_sa_conf_b64"
+    ph_set SERVICE_ACCOUNT_KEYS_B64       "$_sa_keys_b64"
     ph_set SERVICE_ACCOUNTS_FILE_LINE     "$_sa_file_line"
     ph_set SERVICE_ACCOUNTS_DEFAULTS_YAML "$_sa_defaults_yaml"
 

--- a/admin-builder/ob-builder
+++ b/admin-builder/ob-builder
@@ -86,6 +86,17 @@ SERVER_GROUP=""
 SERVER_GROUP_POLICY=""
 TARGET_ROLE=""
 AUTO_ENROLL_SETUP=""
+# Pass --enable-service-keys through to the setup script the bundle runs.
+#
+# Without it the bundle deploys the keys and then the setup run it launches
+# REMOVES the drop-in that serves them: a setup run without the flag cleans up
+# its own generated file (#265), and the installer's setup argv had no way to
+# carry one. The two features together were self-defeating.
+#
+# Defaults to on when any service account carries a key, since deploying a key
+# nothing serves is the exact state #263 was reported for; an explicit
+# `service_keys: false` overrides.
+SERVICE_KEYS_SETUP=""
 SELF_DELETE=""
 ALLOWED_BASTIONS=""
 ANSIBLE_AUTO_APPROVE=""
@@ -191,13 +202,15 @@ SERVICE ACCOUNTS (--config YAML):
   (#263). With it, the bundle also writes
   /etc/open-bastion/service-accounts.d/<name>.pub.
 
-  sshd still needs the AuthorizedKeysCommand that serves those files, which is
-  a host-wide change: run "ob-bastion-setup --enable-service-keys" (or
-  ob-backend-setup) on the target. The generated installer says so when it
-  cannot find one. Example:
+  sshd still needs the AuthorizedKeysCommand that serves those files. When any
+  account carries a key the bundle passes --enable-service-keys to the setup it
+  runs, so this is handled; set service_keys: false to opt out, or true to
+  force it. If setup is skipped, run it by hand on the target -- the installer
+  says so when it finds sshd not serving them. Example:
     service_accounts:
       - name: ci-ansible            # dedicated name (not an existing system user)
         public_key_file: keys/ci.pub  # or public_key: "ssh-ed25519 AAAA… ci@host"
+                                      # (relative to THIS file; the two are exclusive)
         # key_fingerprint is DERIVED from the key. Give it too only if you want
         # it cross-checked: a mismatch stops the build rather than shipping a
         # bundle that installs cleanly and refuses the login.
@@ -365,6 +378,7 @@ _load_config_yq() {
     v=$(_yq_get server_group_policy); [ -n "$v" ] && SERVER_GROUP_POLICY="$v"
     v=$(_yq_get target_role);         [ -n "$v" ] && TARGET_ROLE="$v"
     v=$(_yq_get auto_enroll_setup);   [ -n "$v" ] && AUTO_ENROLL_SETUP="$v"
+    v=$(_yq_get service_keys);        [ -n "$v" ] && SERVICE_KEYS_SETUP="$v"
     v=$(_yq_get self_delete);         [ -n "$v" ] && SELF_DELETE="$v"
     v=$(_yq_get allowed_bastions);    [ -n "$v" ] && ALLOWED_BASTIONS="$v"
     v=$(_yq_get ansible_auto_approve); [ -n "$v" ] && ANSIBLE_AUTO_APPROVE="$v"
@@ -418,6 +432,7 @@ _load_config_awk() {
                 server_group_policy) SERVER_GROUP_POLICY="$val" ;;
                 target_role)         TARGET_ROLE="$val" ;;
                 auto_enroll_setup)   AUTO_ENROLL_SETUP="$val" ;;
+                service_keys)        SERVICE_KEYS_SETUP="$val" ;;
                 self_delete)         SELF_DELETE="$val" ;;
                 allowed_bastions)    ALLOWED_BASTIONS="$val" ;;
                 ansible_auto_approve) ANSIBLE_AUTO_APPROVE="$val" ;;
@@ -461,24 +476,51 @@ _sa_field() {
 # nothing, and the login fails at the fingerprint check with the key looking
 # perfectly correct on both ends.
 _sa_fingerprint_of() {
-    local pub="$1" tmp out
+    local pub="$1" alg="${2:-sha256}" tmp out got
     command -v ssh-keygen >/dev/null 2>&1 || return 1
     tmp=$(mktemp) || return 1
     printf '%s\n' "$pub" > "$tmp"
-    out=$(ssh-keygen -lf "$tmp" 2>/dev/null) || { rm -f "$tmp"; return 1; }
+    out=$(ssh-keygen -E "$alg" -lf "$tmp" 2>/dev/null) || { rm -f "$tmp"; return 1; }
     rm -f "$tmp"
-    printf '%s' "$out" | awk '{print $2}' | grep -q '^SHA256:' || return 1
-    printf '%s' "$out" | awk '{print $2}'
+    got=$(printf '%s' "$out" | awk '{print $2}')
+    case "$alg:$got" in
+        sha256:SHA256:*|md5:MD5:*) printf '%s' "$got" ;;
+        *) return 1 ;;
+    esac
 }
 
 # An SSH public key is one line: "<type> <base64> [comment]".
+# Normalise an authorized_keys line to the bare "<type> <base64> [comment]" the
+# helper serves, dropping any options prefix. A public_key_file pointed at a copy
+# of someone's authorized_keys is the obvious way to get one, and silently
+# refusing it produced the #263 shape: no .pub deployed, everything else fine.
+_sa_strip_key_options() {
+    local line="$1"
+    case "$line" in
+        ssh-*|ecdsa-*|sk-*) printf '%s' "$line"; return 0 ;;
+    esac
+    # Options come first, then the key type. Find the first field that looks
+    # like one and keep from there.
+    printf '%s' "$line" | grep -oE '(ssh-(rsa|ed25519|dss)|ecdsa-sha2-[a-z0-9]+|sk-(ssh-ed25519|ecdsa-sha2-nistp256)@openssh\.com)[[:space:]].*$' \
+        || printf '%s' "$line"
+}
+
+# One line, a supported plain key type, and not a certificate.
+#
+# Certificates are rejected on purpose: the helper serves the file to sshd as an
+# authorized key, and a cert is not one. The previous globs let
+# ecdsa-sha2-*-cert-v01@openssh.com through while rejecting the ed25519 and rsa
+# cert forms -- an accident of glob order, not a policy.
 _sa_is_valid_pubkey() {
     local pub="$1"
+    case "$pub" in *$'\n'*) return 1 ;; esac
+    case "$pub" in *-cert-v01@openssh.com\ *) return 1 ;; esac
     case "$pub" in
-        ssh-rsa\ *|ssh-ed25519\ *|ecdsa-sha2-*\ *|sk-ssh-ed25519@*\ *|sk-ecdsa-sha2-*\ *) ;;
+        ssh-rsa\ *|ssh-ed25519\ *|ssh-dss\ *) ;;
+        ecdsa-sha2-nistp256\ *|ecdsa-sha2-nistp384\ *|ecdsa-sha2-nistp521\ *) ;;
+        sk-ssh-ed25519@openssh.com\ *|sk-ecdsa-sha2-nistp256@openssh.com\ *) ;;
         *) return 1 ;;
     esac
-    case "$pub" in *$'\n'*) return 1 ;; esac
     return 0
 }
 
@@ -492,22 +534,52 @@ _sa_is_valid_pubkey() {
 #                        and on the target it shows up as a login refused with a
 #                        key that looks right in every listing.
 _sa_reconcile_key() {
-    local derived
-    if [ -n "$pubkey" ]; then
-        if ! _sa_is_valid_pubkey "$pubkey"; then
-            log_warn "service account '$name': public_key is not a single-line SSH public key; ignoring it."
-            pubkey=""
-        fi
+    local derived want_alg="sha256"
+
+    # A key that is present but unusable is an ERROR, not a warning.
+    #
+    # Warning and continuing produced the asymmetry the review caught: a stale
+    # but parseable fingerprint killed the build, while a corrupt key shipped
+    # and refused the login on the target. The second is the failure #263 is
+    # about, so it gets the louder treatment, not the quieter one.
+    if [ -n "$pubkey" ] && ! _sa_is_valid_pubkey "$pubkey"; then
+        log_error "service account '$name': public_key is not a usable SSH public key."
+        log_error "  got: ${pubkey:0:60}..."
+        log_error "  Expected one line: '<type> <base64> [comment]'. Options prefixes"
+        log_error "  (restrict,from=...) are stripped automatically; certificates are not"
+        log_error "  supported here -- deploy the plain public key."
+        return 1
     fi
+
     if [ -z "$pubkey" ]; then
-        [ -n "$fp" ] || return 0
+        # Fingerprint-only. Promised a message here and never emitted one; the
+        # branch was dead code. It matters: this is the pre-#263 shape, and the
+        # bundle cannot make the account work on its own.
+        if [ -n "$fp" ]; then
+            log_warn "service account '$name': key_fingerprint without public_key."
+            log_warn "  The bundle will deploy service-accounts.conf but no"
+            log_warn "  /etc/open-bastion/service-accounts.d/$name.pub, so sshd has no key to"
+            log_warn "  offer and the account cannot log in until you deploy one by hand."
+            log_warn "  Add public_key or public_key_file to have this handled for you."
+        fi
         return 0
     fi
 
-    if ! derived=$(_sa_fingerprint_of "$pubkey"); then
-        log_warn "service account '$name': could not compute the fingerprint of public_key"
-        log_warn "  (is ssh-keygen installed on this build host?). The key is still deployed."
-        return 0
+    # Derive in the same algorithm the operator used, so an existing MD5 entry
+    # can gain a public_key without the cross-check declaring both values stale.
+    # is_valid_fingerprint, the questionnaire and src/service_account.c all still
+    # accept MD5; refusing it here would have made this PR's own remediation
+    # ("add the key") impossible for those entries.
+    case "$fp" in
+        MD5:*) want_alg="md5" ;;
+    esac
+
+    if ! derived=$(_sa_fingerprint_of "$pubkey" "$want_alg"); then
+        log_error "service account '$name': could not compute the fingerprint of public_key."
+        log_error "  ssh-keygen rejected it, or is not installed on this build host."
+        log_error "  Refusing rather than shipping a key nothing has validated: on the"
+        log_error "  target that is a login refused with everything looking deployed."
+        return 1
     fi
 
     if [ -z "$fp" ]; then
@@ -524,7 +596,6 @@ _sa_reconcile_key() {
         return 1
     fi
 }
-
 # Validate one packed record. Mirrors the authoritative checks in
 # src/service_account.c so a bad value is caught at build time rather than
 # failing the PAM module load on the target.
@@ -555,6 +626,16 @@ warn_service_account_unapproved() {
     local name home shell uid gid pfx ok
     name=$(_sa_field 1 "$rec"); shell=$(_sa_field 5 "$rec"); home=$(_sa_field 6 "$rec")
     uid=$(_sa_field 8 "$rec"); gid=$(_sa_field 9 "$rec")
+    # Field 10 too. This function's contract is "a bad value is caught at build
+    # time rather than failing on the target", and a record built anywhere other
+    # than _sa_flush -- the interactive loop, a future caller -- would otherwise
+    # reach the deployment with a key nothing had looked at.
+    local pub
+    pub=$(_sa_field 10 "$rec")
+    if [ -n "$pub" ] && ! _sa_is_valid_pubkey "$pub"; then
+        log_error "service account '$name': public_key is not a usable SSH public key."
+        return 1
+    fi
     # Reserved system name: still accepted, but the existing account is used as-is
     # (the config's shell/home/uid apply only to accounts ob-bastion creates).
     for pfx in $_OB_SA_SYSTEM_NAMES; do
@@ -617,10 +698,22 @@ _parse_service_accounts_block() {
     local f="$1"
     local in_block=0 line key val
     local name fp sudo_allowed sudo_nopasswd shell home gecos uid gid pubkey
-    _sa_reset_fields() { name=""; fp=""; sudo_allowed="false"; sudo_nopasswd="false"; shell=""; home=""; gecos=""; uid=""; gid=""; pubkey=""; }
+    local _sa_key_conflict=0
+    _sa_reset_fields() { name=""; fp=""; sudo_allowed="false"; sudo_nopasswd="false"; shell=""; home=""; gecos=""; uid=""; gid=""; pubkey=""; _sa_key_conflict=0; }
     local have_acct=0
     _sa_flush() {
         [ "$have_acct" = 1 ] || return 0
+        # Both public_key and public_key_file: which one wins was decided by
+        # line order, silently. An operator rotating a key by adding the new
+        # form above the old one would have shipped the OLD key -- and, with a
+        # fingerprint matching the intended one, been told the value that was
+        # actually shipped is the "stale" one.
+        if [ "$_sa_key_conflict" = 1 ]; then
+            log_error "service account '$name': both public_key and public_key_file are set."
+            log_error "  Which one wins would depend on their order in the file. Keep one."
+            exit 1
+        fi
+
         # A key/fingerprint mismatch stops the build. Not a warning: the bundle
         # would install cleanly and refuse the login on the target, which is the
         # most expensive place to discover it. Explicit rather than relying on
@@ -670,15 +763,34 @@ _parse_service_accounts_block() {
                 gecos)           gecos="$val" ;;
                 uid)             uid="$val" ;;
                 gid)             gid="$val" ;;
-                public_key)      pubkey="$val" ;;
+                public_key)
+                    [ -z "$pubkey" ] || { _sa_key_conflict=1; }
+                    pubkey=$(_sa_strip_key_options "$val")
+                    ;;
                 public_key_file)
                     # Read at BUILD time: the target has no access to the
                     # builder's filesystem, and shipping a path would be a
                     # promise the installer cannot keep.
-                    if [ -r "$val" ]; then
-                        pubkey=$(head -n1 "$val")
+                    #
+                    # Resolved against the CONFIG FILE's directory, not the
+                    # builder's cwd. The documented example is relative
+                    # ("keys/ci.pub"), and resolving it from wherever the build
+                    # was launched made a correct config fail depending on the
+                    # caller's directory.
+                    [ -z "$pubkey" ] || { _sa_key_conflict=1; }
+                    local _kf="$val"
+                    case "$_kf" in
+                        /*) ;;
+                        *) _kf="$(dirname "$f")/$val" ;;
+                    esac
+                    if [ -r "$_kf" ]; then
+                        pubkey=$(_sa_strip_key_options "$(head -n1 "$_kf")")
                     else
-                        log_warn "service account '$name': public_key_file '$val' is not readable; ignoring."
+                        log_error "service account '$name': public_key_file '$val' is not readable."
+                        log_error "  looked for: $_kf (relative paths resolve against the config file)"
+                        log_error "  Refusing: continuing would ship the account without its key, which"
+                        log_error "  is the state #263 was reported for."
+                        exit 1
                     fi
                     ;;
             esac
@@ -793,7 +905,16 @@ collect_service_accounts_interactive() {
         uid=$(ask "  Fixed UID (recommended; empty = auto)" "")
         gid=$(ask "  Fixed GID (recommended; empty = auto)" "")
 
-        rec=$(_sa_pack "$name" "$fp" "$sudo_allowed" "$sudo_nopasswd" "$shell" "$home" "$gecos" "$uid" "$gid")
+        # Ten fields, like the YAML path: a 9-field record leaves field 10
+        # undefined rather than empty, and every consumer would have to know it.
+        # The questionnaire does not ask for a key yet, so it is empty here --
+        # and that is exactly the shape worth warning about.
+        rec=$(_sa_pack "$name" "$fp" "$sudo_allowed" "$sudo_nopasswd" "$shell" "$home" "$gecos" "$uid" "$gid" "")
+        log_warn "service account '$name': no public key given."
+        log_warn "  The bundle will deploy service-accounts.conf but no"
+        log_warn "  /etc/open-bastion/service-accounts.d/$name.pub, so sshd has no key to"
+        log_warn "  offer and the account cannot log in until you deploy one by hand."
+        log_warn "  Use --config with public_key_file to have this handled for you."
         if validate_service_account_record "$rec"; then
             SERVICE_ACCOUNTS_RECORDS+=("$rec")
             log_info "Added service account '$name' (${#SERVICE_ACCOUNTS_RECORDS[@]} total)."
@@ -1482,6 +1603,18 @@ build_placeholder_map() {
         _sa_defaults_yaml='ob_service_accounts_enabled: false'$'\n''ob_service_accounts_content: ""'$'\n''ob_service_account_keys: ""'
     fi
     _sa_keys_b64="${_sa_keys_b64:-}"
+
+    # Default on when any account carries a key: shipping a key that nothing
+    # serves is the state #263 was reported for. An explicit `service_keys:`
+    # in the config wins either way.
+    local _svc_keys_bool="false"
+    case "$(printf '%s' "${SERVICE_KEYS_SETUP:-}" | tr 'A-Z' 'a-z')" in
+        true|yes|1|on)   _svc_keys_bool="true" ;;
+        false|no|0|off)  _svc_keys_bool="false" ;;
+        "") [ -n "${_sa_keys:-}" ] && _svc_keys_bool="true" ;;
+        *)  log_warn "service_keys: unrecognised value '${SERVICE_KEYS_SETUP}', treating as false" ;;
+    esac
+    ph_set SERVICE_KEYS_SETUP_BOOL        "$_svc_keys_bool"
     ph_set SERVICE_ACCOUNTS_ENABLED_BOOL  "$_sa_enabled_bool"
     ph_set SERVICE_ACCOUNTS_CONF_B64      "$_sa_conf_b64"
     ph_set SERVICE_ACCOUNT_KEYS_B64       "$_sa_keys_b64"

--- a/admin-builder/templates/ansible/role/tasks/main.yml.in
+++ b/admin-builder/templates/ansible/role/tasks/main.yml.in
@@ -97,5 +97,49 @@
     mode: '0600'
   when: ob_service_accounts_enabled | default(false)
 
+# service-accounts.conf says what fingerprint to expect; it gives sshd nothing
+# to accept. Without these files the account cannot log in and the deployment
+# looks complete (#263). 0644 under a 0755 directory: the
+# AuthorizedKeysCommandUser (nobody) reads them.
+- name: Create the service-account key directory
+  ansible.builtin.file:
+    path: /etc/open-bastion/service-accounts.d
+    state: directory
+    owner: root
+    group: root
+    mode: '0755'
+  when: (ob_service_account_keys | default('')) | length > 0
+
+- name: Deploy service-account public keys
+  ansible.builtin.copy:
+    content: "{{ item.split(' ', 1)[1] }}\n"
+    dest: "/etc/open-bastion/service-accounts.d/{{ item.split(' ', 1)[0] }}.pub"
+    owner: root
+    group: root
+    mode: '0644'
+  loop: "{{ (ob_service_account_keys | default('')).splitlines() | select('search', ' ') | list }}"
+  loop_control:
+    label: "{{ item.split(' ', 1)[0] }}"
+
+# The keys are only half of it: sshd needs the AuthorizedKeysCommand that serves
+# them, which is a host-wide change and therefore opt-in.
+- name: Check sshd serves the service-account keys
+  ansible.builtin.command:
+    cmd: grep -rqs ob-service-account-keys /etc/ssh/sshd_config.d/ /etc/ssh/sshd_config
+  register: ob_svc_keys_sshd
+  changed_when: false
+  failed_when: false
+  when: (ob_service_account_keys | default('')) | length > 0
+
+- name: Warn when sshd has no AuthorizedKeysCommand for service accounts
+  ansible.builtin.debug:
+    msg: >-
+      Service-account keys were deployed, but sshd has no AuthorizedKeysCommand
+      to serve them. Run "ob-bastion-setup --enable-service-keys" (or
+      ob-backend-setup) on this host, or the accounts cannot log in.
+  when:
+    - (ob_service_account_keys | default('')) | length > 0
+    - ob_svc_keys_sshd.rc | default(1) != 0
+
 - name: Dispatch role-specific tasks
   ansible.builtin.include_tasks: "{{ ob_role }}.yml"

--- a/admin-builder/templates/ansible/role/tasks/main.yml.in
+++ b/admin-builder/templates/ansible/role/tasks/main.yml.in
@@ -55,7 +55,10 @@
     state: directory
     owner: root
     group: root
-    mode: '0700'
+    # 0711, not 0700: the AuthorizedKeysCommandUser (nobody) must traverse this
+    # directory to read service-accounts.d/<name>.pub. Secrets inside are each
+    # 0600 root, so traverse-only is safe and the directory stays unlistable.
+    mode: '0711'
 
 - name: Deploy SSH CA public key
   ansible.builtin.copy:
@@ -123,13 +126,42 @@
 
 # The keys are only half of it: sshd needs the AuthorizedKeysCommand that serves
 # them, which is a host-wide change and therefore opt-in.
+# Remove keys for accounts no longer declared. Without this the directory is
+# write-only: dropping an account from service_accounts: converges the .conf but
+# leaves its .pub served, and ob-service-account-keys offers ANY present file
+# without consulting the .conf -- so the account keeps being offered at the SSH
+# layer indefinitely, and re-adding it fingerprint-only makes sshd offer the
+# stale key while PAM denies it.
+- name: Remove service-account keys that are no longer declared
+  ansible.builtin.shell: |
+    set -eu
+    keep=$(printf '%s\n' "{{ ob_service_account_keys | default('') }}" \
+           | awk 'NF {print $1 ".pub"}')
+    cd /etc/open-bastion/service-accounts.d 2>/dev/null || exit 0
+    for f in *.pub; do
+      [ -e "$f" ] || continue
+      printf '%s\n' "$keep" | grep -qxF "$f" || { rm -f -- "$f"; echo "removed $f"; }
+    done
+  register: ob_svc_keys_pruned
+  changed_when: "'removed ' in ob_svc_keys_pruned.stdout"
+
+# Anchored, and over *.conf only: `grep -r ob-service-account-keys` matched a
+# commented-out line, a .bak left beside a drop-in, or a pre-#265 two-directive
+# file with no ExposeAuthInfo -- all of which silence the warning while nothing
+# is actually served or verified.
 - name: Check sshd serves the service-account keys
-  ansible.builtin.command:
-    cmd: grep -rqs ob-service-account-keys /etc/ssh/sshd_config.d/ /etc/ssh/sshd_config
+  ansible.builtin.shell: |
+    set -eu
+    ok=1
+    for f in /etc/ssh/sshd_config.d/*.conf /etc/ssh/sshd_config; do
+      [ -f "$f" ] || continue
+      grep -qiE '^[[:space:]]*AuthorizedKeysCommand[[:space:]].*ob-service-account-keys' "$f" || continue
+      grep -qiE '^[[:space:]]*ExposeAuthInfo[[:space:]]+yes' "$f" && ok=0
+    done
+    exit $ok
   register: ob_svc_keys_sshd
   changed_when: false
   failed_when: false
-  when: (ob_service_account_keys | default('')) | length > 0
 
 - name: Warn when sshd has no AuthorizedKeysCommand for service accounts
   ansible.builtin.debug:
@@ -138,7 +170,7 @@
       to serve them. Run "ob-bastion-setup --enable-service-keys" (or
       ob-backend-setup) on this host, or the accounts cannot log in.
   when:
-    - (ob_service_account_keys | default('')) | length > 0
+    - ob_service_accounts_enabled | default(false)
     - ob_svc_keys_sshd.rc | default(1) != 0
 
 - name: Dispatch role-specific tasks

--- a/admin-builder/templates/shell/installer.sh.in
+++ b/admin-builder/templates/shell/installer.sh.in
@@ -467,7 +467,12 @@ step_config() {
     fi
 
     mkdir -p /etc/open-bastion
-    chmod 0700 /etc/open-bastion
+    # 0711, not 0700: the AuthorizedKeysCommandUser (nobody) has to traverse
+    # this directory to read service-accounts.d/<name>.pub. Every secret inside
+    # is individually 0600 root, so traverse-only is safe -- the directory stays
+    # unlistable. At 0700 the helper's stat fails with EACCES, it exits 0 with
+    # no output, and sshd refuses the login with everything looking deployed.
+    chmod 0711 /etc/open-bastion
 
     # Write openbastion.conf — substitute runtime-resolved values in the
     # embedded template. ##VAR## are runtime placeholders; @@VAR@@ were
@@ -511,24 +516,60 @@ OB_CONF_EOF
     # Deposit each service account's authorized public key. service-accounts.conf
     # tells pam_openbastion what fingerprint to expect; it gives sshd nothing to
     # accept, so without these files the account cannot log in at all and the
-    # deployment looks complete (#263). 0644 root:root under a 0755 directory:
-    # the AuthorizedKeysCommandUser (nobody) has to read them.
+    # deployment looks complete (#263). 0644 root:root under a 0711 parent: the
+    # AuthorizedKeysCommandUser (nobody) has to read them.
+    install -d -m 0755 -o root -g root /etc/open-bastion/service-accounts.d
     if [ -n "@@SERVICE_ACCOUNT_KEYS_B64@@" ]; then
-        install -d -m 0755 -o root -g root /etc/open-bastion/service-accounts.d
-        printf '%s' "@@SERVICE_ACCOUNT_KEYS_B64@@" | base64 -d | while read -r _sa_name _sa_key; do
+        _sa_keep=""
+        # temp+mv per account, like the conf and CA writes above. A bare `>`
+        # under this installer's `set -euo pipefail` aborted the WHOLE run on
+        # the first failed write -- with service-accounts.conf already committed,
+        # so some accounts had keys and the rest never would, and the error named
+        # no account.
+        printf '%s' "@@SERVICE_ACCOUNT_KEYS_B64@@" | base64 -d > /tmp/.ob-sa-keys.$$
+        while read -r _sa_name _sa_key; do
             [ -n "${_sa_name}" ] || continue
-            printf '%s\n' "${_sa_key}" > "/etc/open-bastion/service-accounts.d/${_sa_name}.pub"
-            chmod 0644 "/etc/open-bastion/service-accounts.d/${_sa_name}.pub"
-            chown root:root "/etc/open-bastion/service-accounts.d/${_sa_name}.pub"
-            log_info "Written: /etc/open-bastion/service-accounts.d/${_sa_name}.pub"
+            _sa_dst="/etc/open-bastion/service-accounts.d/${_sa_name}.pub"
+            _sa_tmpk=$(mktemp "${_sa_dst}.XXXXXX") || die "cannot create a temp file for ${_sa_name}.pub"
+            printf '%s\n' "${_sa_key}" > "${_sa_tmpk}" || die "cannot write the key for ${_sa_name}"
+            chmod 0644 "${_sa_tmpk}"
+            chown root:root "${_sa_tmpk}"
+            mv -f "${_sa_tmpk}" "${_sa_dst}" || die "cannot install ${_sa_dst}"
+            _sa_keep="${_sa_keep} ${_sa_name}.pub"
+            log_info "Written: ${_sa_dst}"
+        done < /tmp/.ob-sa-keys.$$
+        rm -f /tmp/.ob-sa-keys.$$
+
+        # Remove keys for accounts no longer declared. Without this the directory
+        # is write-only: dropping an account from the config converges the .conf
+        # but leaves its .pub served, and ob-service-account-keys offers ANY
+        # present file without consulting the .conf.
+        for _sa_old in /etc/open-bastion/service-accounts.d/*.pub; do
+            [ -e "${_sa_old}" ] || continue
+            case " ${_sa_keep} " in
+                *" $(basename "${_sa_old}") "*) ;;
+                *) rm -f "${_sa_old}"; log_info "Removed stale ${_sa_old}" ;;
+            esac
         done
-        # The key is only half of it: sshd still needs the AuthorizedKeysCommand
-        # that serves these files. That is a host-wide sshd change, so it stays
-        # opt-in rather than being made here.
-        if ! grep -rqs 'ob-service-account-keys' /etc/ssh/sshd_config.d/ /etc/ssh/sshd_config; then
-            log_warn "sshd has no AuthorizedKeysCommand for service accounts."
-            log_warn "These keys will not be offered until you run:"
-            log_warn "  ob-bastion-setup --enable-service-keys   (or ob-backend-setup)"
+    fi
+
+    # sshd must actually serve them, and with ExposeAuthInfo or the fingerprint
+    # is never checked. Anchored and over *.conf only: a plain `grep -r` matched
+    # a commented-out line or a .bak beside a drop-in and stayed silent while
+    # nothing was served. Reported whenever service accounts are configured, not
+    # only when this bundle carried keys -- a fingerprint-only bundle has the
+    # same problem and used to say nothing.
+    if [ -n "@@SERVICE_ACCOUNTS_CONF_B64@@" ]; then
+        _sa_served=1
+        for _sa_f in /etc/ssh/sshd_config.d/*.conf /etc/ssh/sshd_config; do
+            [ -f "${_sa_f}" ] || continue
+            grep -qiE '^[[:space:]]*AuthorizedKeysCommand[[:space:]].*ob-service-account-keys' "${_sa_f}" || continue
+            grep -qiE '^[[:space:]]*ExposeAuthInfo[[:space:]]+yes' "${_sa_f}" && _sa_served=0
+        done
+        if [ "${_sa_served}" -ne 0 ]; then
+            log_warn "sshd does not serve service-account keys (or does so without ExposeAuthInfo)."
+            log_warn "Without both, the account cannot log in, or its fingerprint is never checked."
+            log_warn "Run:  ob-bastion-setup --enable-service-keys   (or ob-backend-setup)"
         fi
     fi
 
@@ -714,6 +755,10 @@ step_setup() {
             [ "${PAM_MODE}" = "E" ] && _setup_opts+=("--max-security")
             [ "${OPT_INSECURE}" = "true" ] && _setup_opts+=("-k")
             [ "${ENABLE_HARDENING}" = "yes" ] && _setup_opts+=("--enable-hardening")
+            # Without this the setup run below REMOVES the drop-in we just
+            # deployed: a run without the flag cleans up its own generated file
+            # (#265), so the bundle would tear down its own work and end green.
+            [ "@@SERVICE_KEYS_SETUP_BOOL@@" = "true" ] && _setup_opts+=("--enable-service-keys")
             [ "${ENABLE_AUDIT_TRACE}" = "yes" ] && _setup_opts+=("--enable-audit-trace")
             [ "${DISABLE_SESSION_RECORDER}" = "yes" ] && _setup_opts+=("--disable-session-recorder")
             if [ "${OPT_DRY_RUN}" = "true" ]; then
@@ -740,6 +785,10 @@ step_setup() {
             [ "${PAM_MODE}" = "E" ] && _setup_opts+=("--max-security")
             [ "${OPT_INSECURE}" = "true" ] && _setup_opts+=("-k")
             [ "${ENABLE_HARDENING}" = "yes" ] && _setup_opts+=("--enable-hardening")
+            # Without this the setup run below REMOVES the drop-in we just
+            # deployed: a run without the flag cleans up its own generated file
+            # (#265), so the bundle would tear down its own work and end green.
+            [ "@@SERVICE_KEYS_SETUP_BOOL@@" = "true" ] && _setup_opts+=("--enable-service-keys")
             [ "${ENABLE_AUDIT_TRACE}" = "yes" ] && _setup_opts+=("--enable-audit-trace")
             if [ "${OPT_DRY_RUN}" = "true" ]; then
                 log_info "[DRY-RUN] Would run: OB_CLIENT_SECRET=<secret> /usr/sbin/ob-backend-setup ${_setup_opts[*]}"

--- a/admin-builder/templates/shell/installer.sh.in
+++ b/admin-builder/templates/shell/installer.sh.in
@@ -508,6 +508,30 @@ OB_CONF_EOF
         log_info "Written: /etc/open-bastion/service-accounts.conf (0600 root:root)"
     fi
 
+    # Deposit each service account's authorized public key. service-accounts.conf
+    # tells pam_openbastion what fingerprint to expect; it gives sshd nothing to
+    # accept, so without these files the account cannot log in at all and the
+    # deployment looks complete (#263). 0644 root:root under a 0755 directory:
+    # the AuthorizedKeysCommandUser (nobody) has to read them.
+    if [ -n "@@SERVICE_ACCOUNT_KEYS_B64@@" ]; then
+        install -d -m 0755 -o root -g root /etc/open-bastion/service-accounts.d
+        printf '%s' "@@SERVICE_ACCOUNT_KEYS_B64@@" | base64 -d | while read -r _sa_name _sa_key; do
+            [ -n "${_sa_name}" ] || continue
+            printf '%s\n' "${_sa_key}" > "/etc/open-bastion/service-accounts.d/${_sa_name}.pub"
+            chmod 0644 "/etc/open-bastion/service-accounts.d/${_sa_name}.pub"
+            chown root:root "/etc/open-bastion/service-accounts.d/${_sa_name}.pub"
+            log_info "Written: /etc/open-bastion/service-accounts.d/${_sa_name}.pub"
+        done
+        # The key is only half of it: sshd still needs the AuthorizedKeysCommand
+        # that serves these files. That is a host-wide sshd change, so it stays
+        # opt-in rather than being made here.
+        if ! grep -rqs 'ob-service-account-keys' /etc/ssh/sshd_config.d/ /etc/ssh/sshd_config; then
+            log_warn "sshd has no AuthorizedKeysCommand for service accounts."
+            log_warn "These keys will not be offered until you run:"
+            log_warn "  ob-bastion-setup --enable-service-keys   (or ob-backend-setup)"
+        fi
+    fi
+
     # Deposit SSH CA public key
     base64 -d > /etc/ssh/open-bastion_ca.pub.tmp << 'OB_CA_EOF'
 @@CA_SSH_PUB_B64@@

--- a/doc/service-accounts.md
+++ b/doc/service-accounts.md
@@ -101,6 +101,8 @@ ssh-keygen -lf /path/to/key.pub
 | Option            | Required | Description                                                                                                                                                                      |
 | ----------------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `key_fingerprint` | Yes      | SSH key fingerprint (SHA256:... or MD5:...)                                                                                                                                      |
+| `public_key`      | No†      | The account's SSH public key. Deployed to `service-accounts.d/<name>.pub`; `key_fingerprint` is derived from it                                                                  |
+| `public_key_file` | No†      | Path to that key, resolved against the config file's directory and read at build time. Mutually exclusive with `public_key`                                                      |
 | `sudo_allowed`    | No       | Allow sudo access (default: false)                                                                                                                                               |
 | `sudo_nopasswd`   | No       | Sudo without re-proving the key (default: false) — see [Sudo and the key check](#sudo-and-the-key-check)                                                                         |
 | `gecos`           | No       | User description                                                                                                                                                                 |
@@ -108,6 +110,9 @@ ssh-keygen -lf /path/to/key.pub
 | `home`            | No       | Home directory — must be under `approved_home_prefixes` (default `/home:/var/home`) or the account is dropped                                                                    |
 | `uid`             | See note | Fixed UID. **Required (with `gid`) for SSH-reachable accounts** — NSS resolves them only when both are set; `0` = auto-assign (works only if the account already exists locally) |
 | `gid`             | See note | Fixed GID. See `uid`                                                                                                                                                             |
+
+† Not required by the file format, but one of the two is what makes the account
+usable: without a key the bundle deploys no `.pub` and `sshd` has nothing to offer.
 
 ## How It Works
 
@@ -143,14 +148,16 @@ service accounts once in [`ob-builder`](../admin-builder/README.md) and have the
 baked into the generated shell installer and/or Ansible role.
 
 **Interactive:** the questionnaire asks whether to define service accounts and
-loops over name / fingerprint / sudo / shell / home for each.
+loops over name / fingerprint / sudo / shell / home for each. It does not ask for
+a public key, so a bundle built this way deploys no `.pub` and warns about it;
+use `--config` when you want the SSH layer handled for you.
 
 **Non-interactive (`--config`):** add a `service_accounts:` list to the YAML:
 
 ```yaml
 service_accounts:
   - name: ci-ansible # avoid system names like 'ansible' only if they exist; use a dedicated name
-    key_fingerprint: "SHA256:abc123def456..."
+    public_key_file: keys/ci-ansible.pub # key_fingerprint is derived from it
     sudo_allowed: true
     sudo_nopasswd: true
     shell: /bin/bash
@@ -159,7 +166,7 @@ service_accounts:
     uid: 6001 # fixed uid+gid → NSS-resolvable → reachable over SSH
     gid: 6001
   - name: obbackup
-    key_fingerprint: "SHA256:xyz789..."
+    public_key: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAA… backup@ops"
     sudo_allowed: false
     shell: /bin/sh
     home: /home/obbackup
@@ -181,11 +188,14 @@ warning above) — then:
 
 Service accounts apply to every role (bastion, backend, standalone).
 
-> **ob-builder deposits the fingerprint, not the public key.** The generated
-> `service-accounts.conf` carries `key_fingerprint` only. That is what
-> `pam_openbastion` checks, but it is **not** enough for `sshd` to accept the
-> connection — you must also authorize the public key at the SSH layer (next
-> section). This is an explicit, documented manual step.
+> **Give each account its `public_key`, or the SSH layer is left to you.** With a
+> key, `ob-builder` derives the fingerprint, writes `service-accounts.conf` **and**
+> deploys `/etc/open-bastion/service-accounts.d/<name>.pub` — see
+> [Letting ob-builder deploy the key](#letting-ob-builder-deploy-the-key) below.
+> With `key_fingerprint` alone the bundle carries no key, `sshd` has nothing to
+> accept, and the account cannot log in until you deploy one by hand: that is
+> what `pam_openbastion` checks, and it is **not** what lets the connection in.
+> The build warns when an account is in that state.
 
 ## Authorizing the public key at the SSH layer
 

--- a/doc/service-accounts.md
+++ b/doc/service-accounts.md
@@ -219,6 +219,28 @@ the public key. So `sshd` must be told the key is acceptable, by one of:
   Drop each account's public key at `/etc/open-bastion/service-accounts.d/<name>.pub`
   and reload `sshd`.
 
+### Letting ob-builder deploy the key
+
+Since #263 a `service_accounts:` entry can carry the key itself, and then the
+generated bundle writes `/etc/open-bastion/service-accounts.d/<name>.pub` for you:
+
+```yaml
+service_accounts:
+  - name: ci-ansible
+    public_key_file: keys/ci.pub # or public_key: "ssh-ed25519 AAAA… ci@host"
+    uid: 6001
+    gid: 6001
+```
+
+`key_fingerprint` is **derived** from the key. Supply it as well only if you want it
+cross-checked — a value that does not describe the key stops the build, rather than
+producing a bundle that installs cleanly and refuses the login with a key that looks
+correct in every listing.
+
+The bundle still cannot turn on the `AuthorizedKeysCommand`: that is a host-wide sshd
+change, so it stays with `--enable-service-keys`. The generated installer and the
+Ansible role both say so when they find no such command configured.
+
 ### What actually enforces the fingerprint, and when it does not
 
 Read this before relying on `key_fingerprint`.

--- a/tests/test_ob_builder_service_accounts.sh
+++ b/tests/test_ob_builder_service_accounts.sh
@@ -174,7 +174,7 @@ echo ""
 # fingerprint maintained apart from the key it describes matches nothing, and
 # the failure appears at login with the key looking correct in every listing.
 test_fingerprint_derived_from_key() {
-    command -v ssh-keygen >/dev/null 2>&1 || { test_pass "derivation (skipped: no ssh-keygen)"; return; }
+    command -v ssh-keygen >/dev/null 2>&1 || { echo "SKIP: ssh-keygen required"; return; }
     local d="$TEST_TMPDIR/deriv"; mkdir -p "$d"
     ssh-keygen -t ed25519 -f "$d/k" -N "" -q -C "svc@test"
     local pub expected cfg
@@ -207,7 +207,7 @@ YML
 # A warning would not do. The bundle would install cleanly and refuse the login
 # on the target, which is the most expensive place to find out.
 test_mismatch_is_rejected() {
-    command -v ssh-keygen >/dev/null 2>&1 || { test_pass "mismatch (skipped: no ssh-keygen)"; return; }
+    command -v ssh-keygen >/dev/null 2>&1 || { echo "SKIP: ssh-keygen required"; return; }
     local d="$TEST_TMPDIR/mismatch"; mkdir -p "$d"
     ssh-keygen -t ed25519 -f "$d/k" -N "" -q -C "svc@test"
     local pub; pub=$(cat "$d/k.pub")
@@ -238,23 +238,32 @@ test_mismatch_is_rejected() {
 # A path would be a promise the installer cannot keep -- the target has no
 # access to the builder's filesystem.
 test_public_key_file() {
+    command -v ssh-keygen >/dev/null 2>&1 || { echo "SKIP: ssh-keygen required"; return; }
     local d="$TEST_TMPDIR/keyfile"; mkdir -p "$d"
-    printf 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFAKEKEYFORTESTINGONLYxxxxxxxxxxxxxxxxxxxx svc@file\n' \
-        > "$d/svc.pub"
+    ssh-keygen -t ed25519 -f "$d/k" -N "" -q -C "svc@file"
+    cp "$d/k.pub" "$d/svc.pub"
+
+    # RELATIVE path: it must resolve against the config file's directory, not the
+    # builder's cwd. Run from elsewhere so a cwd-relative resolution fails.
     local cfg="$d/cfg.yml"
-    cat > "$cfg" <<YML
+    cat > "$cfg" <<'YML'
 deployment_slug: demo
 service_accounts:
   - name: svc
-    key_fingerprint: "SHA256:doesnotmatterhere"
-    public_key_file: $d/svc.pub
+    public_key_file: svc.pub
 YML
-    SERVICE_ACCOUNTS_RECORDS=()
-    _parse_service_accounts_block "$cfg" >/dev/null 2>&1
-    local got; got=$(_sa_field 10 "${SERVICE_ACCOUNTS_RECORDS[0]:-}")
+    # A subshell: the parser calls `_sa_reconcile_key || exit 1`, and this suite
+    # sources ob-builder in-process -- a parser-driven failure would otherwise
+    # kill the whole run mid-way with no diagnostics and later tests never run.
+    local got
+    got=$( cd / && SERVICE_ACCOUNTS_RECORDS=() ; \
+           _parse_service_accounts_block "$cfg" >/dev/null 2>&1 ; \
+           _sa_field 10 "${SERVICE_ACCOUNTS_RECORDS[0]:-}" )
     case "$got" in
-        ssh-ed25519\ *svc@file) test_pass "public_key_file is read at build time" ;;
-        *) test_fail "public_key_file is read at build time" "got '$got'" ;;
+        ssh-ed25519\ *svc@file)
+            test_pass "public_key_file is read at build time, relative to the config file" ;;
+        *)  test_fail "public_key_file is read at build time, relative to the config file" \
+                      "got '$got'" ;;
     esac
 }
 
@@ -268,13 +277,16 @@ service_accounts:
     key_fingerprint: "SHA256:abc"
     public_key: "not-an-ssh-key at all"
 YML
-    SERVICE_ACCOUNTS_RECORDS=()
-    _parse_service_accounts_block "$cfg" >/dev/null 2>&1
-    local got; got=$(_sa_field 10 "${SERVICE_ACCOUNTS_RECORDS[0]:-}")
-    if [ -z "$got" ]; then
-        test_pass "a value that is not an SSH public key is dropped, not deployed"
+    # A key that cannot be used is now a build ERROR, not a silent drop: warning
+    # and continuing shipped a garbage key while a merely stale fingerprint
+    # killed the build -- the asymmetry the review caught. Subshell, because the
+    # refusal is an `exit 1` inside a sourced parser.
+    local rc=0
+    ( SERVICE_ACCOUNTS_RECORDS=(); _parse_service_accounts_block "$cfg" ) >/dev/null 2>&1 || rc=$?
+    if [ "$rc" -ne 0 ]; then
+        test_pass "a value that is not an SSH public key stops the build"
     else
-        test_fail "a value that is not an SSH public key is dropped, not deployed" "got '$got'"
+        test_fail "a value that is not an SSH public key stops the build" "exited 0"
     fi
 }
 
@@ -316,18 +328,99 @@ test_templates_deploy_and_warn() {
     fi
 }
 
-test_syntax
-test_validators
-test_parse_block
-test_parse_none
-test_record_validation
-test_render_conf
-test_fingerprint_derived_from_key
-test_mismatch_is_rejected
-test_public_key_file
-test_bad_key_is_dropped
-test_render_keys
-test_templates_deploy_and_warn
+# ─────────────────────────────────────────────────────────────────────────
+# Guards for the two mistakes made while writing the above
+# ─────────────────────────────────────────────────────────────────────────
+
+# Test: --help contains no live command substitution.
+#
+# The usage text is an UNQUOTED heredoc, so a backtick or $( ) in it is
+# EXECUTED when --help runs. It happened twice: `ob-bastion-setup
+# --enable-service-keys` and `service_keys: false` were both run as commands and
+# --help printed an empty gap where the text should be. A reader sees a
+# half-sentence; on a hostile config value it would be worse than cosmetic.
+test_help_has_no_substitution() {
+    local out bad=""
+    out=$("$BUILDER" --help 2>&1) || true
+
+    # Nothing executed: the rendered help must not contain an empty "set  to"
+    # style gap, and the source block must carry no backtick or $( ).
+    local blk
+    blk=$(awk '/^    cat << EOF$/{f=1;next} f&&/^EOF$/{exit} f' "$BUILDER")
+    printf '%s' "$blk" | grep -q '`'      && bad="$bad backtick-in-help"
+    printf '%s' "$blk" | grep -q '\$('    && bad="$bad command-substitution-in-help"
+
+    # And the help really renders (a failed substitution can empty it).
+    printf '%s' "$out" | grep -q 'SERVICE ACCOUNTS' || bad="$bad help-section-missing"
+
+    if [ -z "$bad" ]; then
+        test_pass "--help contains no live command substitution"
+    else
+        test_fail "--help contains no live command substitution" "$bad"
+    fi
+}
+
+# Test: the RENDERED artefacts, not the .in templates.
+#
+# The previous version grepped the raw .in text, so a ph_set-side typo or a
+# missing placeholder entry left "@@SERVICE_ACCOUNT_KEYS_B64@@" literally in the
+# installer -- where `[ -n "@@...@@" ]` is truthy and `base64 -d` decodes a
+# placeholder -- and the suite stayed green. Same class as the #DEBHELPER# token
+# that shipped a broken postinst.
+test_rendered_artifacts() {
+    local d="$TEST_TMPDIR/render"; mkdir -p "$d"
+    local tpl="$OB_REPO_ROOT/admin-builder/templates/shell/installer.sh.in"
+    [ -f "$tpl" ] || { test_fail "rendered installer is sound" "template missing"; return; }
+
+    # Minimal placeholder set: enough for the service-account paths.
+    SERVICE_ACCOUNTS_RECORDS=(
+        "$(_sa_pack svc "SHA256:x" false false "" "" "" "" "" "ssh-ed25519 AAAAB svc@h")"
+    )
+    local keys keys_b64 conf conf_b64
+    keys=$(_render_service_account_keys); keys_b64=$(base64_string "$keys")
+    conf=$(_render_service_accounts_conf); conf_b64=$(base64_string "$conf")
+
+    local out="$d/installer.sh"
+    sed -e "s|@@SERVICE_ACCOUNT_KEYS_B64@@|$keys_b64|g" \
+        -e "s|@@SERVICE_ACCOUNTS_CONF_B64@@|$conf_b64|g" \
+        -e "s|@@SERVICE_KEYS_SETUP_BOOL@@|true|g" \
+        -e "s|@@[A-Z0-9_]*@@|x|g" "$tpl" > "$out"
+
+    local bad=""
+    grep -q '@@' "$out" && bad="$bad placeholder-left-in-artifact"
+    bash -n "$out" 2>/dev/null || bad="$bad artifact-does-not-parse"
+    grep -q 'service-accounts.d/${_sa_name}.pub' "$out" || bad="$bad no-key-deploy"
+    grep -q 'Removed stale' "$out"        || bad="$bad no-stale-cleanup"
+    grep -q 'enable-service-keys' "$out"  || bad="$bad setup-flag-not-passed"
+    grep -q 'chmod 0711 /etc/open-bastion' "$out" || bad="$bad parent-not-traversable"
+
+    # The key really survives the round trip.
+    printf '%s' "$keys_b64" | base64 -d | grep -q '^svc ssh-ed25519 AAAAB svc@h$' \
+        || bad="$bad key-not-in-blob"
+
+    if [ -z "$bad" ]; then
+        test_pass "the rendered installer carries the keys, the flag and a traversable parent"
+    else
+        test_fail "the rendered installer carries the keys, the flag and a traversable parent" "$bad"
+    fi
+}
+
+# A name here that is not a defined function used to be a shell error the script
+# walked past, leaving the suite green with a test that never ran -- it happened
+# while adding the last three. Fail loudly instead.
+for _t in test_syntax test_validators test_parse_block test_parse_none \
+          test_record_validation test_render_conf \
+          test_fingerprint_derived_from_key test_mismatch_is_rejected \
+          test_public_key_file test_bad_key_is_dropped test_render_keys \
+          test_templates_deploy_and_warn test_help_has_no_substitution \
+          test_rendered_artifacts; do
+    if declare -F "$_t" >/dev/null; then
+        "$_t"
+    else
+        test_fail "$_t is listed as a test but is not defined"
+    fi
+done
+
 
 echo ""
 echo "=========================================="

--- a/tests/test_ob_builder_service_accounts.sh
+++ b/tests/test_ob_builder_service_accounts.sh
@@ -19,6 +19,9 @@ YELLOW='\033[1;33m'
 NC='\033[0m'
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# ob-builder defines its own SCRIPT_DIR, and the eval below overwrites ours.
+# Keep the repository root under a name it does not use.
+OB_REPO_ROOT="$SCRIPT_DIR"
 BUILDER="$SCRIPT_DIR/admin-builder/ob-builder"
 export OB_BUILDER_LIB_DIR="$SCRIPT_DIR/admin-builder/lib"
 export OB_BUILDER_SHARE="$SCRIPT_DIR/admin-builder"
@@ -160,12 +163,171 @@ echo "Testing ob-builder service-account support"
 echo "=========================================="
 echo ""
 
+
+# ─────────────────────────────────────────────────────────────────────────
+# public_key: the field service-accounts.conf could never carry (#263)
+# ─────────────────────────────────────────────────────────────────────────
+
+# Test: the fingerprint is derived from the key, and matches ssh-keygen exactly.
+#
+# This is the copy-error class the field report ran into from the other side: a
+# fingerprint maintained apart from the key it describes matches nothing, and
+# the failure appears at login with the key looking correct in every listing.
+test_fingerprint_derived_from_key() {
+    command -v ssh-keygen >/dev/null 2>&1 || { test_pass "derivation (skipped: no ssh-keygen)"; return; }
+    local d="$TEST_TMPDIR/deriv"; mkdir -p "$d"
+    ssh-keygen -t ed25519 -f "$d/k" -N "" -q -C "svc@test"
+    local pub expected cfg
+    pub=$(cat "$d/k.pub")
+    expected=$(ssh-keygen -lf "$d/k.pub" | awk '{print $2}')
+
+    cfg="$d/cfg.yml"
+    cat > "$cfg" <<YML
+deployment_slug: demo
+service_accounts:
+  - name: svc
+    public_key: "$pub"
+YML
+    SERVICE_ACCOUNTS_RECORDS=()
+    _parse_service_accounts_block "$cfg" >/dev/null 2>&1
+
+    local got_fp got_pub
+    got_fp=$(_sa_field 2 "${SERVICE_ACCOUNTS_RECORDS[0]:-}")
+    got_pub=$(_sa_field 10 "${SERVICE_ACCOUNTS_RECORDS[0]:-}")
+    if [ "$got_fp" = "$expected" ] && [ "$got_pub" = "$pub" ]; then
+        test_pass "key_fingerprint is derived from public_key, and the key is kept"
+    else
+        test_fail "key_fingerprint is derived from public_key, and the key is kept" \
+                  "fp='$got_fp' expected='$expected'"
+    fi
+}
+
+# Test: a fingerprint that does not describe the key stops the build.
+#
+# A warning would not do. The bundle would install cleanly and refuse the login
+# on the target, which is the most expensive place to find out.
+test_mismatch_is_rejected() {
+    command -v ssh-keygen >/dev/null 2>&1 || { test_pass "mismatch (skipped: no ssh-keygen)"; return; }
+    local d="$TEST_TMPDIR/mismatch"; mkdir -p "$d"
+    ssh-keygen -t ed25519 -f "$d/k" -N "" -q -C "svc@test"
+    local pub; pub=$(cat "$d/k.pub")
+
+    # Drive the reconciliation directly: the variables it reads are the parser's,
+    # so they are set here and consumed through dynamic scope -- which shellcheck
+    # cannot follow, hence the directive.
+    # shellcheck disable=SC2034
+    local name="svc" fp="SHA256:StaleFromAPreviousRotation0000000000000000" pubkey="$pub"
+    if _sa_reconcile_key >/dev/null 2>&1; then
+        test_fail "a key_fingerprint that does not match public_key is rejected" \
+                  "_sa_reconcile_key returned 0"
+    else
+        test_pass "a key_fingerprint that does not match public_key is rejected"
+    fi
+
+    # And the matching pair is accepted.
+    # shellcheck disable=SC2034
+    fp=$(ssh-keygen -lf "$d/k.pub" | awk '{print $2}')
+    if _sa_reconcile_key >/dev/null 2>&1; then
+        test_pass "a matching key_fingerprint/public_key pair is accepted"
+    else
+        test_fail "a matching key_fingerprint/public_key pair is accepted"
+    fi
+}
+
+# Test: public_key_file is read at build time.
+# A path would be a promise the installer cannot keep -- the target has no
+# access to the builder's filesystem.
+test_public_key_file() {
+    local d="$TEST_TMPDIR/keyfile"; mkdir -p "$d"
+    printf 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFAKEKEYFORTESTINGONLYxxxxxxxxxxxxxxxxxxxx svc@file\n' \
+        > "$d/svc.pub"
+    local cfg="$d/cfg.yml"
+    cat > "$cfg" <<YML
+deployment_slug: demo
+service_accounts:
+  - name: svc
+    key_fingerprint: "SHA256:doesnotmatterhere"
+    public_key_file: $d/svc.pub
+YML
+    SERVICE_ACCOUNTS_RECORDS=()
+    _parse_service_accounts_block "$cfg" >/dev/null 2>&1
+    local got; got=$(_sa_field 10 "${SERVICE_ACCOUNTS_RECORDS[0]:-}")
+    case "$got" in
+        ssh-ed25519\ *svc@file) test_pass "public_key_file is read at build time" ;;
+        *) test_fail "public_key_file is read at build time" "got '$got'" ;;
+    esac
+}
+
+# Test: a malformed key is dropped rather than deployed.
+test_bad_key_is_dropped() {
+    local cfg="$TEST_TMPDIR/badkey.yml"
+    cat > "$cfg" <<'YML'
+deployment_slug: demo
+service_accounts:
+  - name: svc
+    key_fingerprint: "SHA256:abc"
+    public_key: "not-an-ssh-key at all"
+YML
+    SERVICE_ACCOUNTS_RECORDS=()
+    _parse_service_accounts_block "$cfg" >/dev/null 2>&1
+    local got; got=$(_sa_field 10 "${SERVICE_ACCOUNTS_RECORDS[0]:-}")
+    if [ -z "$got" ]; then
+        test_pass "a value that is not an SSH public key is dropped, not deployed"
+    else
+        test_fail "a value that is not an SSH public key is dropped, not deployed" "got '$got'"
+    fi
+}
+
+# Test: the renderer emits one "<name> <key>" line per account that has a key.
+test_render_keys() {
+    SERVICE_ACCOUNTS_RECORDS=(
+        "$(_sa_pack a "SHA256:1" false false "" "" "" "" "" "ssh-ed25519 AAAA a@h")"
+        "$(_sa_pack b "SHA256:2" false false "" "" "" "" "" "")"
+        "$(_sa_pack c "SHA256:3" false false "" "" "" "" "" "ssh-rsa BBBB c@h")"
+    )
+    local out; out=$(_render_service_account_keys)
+    local n; n=$(printf '%s\n' "$out" | grep -c .)
+    if [ "$n" -eq 2 ] \
+       && printf '%s' "$out" | grep -q '^a ssh-ed25519 AAAA a@h$' \
+       && printf '%s' "$out" | grep -q '^c ssh-rsa BBBB c@h$'; then
+        test_pass "only accounts with a key are rendered, one line each"
+    else
+        test_fail "only accounts with a key are rendered, one line each" "$out"
+    fi
+}
+
+# Test: both artefact templates deploy the keys, and neither is silent about
+# the sshd half. Deploying <name>.pub without an AuthorizedKeysCommand leaves
+# the account still unable to log in -- the failure #263 reported.
+test_templates_deploy_and_warn() {
+    local sh_t="$OB_REPO_ROOT/admin-builder/templates/shell/installer.sh.in"
+    local an_t="$OB_REPO_ROOT/admin-builder/templates/ansible/role/tasks/main.yml.in"
+    local bad=""
+    grep -q 'SERVICE_ACCOUNT_KEYS_B64' "$sh_t"          || bad="$bad shell(no-placeholder)"
+    grep -q 'service-accounts.d/\${_sa_name}.pub' "$sh_t" || bad="$bad shell(no-deploy)"
+    grep -q 'enable-service-keys' "$sh_t"                || bad="$bad shell(no-sshd-warning)"
+    grep -q 'ob_service_account_keys' "$an_t"            || bad="$bad ansible(no-var)"
+    grep -q 'service-accounts.d/' "$an_t"                || bad="$bad ansible(no-deploy)"
+    grep -q 'enable-service-keys' "$an_t"                || bad="$bad ansible(no-sshd-warning)"
+    if [ -z "$bad" ]; then
+        test_pass "both templates deploy <name>.pub and warn when sshd cannot serve it"
+    else
+        test_fail "both templates deploy <name>.pub and warn when sshd cannot serve it" "$bad"
+    fi
+}
+
 test_syntax
 test_validators
 test_parse_block
 test_parse_none
 test_record_validation
 test_render_conf
+test_fingerprint_derived_from_key
+test_mismatch_is_rejected
+test_public_key_file
+test_bad_key_is_dropped
+test_render_keys
+test_templates_deploy_and_warn
 
 echo ""
 echo "=========================================="


### PR DESCRIPTION
Batch 3 of #263, and the last piece. **Stacked on #265** — review that one first;
this diff is only the builder.

## The gap

`service-accounts.conf` told `pam_openbastion` what fingerprint to expect and gave
sshd nothing to accept. `ob-builder`'s record schema carried only the fingerprint, so
the key had to be deployed by hand — and the generated bundle reported success with
the account still unable to log in. That is how the field report reached us.

A `service_accounts:` entry now takes `public_key` or `public_key_file` (read at
**build** time — a path would be a promise the installer cannot keep), and both
artefacts write `/etc/open-bastion/service-accounts.d/<name>.pub`.

## The fingerprint is derived, not transcribed

Supplying both cross-checks them, and a mismatch **stops the build**:

```
[ERROR] service account 'svcacct': key_fingerprint does not match public_key.
[ERROR]   configured: SHA256:StaleFingerprintFromAPreviousKeyRotation000
[ERROR]   actual:     SHA256:ftPtIZMXxQPKlOgU1Ofjub7kF4gz5MzXSr0UVuU2Fc4
```

A warning would not do. The bundle installs cleanly and the failure appears at login,
with the key looking correct in every listing anyone would think to check — the same
shape of problem as the one being fixed, one layer along. Explicit `|| exit 1` rather
than relying on errexit, whose behaviour depends on the calling context.

Neither artefact turns on the `AuthorizedKeysCommand`: that is host-wide and stays
with `--enable-service-keys` (#265). Both now **report** when they find none, so a
bundle can no longer look complete when it is not.

## Two defects found while testing this, both mine

- the flat-key config parser did not know `public_key`/`public_key_file` and printed
  `Unknown config key` on a correct file;
- the usage text is an **unquoted** heredoc, so the backticks I put around
  `ob-bastion-setup --enable-service-keys` were executed as a command substitution and
  `--help` printed *"run  (or ob-backend-setup)"*. Quoted instead; checked there is no
  other backtick or `$` in that block.

## Evidence

End to end against a mock OIDC discovery + `/ssh/ca` endpoint, both artefacts
generated:

```
installer carries: svcacct ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAA…  svc@lab
service-accounts.conf: key_fingerprint = SHA256:ftPtIZMXxQPKlOgU1Ofjub7kF4gz5MzXSr0UVuU2Fc4
ansible defaults:  ob_service_account_keys: | svcacct ssh-ed25519 …
```

— the fingerprint in the `.conf` is the one `ssh-keygen -lf` prints for that key, and
the Ansible `tasks/main.yml` is valid YAML that `ansible-playbook --syntax-check`
accepts.

Six tests added (13 total in that suite). Mutations caught: dropping the mismatch
check, dropping the derivation, removing the deployment from the installer template.

35 shell suites, **none skipped**; shellcheck on `ob-builder` clean; the one remaining
warning in the test file is pre-existing.

Closes #263.