### PR TITLE
test(mutation): make every security control prove its test can fail

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -332,10 +332,15 @@ jobs:
         apt-get update -qq
         DEBIAN_FRONTEND=noninteractive apt-get install -y -qq \
           build-essential cmake pkg-config git jq curl python3 openssh-client \
-          libcurl4-openssl-dev libjson-c-dev libpam0g-dev libssl-dev libkeyutils-dev
+          socat libcurl4-openssl-dev libjson-c-dev libpam0g-dev libssl-dev libkeyutils-dev
 
+    # The suites the catalogue drives must be able to RUN here: one that skips
+    # for a missing dependency is green before and after the mutation, and the
+    # runner now refuses to conclude from that rather than calling it a
+    # surviving mutant. socat is what tests/test_ob_fp_daemon.sh needs.
     - name: Build
       run: |
+        git config --global --add safe.directory "$PWD"
         cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug
         cmake --build build -j"$(nproc)"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -341,7 +341,6 @@ jobs:
     # surviving mutant. socat is what tests/test_ob_fp_daemon.sh needs.
     - name: Build
       run: |
-        git config --global --add safe.directory "$PWD"
         cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug
         cmake --build build -j"$(nproc)"
 
@@ -356,15 +355,6 @@ jobs:
         chmod -R a+rX .
         OB_MUTATION_STRICT=1 bash tests/test_ob_mutation.sh
       timeout-minutes: 20
-
-    # A mutant left behind would be invisible to every later job.
-    - name: The tree must be clean afterwards
-      run: |
-        git config --global --add safe.directory "$PWD"
-        git diff --exit-code || {
-          echo "::error::the mutation run left the working tree modified"
-          exit 1
-        }
 
   integration-test:
     name: Integration Tests (Docker)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -332,7 +332,8 @@ jobs:
         apt-get update -qq
         DEBIAN_FRONTEND=noninteractive apt-get install -y -qq \
           build-essential cmake pkg-config git jq curl python3 openssh-client \
-          socat libcurl4-openssl-dev libjson-c-dev libpam0g-dev libssl-dev libkeyutils-dev
+          socat util-linux \
+          libcurl4-openssl-dev libjson-c-dev libpam0g-dev libssl-dev libkeyutils-dev
 
     # The suites the catalogue drives must be able to RUN here: one that skips
     # for a missing dependency is green before and after the mutation, and the
@@ -348,8 +349,12 @@ jobs:
     # that guards it to fail. A surviving mutant means a green suite that checks
     # nothing -- which is what several reviews found by hand during 0.7.0, one
     # PR at a time.
+    # The repository must be readable by the unprivileged user the runner drops
+    # to for `needs: nonroot` entries (setpriv, from util-linux above).
     - name: Mutation
-      run: OB_MUTATION_STRICT=1 bash tests/test_ob_mutation.sh
+      run: |
+        chmod -R a+rX .
+        OB_MUTATION_STRICT=1 bash tests/test_ob_mutation.sh
       timeout-minutes: 20
 
     # A mutant left behind would be invisible to every later job.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -312,6 +312,50 @@ jobs:
         scandir: './scripts'
         severity: warning
 
+  mutation:
+    name: Mutation (every control must be able to fail)
+    runs-on: ubuntu-latest
+    needs: build
+    permissions:
+      contents: read
+    # A container so the run is root: some controls can only be isolated with
+    # privilege, and OB_MUTATION_STRICT below turns "not exercised here" into an
+    # error rather than letting it read as a pass.
+    container: debian:trixie
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v6
+
+    - name: Install dependencies
+      run: |
+        apt-get update -qq
+        DEBIAN_FRONTEND=noninteractive apt-get install -y -qq \
+          build-essential cmake pkg-config git jq curl python3 openssh-client \
+          libcurl4-openssl-dev libjson-c-dev libpam0g-dev libssl-dev libkeyutils-dev
+
+    - name: Build
+      run: |
+        cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug
+        cmake --build build -j"$(nproc)"
+
+    # Removes each control in tests/mutation/catalogue and requires the suite
+    # that guards it to fail. A surviving mutant means a green suite that checks
+    # nothing -- which is what several reviews found by hand during 0.7.0, one
+    # PR at a time.
+    - name: Mutation
+      run: OB_MUTATION_STRICT=1 bash tests/test_ob_mutation.sh
+      timeout-minutes: 20
+
+    # A mutant left behind would be invisible to every later job.
+    - name: The tree must be clean afterwards
+      run: |
+        git config --global --add safe.directory "$PWD"
+        git diff --exit-code || {
+          echo "::error::the mutation run left the working tree modified"
+          exit 1
+        }
+
   integration-test:
     name: Integration Tests (Docker)
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -151,7 +151,10 @@ the `auth` line of certificate-mode PAM stacks, and the accepted permissions of
 
   A mutation that does not apply is a hard error, never a pass; C mutants are
   rebuilt before the suite runs, since an uncompiled mutant would pass for the
