### PR TITLE
fix(pkg): install the ob-standalone-setup links under the install-time prefix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -208,10 +208,16 @@ jobs:
         cmake -B build -DCMAKE_BUILD_TYPE=Release -DUSE_LIBSODIUM=ON
         cmake --build build --parallel
 
+    # cpack reports a failed install step as "CMake Error" and still exits 0
+    # with a package missing the files that step should have put there.
     - name: Create Debian package
       run: |
         cd build
-        cpack -G DEB
+        cpack -G DEB 2>&1 | tee cpack.log
+        if grep -q 'CMake Error' cpack.log; then
+          echo "::error::cpack reported install errors; the package is incomplete"
+          exit 1
+        fi
 
     # Upgrades a host staged from the v0.6.2 tag and checks it converges.
     # It needs docker and a package, which only this job has; on the build jobs

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -513,11 +513,14 @@ install(PROGRAMS ${CMAKE_SOURCE_DIR}/scripts/ob-bastion-setup
 # ob-standalone-setup is a symlink to ob-bastion-setup: invoked under that name
 # the script defaults --node-role to "standalone", giving admins a clearer,
 # self-documenting command for combined bastion+backend hosts.
-install(CODE "
-    set(_sbindir \"\$ENV{DESTDIR}${CMAKE_INSTALL_FULL_SBINDIR}\")
-    execute_process(COMMAND \"${CMAKE_COMMAND}\" -E create_symlink
-        ob-bastion-setup \"\${_sbindir}/ob-standalone-setup\")
-")
+# The link is made in the build tree and installed like any other file, so it
+# follows the install-time prefix: cpack installs under /usr, not the
+# configure-time /usr/local a CMAKE_INSTALL_FULL_* path would bake in.
+execute_process(COMMAND "${CMAKE_COMMAND}" -E create_symlink
+    ob-bastion-setup "${CMAKE_BINARY_DIR}/ob-standalone-setup")
+install(FILES ${CMAKE_BINARY_DIR}/ob-standalone-setup
+    DESTINATION ${CMAKE_INSTALL_SBINDIR}
+)
 
 # Install auditd templates (consumed by `ob-bastion-setup --enable-audit-trace`).
 # Read-only templates under /usr/share/open-bastion/audit/. The setup function
@@ -565,11 +568,11 @@ install(FILES
 )
 
 # Man page for the ob-standalone-setup symlink (points at ob-bastion-setup.8).
-install(CODE "
-    set(_man8dir \"\$ENV{DESTDIR}${CMAKE_INSTALL_FULL_MANDIR}/man8\")
-    execute_process(COMMAND \"${CMAKE_COMMAND}\" -E create_symlink
-        ob-bastion-setup.8 \"\${_man8dir}/ob-standalone-setup.8\")
-")
+execute_process(COMMAND "${CMAKE_COMMAND}" -E create_symlink
+    ob-bastion-setup.8 "${CMAKE_BINARY_DIR}/ob-standalone-setup.8")
+install(FILES ${CMAKE_BINARY_DIR}/ob-standalone-setup.8
+    DESTINATION ${CMAKE_INSTALL_MANDIR}/man8
+)
 
 # Install man pages (section 1 - user commands)
 install(FILES


### PR DESCRIPTION
Reported by @orontee on #272: the "Build Debian Package" job logs two `CMake Error`s and still passes.

```
CMake Error: failed to create symbolic link '…/_CPack_Packages/Linux/DEB/open-bastion-0.6.2-Linux/usr/local/sbin/ob-standalone-setup': No such file or directory
CMake Error: failed to create symbolic link '…/usr/local/share/man/man8/ob-standalone-setup.8': No such file or directory
```

It is not specific to #272 — main has the same two lines.

## Cause

The two links were made by `install(CODE)` against `CMAKE_INSTALL_FULL_SBINDIR` / `CMAKE_INSTALL_FULL_MANDIR`. Those are baked at configure time (`/usr/local/...`), but cpack installs under `/usr`. The parent directory does not exist in the staging tree, `create_symlink` fails, `execute_process` ignores the result, and cpack exits 0 — with a `.deb` that has no `ob-standalone-setup` and no `ob-standalone-setup.8`.

`dpkg-buildpackage` (dh, prefix `/usr`) and `rpmbuild` (`%cmake`) configure with `/usr`, so the paths matched there: **the released packages were not affected** (and both list the link explicitly, so their builds would fail without it).

## Fix

- The links are made in the build tree at configure time and installed with `install(FILES … DESTINATION ${CMAKE_INSTALL_SBINDIR})` (resp. `${CMAKE_INSTALL_MANDIR}/man8`). A relative destination follows the install-time prefix and `DESTDIR`. Works with our `cmake_minimum_required(3.10)`.
- The CI package job now fails when cpack reports a `CMake Error`, since cpack itself does not.

## Verified locally

```
$ cpack -G DEB    # before: 2 × CMake Error, link absent from the .deb
$ cpack -G DEB    # after: 0 × CMake Error
$ dpkg-deb -c open-bastion-0.6.2-Linux.deb | grep standalone
lrwxrwxrwx root/root 0 … ./usr/sbin/ob-standalone-setup -> ob-bastion-setup
lrwxrwxrwx root/root 0 … ./usr/share/man/man8/ob-standalone-setup.8 -> ob-bastion-setup.8
```

and `cmake -DCMAKE_INSTALL_PREFIX=/usr` + `DESTDIR=… cmake --install` (the dh/rpm path) installs both as symlinks.

https://claude.ai/code/session_01Bh9aBGroMwsqpv4q5foHT3
