### PR TITLE
test(anchor): make the two sshd anchor walks one, and test it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -187,6 +187,20 @@ the `auth` line of certificate-mode PAM stacks, and the accepted permissions of
 
 ### Changed
 
+- **The sshd anchor walk lives in one place** (#268). `ob-fp-daemon` and
+  `pam_openbastion` each carried their own copy of the walk that derives the
+  per-connection sshd pid the fingerprint spool is keyed on, kept in step by a
+  comment saying they must agree exactly. Nothing checked that they did, and a
+  divergence would break the SSH fingerprint binding *silently*: no error at
+  login, the module simply finds no drop, and the reduction
+  `doc/security/99-risk-reduce.md` credits to R-S3 and R-S15 is gone. Both now
+  call `ob_find_sshd_anchor()` (`src/sshd_anchor.c`), and
+  `tests/test_sshd_anchor.c` drives it from the writer's and the reader's
+  depths over the same synthetic `/proc` ancestry, plus the depth limit, a
+  non-contiguous `sshd-session` chain, pid 1, a vanished parent and a
+  self-parenting one. Two entries in `tests/mutation/catalogue` fail if the
+  outermost-ancestor rule or the contiguity break is removed. No behaviour
+  change: the shared walk is what both copies already did.
 - **systemd units live in one place** (#254). The Debian packaging kept a second
   copy of the socket units for `dh_installsystemd`'s `package.NAME.socket` form,
   and the copies drifted — `a9a28d8` added `UMask=0077` and the syscall filter to

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,7 @@ set(PAM_MODULE_SOURCES
     src/crowdsec.c
     src/service_account.c
     src/ssh_key_policy.c
+    src/sshd_anchor.c
     src/str_utils.c
 )
 
@@ -330,7 +331,8 @@ install(TARGETS ob-cert-request
 # account. ob-fp-daemon (root) owns a 0700 spool and derives the sshd anchor
 # from the depositing process's own /proc ancestry; ob-fp-submit is what the
 # AuthorizedPrincipalsCommand helper pipes to -- no sudo, no setuid.
-add_executable(ob-fp-daemon src/ob-fp-daemon.c)
+add_executable(ob-fp-daemon src/ob-fp-daemon.c src/sshd_anchor.c)
+target_include_directories(ob-fp-daemon PRIVATE ${CMAKE_SOURCE_DIR}/include)
 target_compile_options(ob-fp-daemon PRIVATE
     -Wall -Wextra -Werror
     -D_GNU_SOURCE

--- a/include/sshd_anchor.h
+++ b/include/sshd_anchor.h
@@ -1,0 +1,56 @@
+/*
+ * sshd_anchor.h - the per-connection sshd "anchor" PID.
+ *
+ * Copyright (C) 2025 Linagora
+ * License: AGPL-3.0
+ *
+ * The SSH fingerprint spool (#249) keys every drop on the anchor: the
+ * AuthorizedPrincipalsCommand helper deposits under it (through ob-fp-daemon,
+ * which derives it from the helper's own ancestry) and pam_openbastion reads
+ * under it. Writer and reader must compute the SAME pid from the SAME process
+ * tree, or the module looks for a drop under a key the daemon never wrote --
+ * and that failure is silent: no error at login, simply no fingerprint, so the
+ * binding doc/security/99-risk-reduce.md credits with reducing R-S3 and R-S15
+ * is gone while everything still appears to work.
+ *
+ * That is why this is one function rather than a rule two files are asked to
+ * obey. Both used to carry their own copy, agreeing only by inspection.
+ */
+
+#ifndef OB_SSHD_ANCHOR_H
+#define OB_SSHD_ANCHOR_H
+
+#include <sys/types.h>
+
+/*
+ * How far up the process tree to walk. sshd puts the anchor two or three hops
+ * above PAM; the limit only bounds the walk on a tree that has no anchor.
+ */
+#define OB_SSHD_ANCHOR_MAX_DEPTH 16
+
+/*
+ * The anchor for `pid`: the OUTERMOST contiguous "sshd-session" ancestor, or
+ * the first "sshd" ancestor on pre-split OpenSSH. Returns 0 when there is
+ * none.
+ *
+ * OpenSSH >= 9.8 splits each connection into TWO processes both named
+ * "sshd-session": the privileged monitor (child of the "sshd" listener) and an
+ * unprivileged child under it. PAM and the principals helper may run under
+ * EITHER, so stopping at the *first* "sshd-session" would key writer and
+ * reader on different pids. Returning the outermost contiguous one converges
+ * both on the monitor. On pre-split OpenSSH (< 9.8, e.g. RHEL/Rocky 9's 8.7)
+ * there is no "sshd-session" and the first "sshd" ancestor is the anchor.
+ *
+ * `pid` itself is examined: the caller's own process may be the anchor.
+ */
+pid_t ob_find_sshd_anchor(pid_t pid);
+
+/*
+ * Same walk against `proc_root` instead of /proc, so tests/test_sshd_anchor.c
+ * can drive it over a synthetic ancestry. Production callers use
+ * ob_find_sshd_anchor(); this exists so the walk above can be tested at all,
+ * and it reads only <root>/<pid>/comm and <root>/<pid>/status.
+ */
+pid_t ob_find_sshd_anchor_in(const char *proc_root, pid_t pid);
+
+#endif /* OB_SSHD_ANCHOR_H */

--- a/src/ob-fp-daemon.c
+++ b/src/ob-fp-daemon.c
@@ -67,6 +67,8 @@
 #include <syslog.h>
 #include <unistd.h>
 
+#include "sshd_anchor.h"
+
 #ifndef OB_FP_SPOOL_DIR
 #define OB_FP_SPOOL_DIR "/run/open-bastion/ssh-fp"
 #endif
@@ -101,8 +103,6 @@
 #define OB_FP_REQ_MAX   20480
 #define OB_FP_FP_MAX      512
 #define OB_FP_ALG_MAX      64
-
-#define OB_FP_PROC_MAX_DEPTH 16
 
 static void reply(int ok, const char *msg)
 {
@@ -209,66 +209,13 @@ static uid_t helper_uid(void)
 
 /* ---------------------------------------------------------------- proc walking */
 
-static int read_proc_line(const char *path, char *out, size_t out_sz)
-{
-    FILE *f = fopen(path, "r");
-    if (!f) return -1;
-    if (!fgets(out, (int)out_sz, f)) { fclose(f); return -1; }
-    fclose(f);
-    char *nl = strchr(out, '\n');
-    if (nl) *nl = '\0';
-    return 0;
-}
-
-static pid_t proc_ppid(pid_t pid)
-{
-    char path[64], line[256];
-    snprintf(path, sizeof(path), "/proc/%d/status", (int)pid);
-    FILE *f = fopen(path, "r");
-    if (!f) return 0;
-    pid_t ppid = 0;
-    while (fgets(line, sizeof(line), f)) {
-        if (strncmp(line, "PPid:", 5) == 0) {
-            ppid = (pid_t)strtol(line + 5, NULL, 10);
-            break;
-        }
-    }
-    fclose(f);
-    return ppid;
-}
-
 /*
- * The anchor for `pid`: the OUTERMOST contiguous "sshd-session" ancestor (the
- * per-connection privileged monitor), or the first "sshd" ancestor on
- * pre-split OpenSSH (< 9.8, e.g. Rocky 9's 8.7).
- *
- * This MUST agree exactly with pam_openbastion's find_sshd_session_ancestor(),
- * or the module looks for a drop under a key this daemon never wrote. The two
- * differ only in their starting point: the module starts at its own pid, this
- * starts at the peer's.
+ * The anchor is derived by ob_find_sshd_anchor() (src/sshd_anchor.c), the same
+ * function pam_openbastion calls. It used to be a second copy of that walk
+ * here, kept in step by a comment; the two differ only in their starting point,
+ * and that is now the only thing this file says about it -- the module starts
+ * at its own pid, this starts at the peer's.
  */
-static pid_t find_anchor(pid_t pid)
-{
-    pid_t outermost = 0;
-    for (int i = 0; i < OB_FP_PROC_MAX_DEPTH && pid > 1; i++) {
-        char path[64], comm[256];
-        snprintf(path, sizeof(path), "/proc/%d/comm", (int)pid);
-        if (read_proc_line(path, comm, sizeof(comm)) != 0) return outermost;
-
-        if (strcmp(comm, "sshd-session") == 0) {
-            outermost = pid;             /* keep climbing for an outer one */
-        } else if (outermost) {
-            return outermost;            /* left the chain: monitor found */
-        } else if (strcmp(comm, "sshd") == 0) {
-            return pid;                  /* pre-split OpenSSH */
-        }
-
-        pid_t ppid = proc_ppid(pid);
-        if (ppid <= 0) return outermost;
-        pid = ppid;
-    }
-    return outermost;
-}
 
 /* ------------------------------------------------------------------- the spool */
 
@@ -399,7 +346,7 @@ int main(void)
 
     /*
      * The peer must still exist for its ancestry to mean anything. This is a
-     * liveness check and nothing more: find_anchor() below reopens /proc by
+     * liveness check and nothing more: the anchor walk below reopens /proc by
      * path, so holding a descriptor here would not pin the walk against pid
      * recycling. Closing that window properly would mean comparing the peer's
      * start time before and after, and it is not worth it -- to exploit the
@@ -419,7 +366,7 @@ int main(void)
      * 2. The anchor is derived, never received. This is what stops a nobody
      *    process from depositing on a session it is not part of.
      */
-    pid_t anchor = find_anchor(cred.pid);
+    pid_t anchor = ob_find_sshd_anchor(cred.pid);
     if (anchor <= 1) {
         reply(0, "no sshd-session ancestor: refusing a deposit that is not "
                  "part of an SSH connection");

--- a/src/pam_openbastion.c
+++ b/src/pam_openbastion.c
@@ -43,6 +43,7 @@
 #include "crowdsec.h"
 #include "service_account.h"
 #include "ssh_key_policy.h"
+#include "sshd_anchor.h"
 #ifdef ENABLE_DESKTOP_SSO  /* Desktop SSO only and never compiled inside open-bastion core */
 #include "offline_cache.h"
 #endif /* ENABLE_DESKTOP_SSO */
@@ -1757,73 +1758,6 @@ static const char *get_client_ip(pam_handle_t *pamh)
 }
 
 /*
- * Walk up the process tree to find the per-connection sshd anchor PID, used to
- * correlate this PAM invocation with the AuthorizedPrincipalsCommand run (which
- * drops the SSH fingerprint at /run/open-bastion/ssh-fp/<anchor>.fp).
- *
- * OpenSSH >= 9.8 splits each connection into TWO processes both named
- * "sshd-session": the privileged monitor (child of the "sshd" listener) and an
- * unprivileged child under it. PAM and the principals helper may run under
- * EITHER, so stopping at the *first* "sshd-session" makes the writer and reader
- * key the spool on different PIDs and the lookup fails. To converge
- * deterministically we return the OUTERMOST contiguous "sshd-session" (the
- * monitor, whose parent is the "sshd" listener). On pre-split OpenSSH (< 9.8,
- * e.g. RHEL/Rocky 9) there is no "sshd-session" and we fall back to the first
- * "sshd" ancestor. Returns 0 if none found.
- */
-static pid_t find_sshd_session_ancestor(void)
-{
-    pid_t pid = getpid();
-    pid_t outermost_session = 0;  /* outermost contiguous sshd-session seen */
-    for (int i = 0; i < 16; i++) {
-        char path[64];
-        char buf[256];
-
-        /* Read /proc/<pid>/comm */
-        snprintf(path, sizeof(path), "/proc/%d/comm", (int)pid);
-        FILE *f = fopen(path, "r");
-        if (!f) return outermost_session;
-        if (!fgets(buf, sizeof(buf), f)) {
-            fclose(f);
-            return outermost_session;
-        }
-        fclose(f);
-        char *nl = strchr(buf, '\n');
-        if (nl) *nl = '\0';
-        if (strcmp(buf, "sshd-session") == 0) {
-            /* Record and keep climbing: a parent sshd-session (the monitor)
-             * outranks this one. */
-            outermost_session = pid;
-        } else if (outermost_session) {
-            /* Left the sshd-session chain; its outermost member is the
-             * per-connection privileged monitor — the common ancestor. */
-            return outermost_session;
-        } else if (strcmp(buf, "sshd") == 0) {
-            /* Pre-split OpenSSH (< 9.8, e.g. RHEL/Rocky 9's 8.7) has no
-             * "sshd-session": the per-connection process is "sshd" itself, and
-             * its first occurrence is the anchor (its parent is the listener). */
-            return pid;
-        }
-
-        /* Read PPid from /proc/<pid>/status */
-        snprintf(path, sizeof(path), "/proc/%d/status", (int)pid);
-        f = fopen(path, "r");
-        if (!f) return outermost_session;
-        pid_t ppid = 0;
-        while (fgets(buf, sizeof(buf), f)) {
-            if (strncmp(buf, "PPid:", 5) == 0) {
-                ppid = (pid_t)strtol(buf + 5, NULL, 10);
-                break;
-            }
-        }
-        fclose(f);
-        if (ppid <= 1 || ppid == pid) return outermost_session;
-        pid = ppid;
-    }
-    return outermost_session;
-}
-
-/*
  * Read one drop file left by ob-ssh-principals in
  * /run/open-bastion/ssh-fp/<sshd-session-pid>.<suffix>. This is the out-of-band
  * channel that compensates for the fact that OpenSSH does not propagate
@@ -1860,7 +1794,15 @@ static pid_t find_sshd_session_ancestor(void)
 static char *read_spool_drop(pam_handle_t *pamh, const char *suffix,
                              size_t max_size, char *path_out, size_t path_sz)
 {
-    pid_t anchor = find_sshd_session_ancestor();
+    /*
+     * The per-connection sshd anchor: the pid this invocation and the
+     * AuthorizedPrincipalsCommand run agree on. The walk is
+     * ob_find_sshd_anchor() (src/sshd_anchor.c), shared with ob-fp-daemon,
+     * which derives the SAME anchor from the depositing helper's ancestry.
+     * This file used to carry its own copy of that walk, and the two agreed
+     * only by inspection.
+     */
+    pid_t anchor = ob_find_sshd_anchor(getpid());
     if (anchor <= 1) {
         OB_LOG_DEBUG(pamh, "No sshd-session ancestor found, skipping SSH fp spool");
         return NULL;

--- a/src/sshd_anchor.c
+++ b/src/sshd_anchor.c
@@ -1,0 +1,94 @@
+/*
+ * sshd_anchor.c - the single implementation of the sshd anchor walk.
+ *
+ * Copyright (C) 2025 Linagora
+ * License: AGPL-3.0
+ *
+ * See include/sshd_anchor.h for what the anchor is and why writer and reader
+ * must agree on it. This file exists so that "must agree" is a property of the
+ * program rather than of two comments.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/types.h>
+
+#include "sshd_anchor.h"
+
+/* Longest path we build: <proc_root>/<pid>/status. */
+#define ANCHOR_PATH_MAX 512
+
+/* Read the first line of `path` into `out`, newline stripped. 0 on success. */
+static int read_first_line(const char *path, char *out, size_t out_sz)
+{
+    FILE *f = fopen(path, "r");
+    if (!f) return -1;
+    if (!fgets(out, (int)out_sz, f)) {
+        fclose(f);
+        return -1;
+    }
+    fclose(f);
+    char *nl = strchr(out, '\n');
+    if (nl) *nl = '\0';
+    return 0;
+}
+
+/* PPid from <proc_root>/<pid>/status, or 0 when it cannot be read. */
+static pid_t read_ppid(const char *proc_root, pid_t pid)
+{
+    char path[ANCHOR_PATH_MAX], line[256];
+    int n = snprintf(path, sizeof(path), "%s/%d/status", proc_root, (int)pid);
+    if (n < 0 || n >= (int)sizeof(path)) return 0;
+
+    FILE *f = fopen(path, "r");
+    if (!f) return 0;
+    pid_t ppid = 0;
+    while (fgets(line, sizeof(line), f)) {
+        if (strncmp(line, "PPid:", 5) == 0) {
+            ppid = (pid_t)strtol(line + 5, NULL, 10);
+            break;
+        }
+    }
+    fclose(f);
+    return ppid;
+}
+
+pid_t ob_find_sshd_anchor_in(const char *proc_root, pid_t pid)
+{
+    pid_t outermost = 0;  /* outermost contiguous sshd-session seen so far */
+
+    /*
+     * pid 1 is never an anchor and has no parent worth following, so it also
+     * terminates the walk.
+     */
+    for (int i = 0; i < OB_SSHD_ANCHOR_MAX_DEPTH && pid > 1; i++) {
+        char path[ANCHOR_PATH_MAX], comm[256];
+        int n = snprintf(path, sizeof(path), "%s/%d/comm", proc_root, (int)pid);
+        if (n < 0 || n >= (int)sizeof(path)) return outermost;
+        if (read_first_line(path, comm, sizeof(comm)) != 0) return outermost;
+
+        if (strcmp(comm, "sshd-session") == 0) {
+            outermost = pid;         /* keep climbing: a parent one outranks it */
+        } else if (outermost) {
+            return outermost;        /* left the chain: the monitor is behind us */
+        } else if (strcmp(comm, "sshd") == 0) {
+            return pid;              /* pre-split OpenSSH */
+        }
+
+        pid_t ppid = read_ppid(proc_root, pid);
+        /*
+         * A parent that is its own child cannot happen on a live tree, but a
+         * corrupt or synthetic one would loop here until the depth limit; stop
+         * on it explicitly so the walk is bounded by the tree, not by luck.
+         */
+        if (ppid <= 0 || ppid == pid) return outermost;
+        pid = ppid;
+    }
+    return outermost;
+}
+
+pid_t ob_find_sshd_anchor(pid_t pid)
+{
+    return ob_find_sshd_anchor_in("/proc", pid);
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -238,6 +238,14 @@ target_link_libraries(test_notify
 )
 add_test(NAME test_notify COMMAND test_notify)
 
+# The sshd anchor walk (#268). ob-fp-daemon and pam_openbastion must derive the
+# SAME pid from the same process tree, from different depths of it; they used to
+# do so from two copies of the walk that agreed only by inspection. There is one
+# implementation now, and this drives it over a synthetic /proc.
+add_executable(test_sshd_anchor test_sshd_anchor.c ../src/sshd_anchor.c)
+target_include_directories(test_sshd_anchor PRIVATE ${CMAKE_SOURCE_DIR}/include)
+add_test(NAME test_sshd_anchor COMMAND test_sshd_anchor)
+
 # Test SSH key policy
 add_executable(test_ssh_key_policy test_ssh_key_policy.c ../src/ssh_key_policy.c)
 target_include_directories(test_ssh_key_policy PRIVATE ${CMAKE_SOURCE_DIR}/include)
@@ -271,7 +279,9 @@ endif()
 # test can only reach through a mount namespace -- and unprivileged namespaces
 # are restricted on Ubuntu 24.04, so a test that needed one would SKIP in CI and
 # a skip reads as a pass. Same source, same logic, different constants.
-add_executable(ob-fp-daemon-testbuild ${CMAKE_SOURCE_DIR}/src/ob-fp-daemon.c)
+add_executable(ob-fp-daemon-testbuild ${CMAKE_SOURCE_DIR}/src/ob-fp-daemon.c
+                                    ${CMAKE_SOURCE_DIR}/src/sshd_anchor.c)
+target_include_directories(ob-fp-daemon-testbuild PRIVATE ${CMAKE_SOURCE_DIR}/include)
 # OB_FP_PRIV_UID is 0 in the shipped binary, so the production code carries no
 # test affordance; here it becomes the uid running the suite, which is what lets
 # these paths be exercised without root.
@@ -287,7 +297,9 @@ target_compile_options(ob-fp-daemon-testbuild PRIVATE -Wall -Wextra -Werror -D_G
 # uses this to prove that control is live -- with the relaxed build the suite's
 # own fake anchor satisfies it either way, so deleting the check outright would
 # otherwise go unnoticed (verified by mutation).
-add_executable(ob-fp-daemon-strictuid ${CMAKE_SOURCE_DIR}/src/ob-fp-daemon.c)
+add_executable(ob-fp-daemon-strictuid ${CMAKE_SOURCE_DIR}/src/ob-fp-daemon.c
+                                    ${CMAKE_SOURCE_DIR}/src/sshd_anchor.c)
+target_include_directories(ob-fp-daemon-strictuid PRIVATE ${CMAKE_SOURCE_DIR}/include)
 target_compile_definitions(ob-fp-daemon-strictuid PRIVATE
     OB_FP_SPOOL_DIR="${CMAKE_CURRENT_BINARY_DIR}/fp-spool-strict"
     OB_FP_SOCKET="${CMAKE_CURRENT_BINARY_DIR}/fp-strict.sock"

--- a/tests/mutation/catalogue
+++ b/tests/mutation/catalogue
@@ -127,3 +127,22 @@ suite   || tests/test_ob_systemd_units.sh
 why     || #254: unit content must live only in systemd/. Mutating the check
 why     || itself would prove nothing -- this puts the duplicate back, which is
 why     || the situation the check exists to refuse.
+
+id      || sshd-anchor-outermost
+file    || src/sshd_anchor.c
+search  || outermost = pid;         /* keep climbing: a parent one outranks it */
+replace || return pid;
+suite   || tests/test_ob_sshd_anchor.sh
+why     || #268: the writer (ob-fp-daemon) and the reader (pam_openbastion) run
+why     || at different depths of the same tree and must converge on the
+why     || OUTERMOST contiguous sshd-session. Stopping at the first keys them on
+why     || different pids, and the fingerprint binding then finds no drop --
+why     || silently, with no error at login.
+
+id      || sshd-anchor-contiguity
+file    || src/sshd_anchor.c
+search  || } else if (outermost) {
+replace || } else if (0) {
+suite   || tests/test_ob_sshd_anchor.sh
+why     || #268: only the outermost of the CONTIGUOUS run is the anchor. Climbing
+why     || past a break picks up an sshd-session belonging to another connection.

--- a/tests/test_ob_sshd_anchor.sh
+++ b/tests/test_ob_sshd_anchor.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# Runs the sshd anchor unit tests (tests/test_sshd_anchor.c).
+#
+# The assertions live in C, next to the other unit tests, and ctest runs them
+# directly. This wrapper exists because tests/mutation/catalogue names its
+# suites as shell scripts: the mutation runner rebuilds the tree after applying
+# a C mutant and then executes `bash <suite>`, so the entry for the anchor walk
+# needs one.
+#
+# It fails rather than skips when the binary is missing: a skip would let the
+# mutation runner conclude the control is covered when nothing ran at all.
+set -uo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+BIN="${OB_BUILD_DIR:-$ROOT_DIR/build}/tests/test_sshd_anchor"
+
+echo "=== sshd anchor walk (#268) ==="
+
+if [ ! -x "$BIN" ]; then
+    echo "  FAIL: $BIN is not built; configure and build the tree first"
+    exit 1
+fi
+
+exec "$BIN"

--- a/tests/test_sshd_anchor.c
+++ b/tests/test_sshd_anchor.c
@@ -1,0 +1,199 @@
+/*
+ * test_sshd_anchor.c - the sshd anchor walk, over a synthetic /proc.
+ *
+ * The anchor keys the SSH fingerprint spool (#249): ob-fp-daemon writes
+ * /run/open-bastion/ssh-fp/<anchor>.fp after deriving <anchor> from the
+ * depositing helper's ancestry, and pam_openbastion reads it after deriving
+ * <anchor> from its own. The two run at DIFFERENT depths of the same process
+ * tree and must still land on the same pid. Until #268 each had its own copy of
+ * the walk and nothing checked they agreed; a divergence breaks the binding
+ * silently -- no error at login, simply no drop found, and the reduction that
+ * doc/security/99-risk-reduce.md credits to R-S3 and R-S15 is gone.
+ *
+ * There is now one implementation (src/sshd_anchor.c) and these tests drive it
+ * from both starting points over the same tree, plus the edge cases the walk
+ * defines: the depth limit, a non-contiguous sshd-session chain, pid 1, a
+ * vanished process, and a self-parenting one.
+ *
+ * The tree is synthetic: a directory of <pid>/{comm,status} files, which is all
+ * the walk reads. Real ancestries cannot be built by a test -- they need sshd.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#include "sshd_anchor.h"
+
+static int tests_run = 0;
+static int tests_passed = 0;
+
+#define CHECK(cond, desc)                                                      \
+    do {                                                                       \
+        tests_run++;                                                           \
+        if (cond) {                                                            \
+            tests_passed++;                                                    \
+            printf("  ok   %s\n", desc);                                       \
+        } else {                                                               \
+            printf("  FAIL %s\n", desc);                                       \
+        }                                                                      \
+    } while (0)
+
+static char root[] = "/tmp/ob-anchor-XXXXXX";
+
+/* Create <root>/<pid>/{comm,status} for a process named `comm` under `ppid`. */
+static void mkproc(pid_t pid, const char *comm, pid_t ppid)
+{
+    char dir[256], path[320];
+    snprintf(dir, sizeof(dir), "%s/%d", root, (int)pid);
+    if (mkdir(dir, 0700) != 0 && access(dir, X_OK) != 0) {
+        perror("mkdir");
+        exit(2);
+    }
+
+    snprintf(path, sizeof(path), "%s/comm", dir);
+    FILE *f = fopen(path, "w");
+    if (!f) { perror("fopen comm"); exit(2); }
+    fprintf(f, "%s\n", comm);
+    fclose(f);
+
+    /*
+     * Real /proc/<pid>/status has ~50 lines with PPid several lines in; put
+     * something before it so the reader is not accidentally tested against a
+     * one-line file.
+     */
+    snprintf(path, sizeof(path), "%s/status", dir);
+    f = fopen(path, "w");
+    if (!f) { perror("fopen status"); exit(2); }
+    fprintf(f, "Name:\t%s\nUmask:\t0022\nState:\tS (sleeping)\nTgid:\t%d\n"
+               "Ngid:\t0\nPid:\t%d\nPPid:\t%d\nTracerPid:\t0\n",
+            comm, (int)pid, (int)pid, (int)ppid);
+    fclose(f);
+}
+
+/* Remove every <pid> subtree between calls, so trees cannot bleed into each
+ * other and make a later case pass on an earlier case's processes. */
+static void reset_tree(void)
+{
+    char cmd[512];
+    snprintf(cmd, sizeof(cmd), "rm -rf %s/*", root);
+    if (system(cmd) != 0) { fprintf(stderr, "cannot clear %s\n", root); exit(2); }
+}
+
+static pid_t anchor(pid_t from)
+{
+    return ob_find_sshd_anchor_in(root, from);
+}
+
+int main(void)
+{
+    if (!mkdtemp(root)) { perror("mkdtemp"); return 2; }
+
+    /*
+     * OpenSSH >= 9.8. Both the monitor and its unprivileged child are named
+     * "sshd-session"; the anchor is the OUTERMOST of the two (900).
+     *
+     *   1 -- 800 sshd (listener) -- 900 sshd-session (monitor)
+     *          -- 950 sshd-session (unpriv child) -- 970 bash
+     */
+    printf("split OpenSSH (>= 9.8):\n");
+    mkproc(800, "sshd", 1);
+    mkproc(900, "sshd-session", 800);
+    mkproc(950, "sshd-session", 900);
+    mkproc(970, "bash", 950);
+
+    CHECK(anchor(970) == 900, "from a leaf under the unprivileged child -> monitor");
+    CHECK(anchor(950) == 900, "from the unprivileged child itself -> monitor");
+    CHECK(anchor(900) == 900, "from the monitor itself -> monitor");
+
+    /*
+     * The property the whole spool rests on. ob-fp-daemon starts at the
+     * principals helper's pid, pam_openbastion at its own; the two sit at
+     * different depths and must produce the same key.
+     */
+    CHECK(anchor(970) == anchor(950) && anchor(950) == anchor(900),
+          "writer and reader depths agree on the same anchor");
+
+    /* Pre-split OpenSSH (< 9.8, RHEL/Rocky 9): no "sshd-session" at all, the
+     * per-connection process is "sshd" and its first occurrence is the anchor.
+     * The listener (800) must NOT win. */
+    printf("pre-split OpenSSH (< 9.8):\n");
+    reset_tree();
+    mkproc(800, "sshd", 1);
+    mkproc(900, "sshd", 800);
+    mkproc(970, "bash", 900);
+    CHECK(anchor(970) == 900, "first sshd ancestor, not the listener");
+
+    /*
+     * Non-contiguous chain. Only the outermost of the CONTIGUOUS run counts:
+     * an sshd-session higher up, separated by something else, belongs to
+     * another connection (a nested ssh, an sshd restarted under one) and
+     * keying on it would cross sessions.
+     *
+     *   1 -- 800 sshd -- 850 sshd-session -- 900 bash -- 950 sshd-session -- 970 cat
+     */
+    printf("non-contiguous sshd-session chain:\n");
+    reset_tree();
+    mkproc(800, "sshd", 1);
+    mkproc(850, "sshd-session", 800);
+    mkproc(900, "bash", 850);
+    mkproc(950, "sshd-session", 900);
+    mkproc(970, "cat", 950);
+    CHECK(anchor(970) == 950, "stops at the break, does not climb to the outer one");
+
+    /* The depth limit is 16 examined processes: distance 0..15 from the start.
+     * A tree deeper than that yields no anchor rather than an unbounded walk. */
+    printf("depth limit (%d):\n", OB_SSHD_ANCHOR_MAX_DEPTH);
+    reset_tree();
+    for (int i = 0; i < OB_SSHD_ANCHOR_MAX_DEPTH - 1; i++)
+        mkproc(1000 + i, "bash", 1000 + i + 1);
+    mkproc(1000 + OB_SSHD_ANCHOR_MAX_DEPTH - 1, "sshd-session", 1);
+    CHECK(anchor(1000) == 1000 + OB_SSHD_ANCHOR_MAX_DEPTH - 1,
+          "an anchor at the last examined depth is still found");
+
+    reset_tree();
+    for (int i = 0; i < OB_SSHD_ANCHOR_MAX_DEPTH; i++)
+        mkproc(1000 + i, "bash", 1000 + i + 1);
+    mkproc(1000 + OB_SSHD_ANCHOR_MAX_DEPTH, "sshd-session", 1);
+    CHECK(anchor(1000) == 0, "one hop beyond the limit is not found");
+
+    printf("degenerate trees:\n");
+    reset_tree();
+    mkproc(800, "systemd", 1);
+    mkproc(900, "bash", 800);
+    CHECK(anchor(900) == 0, "no sshd anywhere in the ancestry -> 0");
+
+    reset_tree();
+    mkproc(1, "systemd", 0);
+    CHECK(anchor(1) == 0, "pid 1 is never an anchor");
+
+    /* A process that exited mid-walk: /proc/<pid> is gone. Whatever was found
+     * below it still stands; nothing above it can be. */
+    reset_tree();
+    mkproc(900, "sshd-session", 850);   /* 850 deliberately does not exist */
+    mkproc(970, "bash", 900);
+    CHECK(anchor(970) == 900, "a vanished parent keeps the anchor found below it");
+
+    reset_tree();
+    mkproc(970, "bash", 900);           /* 900 deliberately does not exist */
+    CHECK(anchor(970) == 0, "a vanished parent with nothing found yet -> 0");
+
+    /* PPid pointing at itself, or at 0: both must terminate. A synthetic or
+     * corrupt tree must not spin. */
+    reset_tree();
+    mkproc(970, "bash", 970);
+    CHECK(anchor(970) == 0, "a self-parenting process terminates the walk");
+
+    reset_tree();
+    mkproc(970, "bash", 0);
+    CHECK(anchor(970) == 0, "PPid 0 terminates the walk");
+
+    reset_tree();
+    rmdir(root);
+
+    printf("\n%d/%d passed\n", tests_passed, tests_run);
+    return (tests_passed == tests_run) ? 0 : 1;
+}


### PR DESCRIPTION
Item 1 of #268.

## The problem

`src/ob-fp-daemon.c` and `src/pam_openbastion.c` each implemented the walk that
derives the per-connection sshd pid the fingerprint spool is keyed on. The
daemon's comment stated what the arrangement rested on:

> This MUST agree exactly with pam_openbastion's `find_sshd_session_ancestor()`,
> or the module looks for a drop under a key this daemon never wrote.

Nothing verified that sentence. A divergence does not announce itself: the
module finds no drop, logs a debug line, and continues without the fingerprint.
Login still works, and the binding `doc/security/99-risk-reduce.md` credits with
reducing R-S3 and R-S15 is gone. The only way to notice was to read both files
side by side — the same drift #254 removed for the systemd units, left in place
on the mechanism whose trust root #249 had just moved.

## What this does

Rather than test that two copies agree, there is one copy. The walk moves to
`src/sshd_anchor.c` behind `ob_find_sshd_anchor()`; both callers use it,
differing only in the starting pid, which is the one thing that was ever meant
to differ between them.

**No behaviour change.** The two copies were already equivalent; the
disagreements were the loop guards (`pid > 1` + `ppid <= 0` vs `ppid <= 1` +
`ppid == pid`). Both leave pid 1 unexamined and return the same anchor for every
tree; the self-parent guard only bounds a tree that cannot occur live. The
merged walk keeps both guards.

## The test

`tests/test_sshd_anchor.c` drives it over a synthetic `/proc` — a directory of
`<pid>/{comm,status}`, which is all the walk reads, since a real sshd ancestry
cannot be built by a test. 14 assertions:

- the property the spool depends on: the **writer's depth and the reader's depth
  in one tree yield the same pid**;
- outermost contiguous `sshd-session` on split OpenSSH (>= 9.8), from three
  depths;
- first `sshd` on pre-split (< 9.8), and not the listener;
- a chain broken by a non-sshd process — the outer session belongs to another
  connection;
- the depth limit, at 15 hops (found) and 16 (not found);
- pid 1, a parent that vanished mid-walk, a self-parenting one, `PPid 0`.

`tests/test_ob_sshd_anchor.sh` is the thin wrapper the mutation runner needs
(it executes suites as shell scripts); it fails rather than skips when the
binary is absent.

## Proof it can fail

Two entries in `tests/mutation/catalogue` for the walk's two load-bearing rules:

| id | mutation | caught by |
|---|---|---|
| `sshd-anchor-outermost` | stop at the *first* `sshd-session` instead of climbing | `tests/test_ob_sshd_anchor.sh` |
| `sshd-anchor-contiguity` | climb past the break in the chain | `tests/test_ob_sshd_anchor.sh` |

```
$ bash tests/test_ob_mutation.sh
  PASS: sshd-anchor-outermost — tests/test_ob_sshd_anchor.sh catches it
  PASS: sshd-anchor-contiguity — tests/test_ob_sshd_anchor.sh catches it
Tests run: 13, passed: 13, failed: 0
```

`ctest` 23/23, `tests/test_ob_fp_daemon.sh` 14/14, `tests/test_ob_ci_coverage.sh`
and `tests/test_ob_changelog.sh` green.