-  wrong reason; and the runner verifies the tree is unchanged afterwards.
+  wrong reason; a suite that **skips** is refused rather than read as a
+  surviving mutant, because it exits 0 both before and after and can neither
+  confirm nor refute; and the runner verifies the tree is unchanged afterwards,
+  distinguishing "the tree differs" from "git could not tell us".
 
 - **`tests/test_ob_ci_coverage.sh`** fails when a test file exists that no CI
   job runs. `tests/test_backend_cert_acceptance.sh` — the e2e guard for "a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -153,7 +153,11 @@ the `auth` line of certificate-mode PAM stacks, and the accepted permissions of
   rebuilt before the suite runs, since an uncompiled mutant would pass for the
   wrong reason; a suite that **skips** is refused rather than read as a
   surviving mutant, because it exits 0 both before and after and can neither
-  confirm nor refute; and the runner verifies the tree is unchanged afterwards,
+  confirm nor refute; an entry declares whether it needs `root` or `nonroot` and
+  the runner switches privilege for it, since a control whose expected owner is
+  root is vacuously satisfied in a root run and one that guards a path only
+  bites in a privileged one — running everything at one level reports the other
+  half as surviving; and the runner verifies the tree is unchanged afterwards,
   distinguishing "the tree differs" from "git could not tell us".
 
 - **`tests/test_ob_ci_coverage.sh`** fails when a test file exists that no CI

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,6 +130,29 @@ the `auth` line of certificate-mode PAM stacks, and the accepted permissions of
   with no sheets at all. Owner names, dates and acceptance decisions are left as
   `À COMPLÉTER`: they belong to the homologation authority. Start at
   [doc/security/README.md](doc/security/README.md).
+- **Mutation testing runs in CI** (`tests/test_ob_mutation.sh`, catalogue in
+  `tests/mutation/`). Each entry removes one security control and requires the
+  suite that guards it to fail; a surviving mutant means a green suite that
+  checks nothing.
+
+  It exists because that is what the 0.7.0 reviews kept finding, one PR at a
+  time: a `grep` matching the comment above a rule instead of the rule, an
+  assertion that passed because the probed file was absent rather than because
+  the check refused it, a `grep -q` whose SIGPIPE under `pipefail` turned a
+  match into a miss. None were coverage gaps — the tests existed, ran, and were
+  green.
+
+  Writing the catalogue immediately found four more: three of its own entries
+  proved nothing (a mutation that added an unreachable branch instead of
+  removing one, two whose search text matched twice, one that mutated the test
+  rather than its subject), and one real gap — the rendered installer was
+  checked for the presence of the key-deployment text, which survives disabling
+  the block that runs it.
+
+  A mutation that does not apply is a hard error, never a pass; C mutants are
+  rebuilt before the suite runs, since an uncompiled mutant would pass for the
+  wrong reason; and the runner verifies the tree is unchanged afterwards.
+
 - **`tests/test_ob_ci_coverage.sh`** fails when a test file exists that no CI
   job runs. `tests/test_backend_cert_acceptance.sh` — the e2e guard for "a
   backend accepts a hop only from its allowlisted bastion" — sat outside the

--- a/tests/mutation/catalogue
+++ b/tests/mutation/catalogue
@@ -1,0 +1,128 @@
+# Mutation catalogue — one security control per stanza.
+#
+# Each entry names a control, the exact text that implements it, what to replace
+# it with to REMOVE it, and the test suite that must then fail. The runner
+# applies one mutant at a time, runs that suite, and requires it to fail. A
+# mutant that SURVIVES means the suite reports success with the control gone --
+# the failure mode this whole file exists to make impossible.
+#
+# Why a curated catalogue rather than a generic mutation engine: what matters is
+# not that some arbitrary line change is detected, but that the checks the EBIOS
+# study credits with reducing a risk are actually exercised. Every entry here is
+# a control a risk sheet or an issue depends on.
+#
+# Format: five ||-separated fields, one stanza per block, blank lines and #
+# comments ignored.
+#   id        || short name, used in the report
+#   file      || path relative to the repository root
+#   search    || literal text to find (must occur EXACTLY once)
+#   replace   || what to put in its place
+#   suite     || the test that must fail once the mutant is applied
+#   needs     || (optional) an environment this entry requires: "root" when the
+#                control cannot be isolated otherwise. Not exercised locally;
+#                OB_MUTATION_STRICT=1, which CI sets, makes it an error instead
+#                of letting it read as a pass
+#   create    || (optional) instead of editing a file, CREATE this path with the
+#                "replace" text as its content. For controls of the form "this
+#                must not exist", where deleting a line cannot express the
+#                mutation -- mutating the CHECK would prove nothing, so the
+#                situation it refuses is put back instead
+#
+# Adding a control without adding it here is allowed; adding one and finding
+# that no suite fails is the signal to write the missing test.
+
+id      || fp-daemon-anchor-owner
+file    || src/ob-fp-daemon.c
+search  || if (ast.st_uid != OB_FP_PRIV_UID) {
+replace || if (0) {
+suite   || tests/test_ob_fp_daemon.sh
+why     || #249: the sshd anchor must be a root-owned process, or a local user
+why     || can put a process named sshd-session in their own ancestry and choose
+why     || which drop is read.
+
+id      || service-keys-root-owner
+file    || scripts/ob-service-account-keys
+search  || [ "$owner" = "0" ] || exit 0
+replace || :
+suite   || tests/test_ob_service_account_keys.sh
+why     || #263: the key file must be root-owned, or any writer of the directory
+why     || chooses who authenticates.
+
+id      || service-keys-name-validation
+file    || scripts/ob-service-account-keys
+search  || *[!a-z0-9_-]*) exit 0 ;;
+replace || *[!a-z0-9_-]*) : ;;
+suite   || tests/test_ob_service_account_keys.sh
+needs   || root
+why     || The username reaches the filesystem; without this a crafted name
+why     || escapes the keys directory.
+
+id      || session-monitor-unknown-verdict
+file    || scripts/ob-session-monitor
+search  || 401|403)\n            # Our credentials, not the user's status.
+replace || __never_matches__)\n            #
+suite   || tests/test_ob_session_monitor.sh
+why     || #257: a portal refusing OUR credentials must not read as "the user
+why     || was revoked" and terminate their sessions.
+
+id      || session-monitor-jq-errexit
+file    || scripts/ob-session-monitor
+search  || end' 2>/dev/null) || true
+replace || end' 2>/dev/null)
+suite   || tests/test_ob_session_monitor.sh
+why     || #257: jq's exit status must not skip the "unknown" branch under
+why     || set -e.
+
+id      || enroll-no-openssl-hmac
+file    || scripts/ob-enroll
+search  || if ! jwt=$(printf '%s' "$client_secret" \
+replace || if ! jwt=$(echo x | openssl dgst -sha256 -hmac "$client_secret" \
+suite   || tests/test_ob_request_signing.sh
+why     || #256: the OIDC client secret must never reach a command line.
+
+id      || service-keys-foreign-command
+file    || scripts/ob-bastion-setup
+search  || if foreign=$(_ob_foreign_authorized_keys_command); then
+replace || if false; then
+suite   || tests/test_ob_service_account_keys.sh
+why     || #263: enabling the flag must refuse rather than silently override a
+why     || key server the host already runs.
+
+id      || service-keys-cleanup
+file    || scripts/ob-bastion-setup
+search  || \n        _ob_drop_service_keys_dropin\n        return 0
+replace || \n        return 0
+suite   || tests/test_ob_service_account_keys.sh
+why     || #263: the flag must not be one-way; a run without it removes the
+why     || drop-in it generated.
+
+id      || exposeauthinfo-guard
+file    || scripts/ob-bastion-setup
+search  || configure_max_security_sshd() {
+replace || configure_max_security_sshd() {\n    cat >/dev/null <<X\nExposeAuthInfo yes\nX
+suite   || tests/test_ob_service_account_keys.sh
+why     || #263: no unconditional ExposeAuthInfo write; every one is behind an
+why     || opt-in guard.
+
+id      || builder-fingerprint-mismatch
+file    || admin-builder/ob-builder
+search  || if [ "$fp" != "$derived" ]; then
+replace || if false; then
+suite   || tests/test_ob_builder_service_accounts.sh
+why     || #263: a key_fingerprint that does not describe public_key must stop
+why     || the build, not ship and fail at login.
+
+id      || builder-key-deployment
+file    || admin-builder/templates/shell/installer.sh.in
+search  || if [ -n "@@SERVICE_ACCOUNT_KEYS_B64@@" ]; then
+replace || if false; then
+suite   || tests/test_ob_builder_service_accounts.sh
+why     || #263: the bundle must deploy <name>.pub, or the account cannot log in.
+
+id      || systemd-units-one-place
+create  || debian/open-bastion-mutant.service
+replace || [Unit]\nDescription=a duplicate unit, as before #254
+suite   || tests/test_ob_systemd_units.sh
+why     || #254: unit content must live only in systemd/. Mutating the check
+why     || itself would prove nothing -- this puts the duplicate back, which is
+why     || the situation the check exists to refuse.

--- a/tests/mutation/catalogue
+++ b/tests/mutation/catalogue
@@ -36,6 +36,7 @@ file    || src/ob-fp-daemon.c
 search  || if (ast.st_uid != OB_FP_PRIV_UID) {
 replace || if (0) {
 suite   || tests/test_ob_fp_daemon.sh
+needs   || nonroot
 why     || #249: the sshd anchor must be a root-owned process, or a local user
 why     || can put a process named sshd-session in their own ancestry and choose
 why     || which drop is read.

--- a/tests/test_ob_builder_service_accounts.sh
+++ b/tests/test_ob_builder_service_accounts.sh
@@ -390,6 +390,14 @@ test_rendered_artifacts() {
     grep -q '@@' "$out" && bad="$bad placeholder-left-in-artifact"
     bash -n "$out" 2>/dev/null || bad="$bad artifact-does-not-parse"
     grep -q 'service-accounts.d/${_sa_name}.pub' "$out" || bad="$bad no-key-deploy"
+    # Reachable, not merely present: disabling the guard leaves every line of
+    # the block in the file, so a text grep stays green while nothing deploys.
+    # Anchored on the KEYS block -- the conf block a few lines above has the
+    # same shape, and matching that one made this assertion pass on a mutant
+    # that had disabled the keys guard.
+    grep -B3 '_sa_keep=""' "$out" \
+        | grep -qE '^[[:space:]]*if \[ -n "[A-Za-z0-9+/=]+" \]; then' \
+        || bad="$bad key-block-unreachable"
     grep -q 'Removed stale' "$out"        || bad="$bad no-stale-cleanup"
     grep -q 'enable-service-keys' "$out"  || bad="$bad setup-flag-not-passed"
     grep -q 'chmod 0711 /etc/open-bastion' "$out" || bad="$bad parent-not-traversable"

--- a/tests/test_ob_mutation.sh
+++ b/tests/test_ob_mutation.sh
@@ -99,10 +99,20 @@ run_stanza() {
     fi
 
     # The suite must be GREEN before the mutation, or the result means nothing.
-    if ! ( cd "$ROOT_DIR" && bash "$suite" ) >/dev/null 2>&1; then
+    local pre
+    pre=$( cd "$ROOT_DIR" && bash "$suite" 2>&1 ) || {
         fail "$id" "$suite already fails before the mutation; nothing can be concluded"
         return
-    fi
+    }
+    # And it must actually RUN. A suite that skips exits 0 before and after, so
+    # the mutant looks survived when in truth nothing was executed -- a missing
+    # dependency reported as a coverage failure. Found in CI, where the job had
+    # no socat and the fingerprint-spool suite skipped.
+    case "$pre" in
+        *SKIP*)
+            fail "$id" "$suite SKIPPED here (missing dependency); it can neither confirm nor refute — install what it needs in this job"
+            return ;;
+    esac
 
     # An entry that cannot be exercised here must not read as a pass. In CI,
     # where the requirement is met, OB_MUTATION_STRICT makes it an error.
@@ -206,14 +216,26 @@ run_stanza
 restore_all
 # Prove the tree is as it was: a runner that leaves a mutant behind is worse
 # than no runner.
-# shellcheck disable=SC2086  # RESTORE_LIST is a space-separated path list
-if [ -n "$RESTORE_LIST" ] \
-   && ! ( cd "$ROOT_DIR" && git diff --quiet -- $RESTORE_LIST 2>/dev/null ); then
-    echo
-    echo "  FAIL: the working tree still differs after restoration:"
-    # shellcheck disable=SC2086
-    ( cd "$ROOT_DIR" && git diff --stat -- $RESTORE_LIST )
-    TESTS_FAILED=$((TESTS_FAILED + 1))
+if [ -n "$RESTORE_LIST" ]; then
+    git_rc=0
+    # shellcheck disable=SC2086  # RESTORE_LIST is a space-separated path list
+    ( cd "$ROOT_DIR" && git diff --quiet -- $RESTORE_LIST ) 2>/dev/null || git_rc=$?
+    case "$git_rc" in
+        0) : ;;
+        1)
+            echo
+            echo "  FAIL: the working tree still differs after restoration:"
+            # shellcheck disable=SC2086
+            ( cd "$ROOT_DIR" && git diff --stat -- $RESTORE_LIST )
+            TESTS_FAILED=$((TESTS_FAILED + 1)) ;;
+        *)
+            # git itself failed -- dubious ownership in a container, no repo,
+            # whatever. That is not "the tree is dirty", and reporting it as
+            # such is the conflation #257 was about. Say which it is.
+            echo
+            echo "  WARN: could not verify the tree with git (exit $git_rc);"
+            echo "        restoration was performed but not confirmed." ;;
+    esac
 fi
 
 echo

--- a/tests/test_ob_mutation.sh
+++ b/tests/test_ob_mutation.sh
@@ -1,0 +1,221 @@
+#!/bin/bash
+# test_ob_mutation.sh
+#
+# Removes each security control in tests/mutation/catalogue, one at a time, and
+# requires the suite that guards it to fail.
+#
+# The campaign that produced this file kept finding the same thing: a test that
+# reported success with the control it was written for deleted. A grep matching
+# the comment above a rule instead of the rule. An assertion that passed because
+# the file it probed did not exist, not because the check refused it. A
+# `grep -q` whose SIGPIPE, under pipefail, turned a match into a miss. None of
+# those are coverage gaps -- the tests existed, ran, and were green. They were
+# simply not testing anything, and nothing said so.
+#
+# A green suite is evidence only if it can go red. That is the property here,
+# and it is checked mechanically rather than remembered.
+#
+# Two rules the runner enforces on itself, both learned the hard way:
+#
+#   - a mutation that does not apply is a HARD ERROR, never a pass. A sed that
+#     silently matched nothing produced a meaningless "caught" more than once
+#     while this was being written by hand;
+#   - every file is restored from a copy taken before the run, and the
+#     restoration is verified. `git checkout` was used once for this and wiped
+#     uncommitted work.
+
+set -uo pipefail
+
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+CATALOGUE="${OB_MUTATION_CATALOGUE:-$ROOT_DIR/tests/mutation/catalogue}"
+
+pass() { TESTS_PASSED=$((TESTS_PASSED + 1)); echo "  PASS: $1"; }
+fail() { TESTS_FAILED=$((TESTS_FAILED + 1)); echo "  FAIL: $1${2:+ - $2}"; }
+
+[ -f "$CATALOGUE" ] || { echo "  FAIL: no catalogue at $CATALOGUE"; exit 1; }
+
+BACKUP=$(mktemp -d)
+RESTORE_LIST=""
+
+# Restore everything, always. A mutant left behind would be committed by the
+# next person to run `git add -u`.
+CREATED_LIST=""
+restore_all() {
+    local f
+    for f in $CREATED_LIST; do rm -f "$ROOT_DIR/$f"; done
+    CREATED_LIST=""
+    for f in $RESTORE_LIST; do
+        [ -f "$BACKUP/$(echo "$f" | tr '/' '_')" ] || continue
+        cp "$BACKUP/$(echo "$f" | tr '/' '_')" "$ROOT_DIR/$f"
+    done
+}
+trap 'restore_all; rm -rf "$BACKUP"' EXIT INT TERM
+
+backup_file() {
+    local f="$1" flat
+    flat=$(echo "$f" | tr '/' '_')
+    [ -f "$BACKUP/$flat" ] && return 0
+    cp "$ROOT_DIR/$f" "$BACKUP/$flat" || return 1
+    RESTORE_LIST="$RESTORE_LIST $f"
+}
+
+# Apply one mutant with python, so the search text is a literal and the
+# occurrence count is checked. Returns non-zero when it does not apply exactly
+# once -- which the caller treats as an error, not as a result.
+apply_mutant() {
+    local file="$1" search="$2" replace="$3"
+    python3 - "$ROOT_DIR/$file" "$search" "$replace" <<'PY'
+import sys
+path, search, replace = sys.argv[1], sys.argv[2], sys.argv[3]
+search = search.replace('\\n', '\n')
+replace = replace.replace('\\n', '\n')
+s = open(path).read()
+n = s.count(search)
+if n != 1:
+    sys.stderr.write("occurrences=%d\n" % n)
+    sys.exit(2)
+open(path, 'w').write(s.replace(search, replace))
+PY
+}
+
+echo "=== mutation: every guarded control must be able to fail ==="
+
+id=""; file=""; search=""; replace=""; suite=""; needs=""; create=""
+run_stanza() {
+    [ -n "$id" ] || return 0
+    TESTS_RUN=$((TESTS_RUN + 1))
+
+    if [ -z "$create" ] && [ ! -f "$ROOT_DIR/$file" ]; then
+        fail "$id" "no such file: $file"
+        return
+    fi
+    if [ ! -f "$ROOT_DIR/$suite" ]; then
+        fail "$id" "no such suite: $suite"
+        return
+    fi
+
+    # The suite must be GREEN before the mutation, or the result means nothing.
+    if ! ( cd "$ROOT_DIR" && bash "$suite" ) >/dev/null 2>&1; then
+        fail "$id" "$suite already fails before the mutation; nothing can be concluded"
+        return
+    fi
+
+    # An entry that cannot be exercised here must not read as a pass. In CI,
+    # where the requirement is met, OB_MUTATION_STRICT makes it an error.
+    if [ -n "$needs" ]; then
+        case "$needs" in
+            root)
+                if [ "$(id -u)" != "0" ]; then
+                    if [ "${OB_MUTATION_STRICT:-0}" = "1" ]; then
+                        fail "$id" "needs root and this run is unprivileged (strict mode)"
+                    else
+                        echo "  ---- $id: needs root to isolate this control; not exercised here"
+                        TESTS_RUN=$((TESTS_RUN - 1))
+                    fi
+                    return
+                fi ;;
+        esac
+    fi
+
+    local rc=0
+    if [ -n "$create" ]; then
+        # Some controls are "this must not exist". Removing a line cannot express
+        # that; creating the thing can.
+        if [ -e "$ROOT_DIR/$create" ]; then
+            fail "$id" "$create already exists; the mutant would not be a mutation"
+            return
+        fi
+        CREATED_LIST="$CREATED_LIST $create"
+        printf '%s\n' "$replace" > "$ROOT_DIR/$create" || {
+            fail "$id" "cannot create $create"; return; }
+    else
+        backup_file "$file" || { fail "$id" "cannot back up $file"; return; }
+        apply_mutant "$file" "$search" "$replace" 2>/dev/null || rc=$?
+        if [ "$rc" -ne 0 ]; then
+            fail "$id" "the mutation does not apply to $file (search text absent or ambiguous) — a mutant that is not applied proves nothing"
+            restore_all
+            return
+        fi
+        # A C mutant that is never compiled proves nothing: the suite would run
+        # the previous binary and pass for the wrong reason.
+        case "$file" in
+            *.c|*.h)
+                # No build tree: the mutant could not be compiled, so the suite
+                # would run the previous binary and pass for the wrong reason.
+                # Report it rather than let it look caught.
+                if [ ! -d "$ROOT_DIR/build" ]; then
+                    if [ "${OB_MUTATION_STRICT:-0}" = "1" ]; then
+                        fail "$id" "no build/ directory; a C mutant cannot be compiled (strict mode)"
+                    else
+                        echo "  ---- $id: no build/ directory; C mutant not exercised here"
+                        TESTS_RUN=$((TESTS_RUN - 1))
+                    fi
+                    restore_all
+                    return
+                fi
+                if ! ( cd "$ROOT_DIR" && cmake --build build -j"$(nproc)" ) >/dev/null 2>&1; then
+                    fail "$id" "the mutated tree does not build; cannot conclude"
+                    restore_all
+                    ( cd "$ROOT_DIR" && cmake --build build -j"$(nproc)" ) >/dev/null 2>&1
+                    return
+                fi ;;
+        esac
+    fi
+
+    local src=0
+    ( cd "$ROOT_DIR" && bash "$suite" ) >/dev/null 2>&1 || src=$?
+    restore_all
+    # Put the real binaries back before judging the next entry.
+    case "$file" in
+        *.c|*.h) ( cd "$ROOT_DIR" && cmake --build build -j"$(nproc)" ) >/dev/null 2>&1 ;;
+    esac
+
+    if [ "$src" -ne 0 ]; then
+        pass "$id — $suite catches it"
+    else
+        fail "$id" "MUTANT SURVIVED: $suite is still green with the control removed ($file)"
+        printf '        the control: %s\n' "$search"
+    fi
+}
+
+while IFS= read -r line || [ -n "$line" ]; do
+    case "$line" in
+        ''|\#*) continue ;;
+    esac
+    key=${line%%'||'*}; val=${line#*'||'}
+    key=$(printf '%s' "$key" | tr -d ' \t')
+    val=$(printf '%s' "$val" | sed 's/^ *//; s/ *$//')
+    case "$key" in
+        id)      run_stanza; id="$val"; file=""; search=""; replace=""; suite=""; needs=""; create="" ;;
+        file)    file="$val" ;;
+        search)  search="$val" ;;
+        replace) replace="$val" ;;
+        suite)   suite="$val" ;;
+        needs)   needs="$val" ;;
+        create)  create="$val" ;;
+        why)     : ;;
+        *)       echo "  (ignoring unknown key '$key')" ;;
+    esac
+done < "$CATALOGUE"
+run_stanza
+
+restore_all
+# Prove the tree is as it was: a runner that leaves a mutant behind is worse
+# than no runner.
+# shellcheck disable=SC2086  # RESTORE_LIST is a space-separated path list
+if [ -n "$RESTORE_LIST" ] \
+   && ! ( cd "$ROOT_DIR" && git diff --quiet -- $RESTORE_LIST 2>/dev/null ); then
+    echo
+    echo "  FAIL: the working tree still differs after restoration:"
+    # shellcheck disable=SC2086
+    ( cd "$ROOT_DIR" && git diff --stat -- $RESTORE_LIST )
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+fi
+
+echo
+echo "Tests run: $((TESTS_PASSED + TESTS_FAILED)), passed: $TESTS_PASSED, failed: $TESTS_FAILED"
+[ "$TESTS_FAILED" -eq 0 ]

--- a/tests/test_ob_mutation.sh
+++ b/tests/test_ob_mutation.sh
@@ -44,6 +44,7 @@ RESTORE_LIST=""
 # Restore everything, always. A mutant left behind would be committed by the
 # next person to run `git add -u`.
 CREATED_LIST=""
+REBUILD_NEEDED=0
 restore_all() {
     local f
     for f in $CREATED_LIST; do rm -f "$ROOT_DIR/$f"; done
@@ -53,7 +54,17 @@ restore_all() {
         cp "$BACKUP/$(echo "$f" | tr '/' '_')" "$ROOT_DIR/$f"
     done
 }
-trap 'restore_all; rm -rf "$BACKUP"' EXIT INT TERM
+cleanup() {
+    restore_all
+    # A source restored without a rebuild leaves the MUTATED BINARY in place --
+    # invisible, and it would poison every test run on this machine afterwards.
+    # An interrupt is exactly when that happens, so it belongs in the trap.
+    if [ "$REBUILD_NEEDED" = "1" ] && [ -d "$ROOT_DIR/build" ]; then
+        ( cd "$ROOT_DIR" && cmake --build build -j"$(nproc)" ) >/dev/null 2>&1
+    fi
+    rm -rf "$BACKUP"
+}
+trap cleanup EXIT INT TERM
 
 backup_file() {
     local f="$1" flat
@@ -175,6 +186,7 @@ run_stanza() {
         # the previous binary and pass for the wrong reason.
         case "$file" in
             *.c|*.h)
+                REBUILD_NEEDED=1
                 # No build tree: the mutant could not be compiled, so the suite
                 # would run the previous binary and pass for the wrong reason.
                 # Report it rather than let it look caught.
@@ -237,30 +249,25 @@ run_stanza
 restore_all
 # Prove the tree is as it was: a runner that leaves a mutant behind is worse
 # than no runner.
-if [ -n "$RESTORE_LIST" ] \
-   && ( cd "$ROOT_DIR" && git rev-parse --is-inside-work-tree ) >/dev/null 2>&1; then
-    git_rc=0
-    # shellcheck disable=SC2086  # RESTORE_LIST is a space-separated path list
-    ( cd "$ROOT_DIR" && git diff --quiet -- $RESTORE_LIST ) 2>/dev/null || git_rc=$?
-    case "$git_rc" in
-        0) : ;;
-        1)
-            echo
-            echo "  FAIL: the working tree still differs after restoration:"
-            # shellcheck disable=SC2086
-            ( cd "$ROOT_DIR" && git diff --stat -- $RESTORE_LIST )
-            TESTS_FAILED=$((TESTS_FAILED + 1)) ;;
-        *)
-            # git itself failed -- dubious ownership in a container, no repo,
-            # whatever. That is not "the tree is dirty", and reporting it as
-            # such is the conflation #257 was about. Say which it is.
-            echo
-            echo "  WARN: could not verify the tree with git (exit $git_rc);"
-            echo "        restoration was performed but not confirmed." ;;
-    esac
-elif [ -n "$RESTORE_LIST" ]; then
+# Verify restoration against the copies taken before each mutation, not against
+# git. The backups ARE the ground truth, they are already in hand, and the check
+# then works with no repository at all -- which matters: actions/checkout with
+# no git preinstalled downloads a tarball, so the container job has no .git and
+# the previous git-based check reported "not a git repository" as a failure.
+# Reaching for git here was habit; the exact answer was already on disk.
+dirty=""
+for f in $RESTORE_LIST; do
+    flat=$(echo "$f" | tr '/' '_')
+    [ -f "$BACKUP/$flat" ] || continue
+    cmp -s "$BACKUP/$flat" "$ROOT_DIR/$f" || dirty="$dirty $f"
+done
+for f in $CREATED_LIST; do
+    [ -e "$ROOT_DIR/$f" ] && dirty="$dirty $f(created)"
+done
+if [ -n "$dirty" ]; then
     echo
-    echo "  WARN: not a git work tree here; restoration was performed but not confirmed."
+    echo "  FAIL: these files are not what they were before the run:$dirty"
+    TESTS_FAILED=$((TESTS_FAILED + 1))
 fi
 
 echo

--- a/tests/test_ob_mutation.sh
+++ b/tests/test_ob_mutation.sh
@@ -89,6 +89,14 @@ run_stanza() {
     [ -n "$id" ] || return 0
     TESTS_RUN=$((TESTS_RUN + 1))
 
+    # How to run the suite for this entry. Some controls only bite as root (a
+    # name that must not reach the filesystem), others only as an ordinary user
+    # (an ownership check whose expected owner IS root: as root the check is
+    # vacuously satisfied, so removing it changes nothing). Running everything
+    # at one privilege level reports the other half as surviving mutants --
+    # which is what CI did, for src/ob-fp-daemon.c.
+    local as=""
+
     if [ -z "$create" ] && [ ! -f "$ROOT_DIR/$file" ]; then
         fail "$id" "no such file: $file"
         return
@@ -100,7 +108,7 @@ run_stanza() {
 
     # The suite must be GREEN before the mutation, or the result means nothing.
     local pre
-    pre=$( cd "$ROOT_DIR" && bash "$suite" 2>&1 ) || {
+    pre=$( cd "$ROOT_DIR" && $as bash "$suite" 2>&1 ) || {
         fail "$id" "$suite already fails before the mutation; nothing can be concluded"
         return
     }
@@ -118,6 +126,19 @@ run_stanza() {
     # where the requirement is met, OB_MUTATION_STRICT makes it an error.
     if [ -n "$needs" ]; then
         case "$needs" in
+            nonroot)
+                if [ "$(id -u)" = "0" ]; then
+                    if command -v setpriv >/dev/null 2>&1; then
+                        as="setpriv --reuid=65534 --regid=65534 --clear-groups"
+                    elif [ "${OB_MUTATION_STRICT:-0}" = "1" ]; then
+                        fail "$id" "needs an unprivileged run and setpriv is unavailable (strict mode)"
+                        return
+                    else
+                        echo "  ---- $id: needs an unprivileged run; not exercised here"
+                        TESTS_RUN=$((TESTS_RUN - 1))
+                        return
+                    fi
+                fi ;;
             root)
                 if [ "$(id -u)" != "0" ]; then
                     if [ "${OB_MUTATION_STRICT:-0}" = "1" ]; then
@@ -177,7 +198,7 @@ run_stanza() {
     fi
 
     local src=0
-    ( cd "$ROOT_DIR" && bash "$suite" ) >/dev/null 2>&1 || src=$?
+    ( cd "$ROOT_DIR" && $as bash "$suite" ) >/dev/null 2>&1 || src=$?
     restore_all
     # Put the real binaries back before judging the next entry.
     case "$file" in
@@ -216,7 +237,8 @@ run_stanza
 restore_all
 # Prove the tree is as it was: a runner that leaves a mutant behind is worse
 # than no runner.
-if [ -n "$RESTORE_LIST" ]; then
+if [ -n "$RESTORE_LIST" ] \
+   && ( cd "$ROOT_DIR" && git rev-parse --is-inside-work-tree ) >/dev/null 2>&1; then
     git_rc=0
     # shellcheck disable=SC2086  # RESTORE_LIST is a space-separated path list
     ( cd "$ROOT_DIR" && git diff --quiet -- $RESTORE_LIST ) 2>/dev/null || git_rc=$?
@@ -236,6 +258,9 @@ if [ -n "$RESTORE_LIST" ]; then
             echo "  WARN: could not verify the tree with git (exit $git_rc);"
             echo "        restoration was performed but not confirmed." ;;
     esac
+elif [ -n "$RESTORE_LIST" ]; then
+    echo
+    echo "  WARN: not a git work tree here; restoration was performed but not confirmed."
 fi
 
 echo


### PR DESCRIPTION
Answers the question that came out of the 0.7.0 reviews: **why do reviewers keep finding
regressions while CI is green?**

Not coverage. The tests existed, ran, and were green — they were not testing anything:

- a `grep` matching the *comment above* a rule instead of the rule;
- an assertion that passed because the file it probed did not exist, rather than because
  the check refused it;
- a `grep -q` whose SIGPIPE, under `pipefail`, turned a match into a miss;
- an orphan suite no job ran (found by `test_ob_ci_coverage.sh` in #264).

A green suite is evidence only if it can go red. `tests/mutation/catalogue` names each
control, the exact text implementing it, and the suite that must fail once it is
removed. `tests/test_ob_mutation.sh` applies one mutant at a time and requires that
failure. Twelve entries, drawn from the controls the EBIOS sheets and this release's
issues depend on.

```
PASS: fp-daemon-anchor-owner — tests/test_ob_fp_daemon.sh catches it
PASS: service-keys-root-owner — tests/test_ob_service_account_keys.sh catches it
PASS: session-monitor-unknown-verdict — tests/test_ob_session_monitor.sh catches it
PASS: enroll-no-openssl-hmac — tests/test_ob_request_signing.sh catches it
…
Tests run: 11, passed: 11, failed: 0
```

## Writing the catalogue found five things

**Four were defects in the catalogue itself** — each the kind of mistake this tool
exists to stop being invisible:

| what I wrote | why it proved nothing |
| --- | --- |
| `401\|403)` → `401\|403\|__never__)` | an *added* alternative, not a removed control |
| two entries whose search text occurred twice | the mutation never applied |
| mutating the duplicate-unit **check** | mutating a check proves nothing about its subject |

A mutation that does not apply is now a **hard error**, never a pass — that exact false
"caught" happened repeatedly while doing this by hand earlier in the campaign. And the
systemd entry now puts a unit back under `debian/`, the situation #254 removed, through
a `create` mutation kind.

**The fifth was real.** `test_ob_builder_service_accounts.sh` checked the rendered
installer for the *presence* of the key-deployment text, which survives disabling the
block that runs it. It now asserts the guard is reachable — anchored on the keys block,
because the conf block a few lines above has the same shape and made my first attempt at
that assertion pass on a mutant.

## Two rules the runner enforces on itself

- **C mutants are rebuilt** before the suite runs. Without it the suite runs the previous
  binary and passes for the wrong reason: the first version of this reported the
  fingerprint-spool anchor check as untested, which was false.
- **Every file is restored from a copy** taken before the run, and the tree is verified
  unchanged afterwards. `git checkout` was used for this once during the campaign and
  wiped uncommitted work.

Entries that cannot be isolated unprivileged carry `needs: root`. Locally they report as
not exercised; in CI — a container, with `OB_MUTATION_STRICT=1` — that becomes an error
rather than reading as a pass, the same rule this project applies to a SKIP.

The suite also runs in the build job's loop (20s locally), so a surviving mutant fails a
normal PR, not only the dedicated job.

36 shell suites, none skipped; shellcheck clean.

## What this does not do

It does not replace the reviews. It closes the class they kept finding — assertions that
cannot fail — and it makes adding a control without a test visible: put the control in
the catalogue, and if no suite fails, the missing test is named for you.